### PR TITLE
Sticky header for month and table labels

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -67,9 +67,13 @@ table {
   margin-right: auto;
   table-layout: fixed;
   width: 90%;
+  position: sticky;
+  top: 0;
+  background: #fff;
+
 }
 
-th {
+.table-header th {
   height: 50px;
   vertical-align: center;
 }
@@ -106,7 +110,7 @@ tr {
   font-weight: bold;
 }
 
-td {
+td, th.th-label {
   padding-right: 7px;
   padding-left: 7px;
   text-align: center;
@@ -182,4 +186,15 @@ input[type="time"]::-webkit-clear-button {
 .punch-button:disabled {
   opacity: 0.5;
   color: rgb(134, 134, 134); 
+}
+
+.table-body {
+  overflow-y: auto;
+}
+
+th.th-label{
+  position: sticky;
+  top: 51px;
+  background-color: #fff;
+  box-shadow: 0px 2px 0px 0px #CBCBCB;
 }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -474,16 +474,17 @@ class Calendar {
      * Returns the code of the header of the calendar table
      */
     _getTableHeaderCode () {
-        return '<tr>' +
+        return '<thead>' +
                 '<tr>' +
-                    '<td class="th th-day-name dayheader" colspan="2">Day</td>' +
-                    '<td class="th th-label">Day Start</td>' +
-                    '<td class="th th-label">Lunch Start</td>' +
-                    '<td class="th th-label">Lunch Total</td>' +
-                    '<td class="th th-label">Lunch End</td>' +
-                    '<td class="th th-label">Day End</td>' +
-                    '<td class="th th-label">Day total</td>' +
-                '</tr>\n';
+                    '<th class="th th-label th-day-name dayheader" colspan="2">Day</th>' +
+                    '<th class="th th-label">Day Start</th>' +
+                    '<th class="th th-label">Lunch Start</th>' +
+                    '<th class="th th-label">Lunch Total</th>' +
+                    '<th class="th th-label">Lunch End</th>' +
+                    '<th class="th th-label">Day End</th>' +
+                    '<th class="th th-label">Day total</th>' +
+                '</tr>' +
+                '</thead>\n';
     }
 
     /*
@@ -493,7 +494,7 @@ class Calendar {
         var monthLength = this.getMonthLength();
         var html = '<div>';
         html += this._getPageHeader(this.year, this.month);
-        html += '<table>';
+        html += '<table class="table-body">';
         html += this._getTableHeaderCode();
         for (var day = 1; day <= monthLength; ++day) {
             html += this._getInputsRowCode(this.year, this.month, day);


### PR DESCRIPTION
Closes #31 
This makes month header and table labels as sticky headers so it gets attached to the top when the user scrolls down.

Screen context:
![image](https://user-images.githubusercontent.com/33427789/66434600-41b4b080-e9f9-11e9-8e4f-c269705253ec.png)

Detailed:
![image](https://user-images.githubusercontent.com/33427789/66434661-63159c80-e9f9-11e9-979d-26aa1eb67645.png)

P.S.: Commits mess caused by me still learning :joy: