### PR TITLE
Remove old options when checking preferences

### DIFF
--- a/js/UserPreferences.js
+++ b/js/UserPreferences.js
@@ -16,8 +16,6 @@ const defaultPreferences = {
     'working-days-sunday': false,
 };
 
-var derivedPreferences;
-
 /*
  * Returns the preference file path, considering the userData path
  */
@@ -46,46 +44,51 @@ function readPreferences() {
     return preferences ? preferences : {};
 }
 
-function copyValuesFromSavedPreferencesToDerivedPreferences(savedPreferences){
-    derivedPreferences = {};
+function getDerivedPrefsFromLoadedPrefs(loadedPreferences){
+    var derivedPreferences = {};
     Object.keys(defaultPreferences).forEach(function(key){
-        derivedPreferences[key] = savedPreferences[key] || defaultPreferences[key];
-    })
+        derivedPreferences[key] = loadedPreferences[key] || defaultPreferences[key];
+    });
+
+    return defaultPreferences;
 }
 
 /*
- * Returns true if something is missing or invalid in preferences file
+ * initializes users preferences if it is not already exists
+ * or any keys of existing preferences is invalid
  */
-function shouldSaveDerivedPreferencesFile() {
+function initPreferencesFileIfNotExistsOrInvalid() {
     if (!fs.existsSync(getPreferencesFilePath())) {
-        return true;
+        savePreferences(defaultPreferences);
+        return;
     }
 
-    var shouldSaveDerivedPref = false;
+    var shouldSaveDerivedPrefs = false,
+        loadedPrefs = readPreferences(),
+        derivedPrefs = getDerivedPrefsFromLoadedPrefs(loadedPrefs),
+        loadedPref = Object.keys(loadedPrefs).sort(),
+        derivedPrefsKeys = Object.keys(derivedPrefs).sort();
 
     // Validate keys
-    var prefs = readPreferences();
-    copyValuesFromSavedPreferencesToDerivedPreferences(prefs);
-    var loadedPref = Object.keys(prefs).sort();
-    var derivedPrefKeys = Object.keys(derivedPreferences).sort();
-    if (JSON.stringify(loadedPref) != JSON.stringify(derivedPrefKeys)) {
-        shouldSaveDerivedPref = true;
+    if (JSON.stringify(loadedPref) != JSON.stringify(derivedPrefsKeys)) {
+        shouldSaveDerivedPrefs = true;
     }
+
     // Validate the values
-    for(var key of derivedPrefKeys) {
-        var value = derivedPreferences[key];
+    for(var key of derivedPrefsKeys) {
+        var value = derivedPrefs[key];
         switch (key) {
         case 'hours-per-day': {
             if (!validateTime(value)) {
-                derivedPreferences[key] = defaultPreferences[key];
-                shouldSaveDerivedPref = true;
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
             }
             break;
         }
         case 'notification': {
             if (value != 'enabled' && value != 'disabled') {
-                derivedPreferences[key] = defaultPreferences[key];
-                shouldSaveDerivedPref = true;
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
             }
             break;
         }
@@ -97,35 +100,35 @@ function shouldSaveDerivedPreferencesFile() {
         case 'working-days-saturday': 
         case 'working-days-sunday': {
             if (value != true && value != false) {
-                derivedPreferences[key] = defaultPreferences[key];
-                shouldSaveDerivedPref = true;
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
             }
             break;
         }
         case 'hide-non-working-days': {
             if (value != true && value != false) {
-                derivedPreferences[key] = defaultPreferences[key];
-                shouldSaveDerivedPref = true;
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
             }
             break;
         }
         }
-    } 
-    return shouldSaveDerivedPref;
+    }
+
+    if(shouldSaveDerivedPrefs) {
+        savePreferences(derivedPrefs);
+    }
 }
 
 /*
  * Returns the user preferences.
  */
-function getUserPreferences() {
-    // Initialize preferences file if it doesn't exists or is invalid
-    if (shouldSaveDerivedPreferencesFile()) {
-        savePreferences(derivedPreferences || defaultPreferences);
-    }
+function getLoadedOrDerivedUserPreferences() {
+    initPreferencesFileIfNotExistsOrInvalid();
     return readPreferences();
 }
 
 module.exports = {
-    getUserPreferences,
+    getUserPreferences: getLoadedOrDerivedUserPreferences,
     savePreferences
 };

--- a/js/UserPreferences.js
+++ b/js/UserPreferences.js
@@ -46,6 +46,13 @@ function readPreferences() {
     return preferences ? preferences : {};
 }
 
+function copyValuesFromSavedPreferencesToDerivedPreferences(savedPreferences){
+    derivedPreferences = {};
+    Object.keys(defaultPreferences).forEach(function(key){
+        derivedPreferences[key] = savedPreferences[key] || defaultPreferences[key];
+    })
+}
+
 /*
  * Returns true if something is missing or invalid in preferences file
  */
@@ -58,7 +65,7 @@ function shouldSaveDerivedPreferencesFile() {
 
     // Validate keys
     var prefs = readPreferences();
-    derivedPreferences = Object.assign(defaultPreferences, prefs);
+    copyValuesFromSavedPreferencesToDerivedPreferences(prefs);
     var loadedPref = Object.keys(prefs).sort();
     var derivedPrefKeys = Object.keys(derivedPreferences).sort();
     if (JSON.stringify(loadedPref) != JSON.stringify(derivedPrefKeys)) {


### PR DESCRIPTION
Here, we are skipping keys from `loadedPreferences` which are not present in `defaultPreferences`.

Additionally, some code refactoring have been done to make code more readable and removed side-effect from function that was unwillingly introduced in #76 .

This PR addresses #79 