### PR TITLE
Always wait on notifications

### DIFF
--- a/js/notification.js
+++ b/js/notification.js
@@ -11,7 +11,7 @@ function notifyUser() {
             message: 'Hey there! I think it\'s time to leave.',
             icon: path.join(__dirname, 'assets/timer.png'), // Absolute path (doesn't work on balloons)
             sound: true, // Only Notification Center or Windows Toasters
-            wait: true // Wait with callback, until user action is taken against notification
+            wait: true
         },
       );
 }
@@ -23,7 +23,7 @@ function notify(msg) {
             message: msg,
             icon: path.join(__dirname, 'assets/timer.png'), // Absolute path (doesn't work on balloons)
             sound: true, // Only Notification Center or Windows Toasters
-            wait: false // Wait with callback, until user action is taken against notification
+            wait: true
         },
       );
 }


### PR DESCRIPTION
Seems like `wait` is only useful when you actually want to do something on the callback. 
Documentation also states this
>     wait: true // Wait with callback, until user action is taken against notification, does not apply to Windows Toasters as they always wait

I found out that having the `wait: false` makes the dialog never show up, so I'm forcing it to true for windows

Closes #72 