### PR TITLE
[enhancement] require('update-electron-app')()

### DIFF
--- a/main.js
+++ b/main.js
@@ -231,3 +231,7 @@ app.on('activate', () => {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+require('update-electron-app')({
+    repo: 'thamara/time-to-leave',
+    updateInterval: '1 day'
+});


### PR DESCRIPTION
This would address #43 ; but, before it is usable, the app needs to be signed. If it is signed when released, that can be tested on an official build. Otherwise, until there are signed Github releases, it won't work with electron's standard ways.

However; it's possible to run your own update server, too, and use electron-builder's electron-updater. 