### PR TITLE
Count from the first punched-in date

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -275,6 +275,7 @@ class Calendar {
             monthLength = d.getDate(),
             workingDaysToCompute = 0,
             monthTotalWorked = '00:00';
+        var countDays = false;
 
         for (var day = 1; day <= monthLength; ++day) {
             if (!showDay(this.year, this.month, day)) {
@@ -285,12 +286,15 @@ class Calendar {
                 //balance considers only up until yesterday
                 break;
             }
-            workingDaysToCompute += 1;
 
             var dayStr = this.year + '-' + this.month + '-' + day + '-' + 'day-total';
             var dayTotal = document.getElementById(dayStr).value;
             if (dayTotal) {
+                countDays = true;
                 monthTotalWorked = sumTime(monthTotalWorked, dayTotal);
+            }
+            if (countDays) {
+                workingDaysToCompute += 1;
             }
         }
         var monthTotalToWork = multiplyTime(getHoursPerDay(), workingDaysToCompute * -1);


### PR DESCRIPTION
Closes #29

This makes the total balance count from the first day that you punched in, making it a lot more usable for people that start using it in the middle of the month and don't want to fill in everything to see a valuable balance.
*Before*
![before](https://user-images.githubusercontent.com/6443427/65924010-43f78900-e3c1-11e9-8145-6808b4fc732c.png)
*After*
![after](https://user-images.githubusercontent.com/6443427/65924026-540f6880-e3c1-11e9-98ec-8e1ff3607565.png)
