### PR TITLE
Suggest punch if idle for over 30 minutes

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,17 @@ var trayIcon = path.join(__dirname, macOS ? 'assets/timer-16-Template.png' : 'as
 var contextMenu;
 var launchDate = new Date();
 
+// Logic for recommending user to punch in when they've been idle for too long
+var recommendPunchIn = false;
+setTimeout(() => { recommendPunchIn = true; }, 30 * 60 * 1000);
+
+function checkIdleAndNotify() {
+    if (recommendPunchIn) {
+        recommendPunchIn = false;
+        notify('Don\'t forget to punch in!');
+    }
+}
+
 function shouldcheckForUpdates() {
     var lastChecked = store.get('update-remind-me-after');
     var today = new Date(),
@@ -357,6 +368,9 @@ function createWindow () {
 app.on('ready', createWindow);
 app.on('ready', () => {
     setInterval(refreshOnDayChange, 60 * 60 * 1000);
+    const { powerMonitor } = require('electron');
+    powerMonitor.on('unlock-screen', () => { checkIdleAndNotify(); });
+    powerMonitor.on('resume', () => { checkIdleAndNotify(); });
 });
 
 // Quit when all windows are closed.


### PR DESCRIPTION
#### Related issue
Closes #67 

#### Context / Background
- Users often forget to punch when they're away from the PC and returning.

#### What change is being introduced by this PR?
- How did you approach this problem?
- What changes did you make to achieve the goal?
Setting a timeout of 30 minutes and a callback on system unlock/resume
- What are the indirect and direct consequences of the change?
A notification to punch in if time was exceeded

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?
I set the timeout to 1s instead.
