### PR TITLE
Support backward compatibilty in preferences

### DIFF
--- a/js/UserPreferences.js
+++ b/js/UserPreferences.js
@@ -47,8 +47,7 @@ function readPreferences() {
 }
 
 /*
- * Returns true if there's a valid preferences file.
- * Invalid files don't have all the settings listed.
+ * Returns true if something is missing or invalid in preferences file
  */
 function shouldSaveDerivedPreferencesFile() {
     if (!fs.existsSync(getPreferencesFilePath())) {

--- a/js/UserPreferences.js
+++ b/js/UserPreferences.js
@@ -16,6 +16,8 @@ const defaultPreferences = {
     'working-days-sunday': false,
 };
 
+var derivedPreferences;
+
 /*
  * Returns the preference file path, considering the userData path
  */
@@ -48,30 +50,36 @@ function readPreferences() {
  * Returns true if there's a valid preferences file.
  * Invalid files don't have all the settings listed.
  */
-function hasValidPreferencesFile() {
+function shouldSaveDerivedPreferencesFile() {
     if (!fs.existsSync(getPreferencesFilePath())) {
-        return false;
+        return true;
     }
+
+    var shouldSaveDerivedPref = false;
+
     // Validate keys
     var prefs = readPreferences();
+    derivedPreferences = Object.assign(defaultPreferences, prefs);
     var loadedPref = Object.keys(prefs).sort();
-    var referencePref = Object.keys(defaultPreferences).sort();
-    if (JSON.stringify(loadedPref) != JSON.stringify(referencePref)) {
-        return false;
+    var derivedPrefKeys = Object.keys(derivedPreferences).sort();
+    if (JSON.stringify(loadedPref) != JSON.stringify(derivedPrefKeys)) {
+        shouldSaveDerivedPref = true;
     }
     // Validate the values
-    for(var key of Object.keys(prefs)) {
-        var value = prefs[key];
+    for(var key of derivedPrefKeys) {
+        var value = derivedPreferences[key];
         switch (key) {
         case 'hours-per-day': {
             if (!validateTime(value)) {
-                return false;
+                derivedPreferences[key] = defaultPreferences[key];
+                shouldSaveDerivedPref = true;
             }
             break;
         }
         case 'notification': {
             if (value != 'enabled' && value != 'disabled') {
-                return false;
+                derivedPreferences[key] = defaultPreferences[key];
+                shouldSaveDerivedPref = true;
             }
             break;
         }
@@ -83,19 +91,21 @@ function hasValidPreferencesFile() {
         case 'working-days-saturday': 
         case 'working-days-sunday': {
             if (value != true && value != false) {
-                return false;
+                derivedPreferences[key] = defaultPreferences[key];
+                shouldSaveDerivedPref = true;
             }
             break;
         }
         case 'hide-non-working-days': {
             if (value != true && value != false) {
-                return false;
+                derivedPreferences[key] = defaultPreferences[key];
+                shouldSaveDerivedPref = true;
             }
             break;
         }
         }
     } 
-    return true;
+    return shouldSaveDerivedPref;
 }
 
 /*
@@ -103,8 +113,8 @@ function hasValidPreferencesFile() {
  */
 function getUserPreferences() {
     // Initialize preferences file if it doesn't exists or is invalid
-    if (!hasValidPreferencesFile()) {
-        savePreferences(defaultPreferences);
+    if (shouldSaveDerivedPreferencesFile()) {
+        savePreferences(derivedPreferences || defaultPreferences);
     }
     return readPreferences();
 }


### PR DESCRIPTION
Here, we are making a derived preferences by overriding values of default preferences using values of currently saved preferences. Then, we are checking keys of current preferences and derived preferences are same or not. If they are not save, we will store the derived preferences.
But before doing that we are also validating values of default preferences. If any value is invalid, we are changing it with default preferences value.

In this workflow, we are not omitting key-values that is present old preference but not in new default preferences. Should I remove these kind of key-values from preferences?

This PR addresses #61 