### PR TITLE
Fixing bugs on workday waiver manager 

### DIFF
--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -67,32 +67,32 @@ function addWaiver() {
         return;
     }
 
-    var temp_date = start_date;
-
     var diff = diffDays(start_date, end_date);
-
     if (diff < 0) {
         alert('End date cannot be less than start date.');
+        return;
     }
 
+    var temp_date = new Date(start_date.getTime());
     for (var i = 0; i <= diff; i++) {
         var temp_date_str = temp_date.toISOString().substr(0, 10);
 
         if (store.has(temp_date_str)) {
             alert(`You already have a waiver on ${temp_date_str}. Remove it before adding a new one.`);
+            return;
         }
 
         temp_date.setDate(temp_date.getDate() + 1);
     }
 
+    temp_date.setDate(start_date.getDate());
     for (i = 0; i <= diff; i++) {
         var temp_year = temp_date.getFullYear(),
             temp_month = temp_date.getMonth(),
             temp_day = temp_date.getDay();
 
         temp_date_str = temp_date.toISOString().substr(0, 10);
-
-        if (showDay(temp_year, temp_month - 1, temp_day) && !store.has(temp_date_str)) {
+        if (showDay(temp_year, temp_month, temp_day) && !store.has(temp_date_str)) {
             store.set(temp_date_str, { 'reason' : reason, 'hours' : hours });
             addRowToListTable(temp_date_str, reason, hours);
         }


### PR DESCRIPTION
#### Related issue
- Closes #120

#### Context / Background
1. When you try to add a waiver, it's added on the day subsequent to the 'End date', respecting the range specified. Trying to add a waiver from 28/10/2019 to 29/10/2019 will create waivers for the days 30/10/2019 and 31/10/2019, e.g.
2. Some days won't have their waives added despite not having a waiver and being a working day. October 07th, 2019; for instance.
3. When you try to add waivers on a range and one of the dates of the range already has a waiver, an alert is displayed, but the dates that don't have a waiver still get it.

#### What change is being introduced by this PR?
1. Subsequent days
    - Changed temp_date from reference to copy of start_date, resetting its value when necessary.
    - The waivers will now be added to the specified range.
2. Waiver not being added to eligible days
    - showDay within the function receives temp_month instead of temp_month - 1, applying the test to the correct month.
    - The eligible days that wouldn't have their waiver added now have.
3. Trying to add waiver on a range that already has at least one
    - A return was added after the alert display on the event of a waiver on the range.
    - All days of the range must not have a waiver for the waivers to be applied on the range.

#### How will this be tested?
1. Trying to add a waiver from 28/10/2019 to 29/10/2019.
2. Trying to add a waiver from 07/10/2019 to 08/10/2019.
3. Trying to add a waiver from 07/10/2019 to 10/10/2019 (supposing 2 was successful and not deleted).

#### Notes
3 is more a change of behavior than a bug, but I judged that this behavior was more desirable. Should I keep the original one?