### PR TITLE
Remove latest releases from help menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -214,12 +214,6 @@ function createWindow () {
                     }
                 },
                 {
-                    label: 'Latest releases',
-                    click () {
-                        shell.openExternal('https://github.com/thamara/time-to-leave/releases');
-                    }
-                },
-                {
                     label: 'Check for updates',
                     click () {
                         checkForUpdates();


### PR DESCRIPTION
#### Related issue
[#102](https://github.com/thamara/time-to-leave/issues/102)

#### Context
- As we have option to view the latest releases in check for updates, we could remove the latest releases from Help menu