### PR TITLE
Disable/enable tray punch

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -677,6 +677,24 @@ function updateTimeDay(year, month, day, key, newValue) {
 }
 
 /*
+ * Listens to attribute changes on the punch button, if disabled, it will disable tray punch button
+ */
+document.addEventListener('DOMContentLoaded', function (event) {
+    var target = document.getElementById('punch-button');
+    observer.observe(target, { attributes: true });
+});
+
+var observer = new MutationObserver(function (mutationRecords, observer) {
+    mutationRecords.forEach(function (mutation) {
+        if (mutation.attributeName == 'disabled' && mutation.target.disabled == true) {
+            ipcRenderer.send('updateTray', false);
+        } else {
+            ipcRenderer.send('updateTray', true);
+        }
+    });
+});
+
+/*
  * Based on the key of the input, updates the values for total in db and display it on page
  */
 function updateTimeDayCallback(key, value) {

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -191,8 +191,10 @@ class Calendar {
 
         if (!showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate())) {
             document.getElementById('punch-button').disabled = true;
+            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         } else {
             document.getElementById('punch-button').disabled = false;
+            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
         }
 
         this.updateLeaveBy();
@@ -376,8 +378,10 @@ class Calendar {
         if (dayBegin.length && lunchBegin.length && lunchEnd.length && dayEnd.length) {
             //All entries computed
             document.getElementById('punch-button').disabled = true;
+            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         } else {
             document.getElementById('punch-button').disabled = false;
+            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
         }
     }
 
@@ -675,24 +679,6 @@ function updateTimeDay(year, month, day, key, newValue) {
 
     colorErrorLine(year, month, day, dayBegin, lunchBegin, lunchEnd, dayEnd);
 }
-
-/*
- * Listens to attribute changes on the punch button, if disabled, it will disable tray punch button
- */
-document.addEventListener('DOMContentLoaded', function () {
-    var target = document.getElementById('punch-button');
-    observer.observe(target, { attributes: true });
-});
-
-var observer = new MutationObserver(function (mutationRecords) {
-    mutationRecords.forEach(function (mutation) {
-        if (mutation.attributeName == 'disabled' && mutation.target.disabled == true) {
-            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
-        } else {
-            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
-        }
-    });
-});
 
 /*
  * Based on the key of the input, updates the values for total in db and display it on page

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -687,9 +687,9 @@ document.addEventListener('DOMContentLoaded', function (_event) {
 var observer = new MutationObserver(function (mutationRecords) {
     mutationRecords.forEach(function (mutation) {
         if (mutation.attributeName == 'disabled' && mutation.target.disabled == true) {
-            ipcRenderer.send('updateTray', false);
+            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         } else {
-            ipcRenderer.send('updateTray', true);
+            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
         }
     });
 });

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -679,12 +679,12 @@ function updateTimeDay(year, month, day, key, newValue) {
 /*
  * Listens to attribute changes on the punch button, if disabled, it will disable tray punch button
  */
-document.addEventListener('DOMContentLoaded', function (event) {
+document.addEventListener('DOMContentLoaded', function (_event) {
     var target = document.getElementById('punch-button');
     observer.observe(target, { attributes: true });
 });
 
-var observer = new MutationObserver(function (mutationRecords, observer) {
+var observer = new MutationObserver(function (mutationRecords) {
     mutationRecords.forEach(function (mutation) {
         if (mutation.attributeName == 'disabled' && mutation.target.disabled == true) {
             ipcRenderer.send('updateTray', false);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -679,7 +679,7 @@ function updateTimeDay(year, month, day, key, newValue) {
 /*
  * Listens to attribute changes on the punch button, if disabled, it will disable tray punch button
  */
-document.addEventListener('DOMContentLoaded', function (_event) {
+document.addEventListener('DOMContentLoaded', function () {
     var target = document.getElementById('punch-button');
     observer.observe(target, { attributes: true });
 });

--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ const waivedWorkdays = new Store({name: 'waived-workdays'});
 const macOS = process.platform === 'darwin';
 var iconpath = path.join(__dirname, macOS ? 'assets/timer.png' : 'assets/timer.ico');
 var trayIcon = path.join(__dirname, macOS ? 'assets/timer-16-Template.png' : 'assets/timer-grey.ico');
+var contextMenu;
 
 function shouldcheckForUpdates() {
     var lastChecked = store.get('update-remind-me-after');
@@ -274,7 +275,7 @@ function createWindow () {
     win.loadFile(path.join(__dirname, 'index.html'));
 
     tray = new Tray(trayIcon);
-    var contextMenu = Menu.buildFromTemplate([
+    var contextMenuTemplate = [
         {
             label: 'Punch time', click: function () {
                 var now = new Date();
@@ -295,7 +296,12 @@ function createWindow () {
                 app.quit();
             }
         }
-    ]);
+    ];
+
+    ipcMain.on('updateTray', function(event, arg) {
+        contextMenuTemplate[0].enabled = arg;
+        contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
+    });
 
     tray.on('click', function handleCliked() {
         win.show();

--- a/main.js
+++ b/main.js
@@ -298,7 +298,7 @@ function createWindow () {
         }
     ];
 
-    ipcMain.on('updateTray', function(_event, arg) {
+    ipcMain.on('TOGGLE_TRAY_PUNCH_TIME', function(_event, arg) {
         contextMenuTemplate[0].enabled = arg;
         contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
     });

--- a/main.js
+++ b/main.js
@@ -298,7 +298,7 @@ function createWindow () {
         }
     ];
 
-    ipcMain.on('updateTray', function(event, arg) {
+    ipcMain.on('updateTray', function(_event, arg) {
         contextMenuTemplate[0].enabled = arg;
         contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
     });


### PR DESCRIPTION
#### Related issue
#70 

#### Context / Background
Tray punch button now follows the behaviour of the punch time button. It is disabled if the day is a non-working day or if all entries have already been punched.

#### What change is being introduced by this PR?
I added an observer on the punch button to see if the attribute changes to disabled. The result of this condition will send the value to main, setting the enabled key in the contextMenuTemplate. The tray menu will be rebuilt on dynamic values.
