### PR TITLE
Sum month balance until previous day

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -151,6 +151,7 @@ input[type="time"]::-webkit-clear-button {
   text-align: right;
   margin-top: auto;
   font-size: 90%;
+  font-variant-caps: all-petite-caps;
 }
 
 .month-total-text {

--- a/index.html
+++ b/index.html
@@ -25,20 +25,6 @@
   <br>
   <br>
   <br>
-  <div class="footer-pre">
-    <table class="month-summary">
-      <tr>
-        <tr class="month-total-row">
-            <td class="month-total-text" title="How many working days there's in the month">Total of working days</td>
-            <td class="month-total-time" title="How many working days there's in the month"><input type="text" id="month-working-days" size="5" disabled></td>
-            <td class="month-total-text" title="How many hours you logged in this month">Month Total</td>
-            <td class="month-total-time" title="How many hours you logged in this month"><input type="text" id="month-total" size="8" disabled></td>
-            <td class="month-total-text" title="Balance up until today for this month. A positive balance means extra hours you don't need to work today (or the rest of the month).">Month Balance</td>
-            <td class="month-total-time" title="Balance up until today for this month. A positive balance means extra hours you don't need to work today (or the rest of the month)."><input type="text" id="month-balance" size="8" disabled></td>
-          </tr>
-      </tr>
-    </table>
-  </div>
   <div class="footer">
     <button class="punch-button" id="punch-button" disabled>
       <img src="assets/fingerprint.svg" height="36" width="36"></img>


### PR DESCRIPTION
#### Related issue
Closes #98

#### Context / Background
- The balance is currently considering the current day, but this is non-intuitive, as you typically want to sum the balance with the amount you have on the current working day.

#### What change is being introduced by this PR?
- Moved code from footer to day before current day.
- People won't know # of working days in a month anymore

#### How will this be tested?
- Tested it by having just one day enabled in preferences and summing manually.

#### Screenshot
![image](https://user-images.githubusercontent.com/6443427/67258581-c70f7a80-f467-11e9-9b8c-79b3df6add9b.png)
