### PR TITLE
Show "up-to-date" only when asking explicitly

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ function shouldcheckForUpdates() {
     return !lastChecked || todayDate > lastChecked;
 }
 
-async function checkForUpdates() {
+async function checkForUpdates(showUpToDateDialog) {
     var online = await isOnline();
     if (!online) {
         return;
@@ -64,13 +64,16 @@ async function checkForUpdates() {
                         }
                     });
                 } else {
-                    const options = {
-                        type: 'info',
-                        buttons: ['OK'],
-                        title: 'TTL Check for updates',
-                        message: 'Your TTL is up to date.'
-                    };
-                    dialog.showMessageBox(null, options);
+                    if (showUpToDateDialog)
+                    {
+                        const options = {
+                            type: 'info',
+                            buttons: ['OK'],
+                            title: 'TTL Check for updates',
+                            message: 'Your TTL is up to date.'
+                        };
+                        dialog.showMessageBox(null, options);  
+                    }
                 }
             }
         });
@@ -216,7 +219,7 @@ function createWindow () {
                 {
                     label: 'Check for updates',
                     click () {
-                        checkForUpdates();
+                        checkForUpdates(/*showUpToDateDialog=*/true);
                     }
                 },
                 {
@@ -320,7 +323,7 @@ function createWindow () {
     });
 
     if (shouldcheckForUpdates()) {
-        checkForUpdates();
+        checkForUpdates(/*showUpToDateDialog=*/false);
     }
 }
 


### PR DESCRIPTION
#### Related issue
#99 

#### Context / Background
- Recently the app started warning when it is up-to-date, whenever it checks for a version.

#### What change is being introduced by this PR?
- It should only pop-up the up-to-date dialog when the user explicitly asks for the app to check if it's up-to-date. When it does so in the background, it should do silently.

#### How will this be tested?
- Cleared the database and reopened it, didn't warn.
