### PR TITLE
add date range for waiver

### DIFF
--- a/js/time_math.js
+++ b/js/time_math.js
@@ -82,6 +82,11 @@ function validateTime(time) {
     return re.test(time);
 }
 
+/**
+ * Get a difference between two dates.
+ * date1, or date2 should be javascript Date instance.
+ * @return Number
+ */
 function diffDays(date1, date2) {
     const diffTime = Math.abs(date2 - date1);
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24));

--- a/js/time_math.js
+++ b/js/time_math.js
@@ -82,6 +82,11 @@ function validateTime(time) {
     return re.test(time);
 }
 
+function diffDays(date1, date2) {
+    const diffTime = Math.abs(date2 - date1);
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+}
+
 module.exports = {
     hourMinToHourFormated,
     isNegative,
@@ -90,5 +95,6 @@ module.exports = {
     subtractTime,
     sumTime,
     validateTime,
-    hourToMinutes
+    hourToMinutes,
+    diffDays
 };

--- a/js/time_math.js
+++ b/js/time_math.js
@@ -88,7 +88,7 @@ function validateTime(time) {
  * @return Number
  */
 function diffDays(date1, date2) {
-    const diffTime = Math.abs(date2 - date1);
+    const diffTime = date2 - date1;
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 }
 

--- a/src/workday_waiver.html
+++ b/src/workday_waiver.html
@@ -25,7 +25,8 @@
                     <tbody>
                     <tr>
                         <td>Date</td>
-                        <td><input id="date" type="date"></td>
+                        <td><input id="start_date" type="date"></td>
+                        <td><input id="end_date" type="date"></td>
                     </tr>
                     <tr>
                         <td>Hours</td>

--- a/src/workday_waiver.html
+++ b/src/workday_waiver.html
@@ -24,8 +24,15 @@
                 <table class="data">
                     <tbody>
                     <tr>
-                        <td>Date</td>
+                        <td></td>
+                        <td>Start date</td>
+                        <td></td>
+                        <td>End date</td>
+                    </tr>
+                    <tr>
+                        <td>From</td>
                         <td><input id="start_date" type="date"></td>
+                        <td>to</td>
                         <td><input id="end_date" type="date"></td>
                     </tr>
                     <tr>

--- a/src/workday_waiver.js
+++ b/src/workday_waiver.js
@@ -83,12 +83,12 @@ function addWaiver() {
         temp_date.setDate(temp_date.getDate() + 1);
     }
 
-    for (var i = 0; i <= diff; i++) {
+    for (i = 0; i <= diff; i++) {
         var temp_year = temp_date.getFullYear(),
             temp_month = temp_date.getMonth(),
             temp_day = temp_date.getDay();
 
-        var temp_date_str = temp_date.toISOString().substr(0, 10);
+        temp_date_str = temp_date.toISOString().substr(0, 10);
 
         if (showDay(temp_year, temp_month - 1, temp_day) && !store.has(temp_date_str)) {
             store.set(temp_date_str, { 'reason' : reason, 'hours' : hours });

--- a/src/workday_waiver.js
+++ b/src/workday_waiver.js
@@ -78,7 +78,7 @@ function addWaiver() {
 
         var temp_date_str = temp_date.toISOString().substr(0, 10);
 
-        if (showDay(temp_year, temp_month - 1, temp_day) && !store.has(temp_date)) {
+        if (showDay(temp_year, temp_month - 1, temp_day) && !store.has(temp_date_str)) {
             store.set(temp_date_str, { 'reason' : reason, 'hours' : hours });
             addRowToListTable(temp_date_str, reason, hours);
         }

--- a/src/workday_waiver.js
+++ b/src/workday_waiver.js
@@ -72,6 +72,18 @@ function addWaiver() {
     var diff = diffDays(start_date, end_date);
 
     for (var i = 0; i <= diff; i++) {
+        var temp_date_str = temp_date.toISOString().substr(0, 10);
+
+        if (store.has(temp_date_str)) {
+            alert('You already have a waiver in range of this day. Remove it before adding a new one.');
+
+            return;
+        }
+
+        temp_date.setDate(temp_date.getDate() + 1);
+    }
+
+    for (var i = 0; i <= diff; i++) {
         var temp_year = temp_date.getFullYear(),
             temp_month = temp_date.getMonth(),
             temp_day = temp_date.getDay();

--- a/src/workday_waiver.js
+++ b/src/workday_waiver.js
@@ -71,13 +71,15 @@ function addWaiver() {
 
     var diff = diffDays(start_date, end_date);
 
+    if (diff < 0) {
+        alert('End date cannot be less than start date.');
+    }
+
     for (var i = 0; i <= diff; i++) {
         var temp_date_str = temp_date.toISOString().substr(0, 10);
 
         if (store.has(temp_date_str)) {
-            alert('You already have a waiver in range of this day. Remove it before adding a new one.');
-
-            return;
+            alert(`You already have a waiver on ${temp_date_str}. Remove it before adding a new one.`);
         }
 
         temp_date.setDate(temp_date.getDate() + 1);


### PR DESCRIPTION
#### Related issue
#106 

#### Context / Background
Add date range for waiver, so it can apply to multiple dates

#### What change is being introduced by this PR?
- What changes did you make to achieve the goal?
  - I change date in waiver to became two date, named start_date and end_date. And make it as `Date()` instance so i can calculate days different from both. from that i make looping that will insert each day a waiver.
- What are the indirect and direct consequences of the change?
  - i remove user interaction (dialog/alert) for validation inside looping, because it will distract user for using the app.

#### How will this be tested?
1. Open waiver window
2. Choose today as the start date (left) and today + 1 day for end date (right)
3. hoose hours
4. type reasons
5. click waive button

![Screen Shot 2019-10-22 at 10 51 58](https://user-images.githubusercontent.com/26959883/67256515-02d33000-f4ba-11e9-9940-a6091c93fdca.png)
