### PR TITLE
Update table when day changes

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ const macOS = process.platform === 'darwin';
 var iconpath = path.join(__dirname, macOS ? 'assets/timer.png' : 'assets/timer.ico');
 var trayIcon = path.join(__dirname, macOS ? 'assets/timer-16-Template.png' : 'assets/timer-grey.ico');
 var contextMenu;
+var launchDate = new Date();
 
 function shouldcheckForUpdates() {
     var lastChecked = store.get('update-remind-me-after');
@@ -83,6 +84,15 @@ async function checkForUpdates(showUpToDateDialog) {
         });
     });
     request.end();
+}
+
+function refreshOnDayChange() {
+    var today = new Date();
+    if (today > launchDate)
+    {
+        launchDate = today;
+        win.reload();
+    }
 }
 
 function createWindow () {
@@ -345,6 +355,9 @@ function createWindow () {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', createWindow);
+app.on('ready', () => {
+    setInterval(refreshOnDayChange, 60 * 60 * 1000);
+});
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {


### PR DESCRIPTION
#### Related issue
Closes #56 

#### Context / Background
- Users typically leave the app open overnight, and thus it has to redraw itself to include the "leave by" bar under the appropriate date.

#### What change is being introduced by this PR?
- How did you approach this problem?
The app needs to periodically check if the current day is greater than the previously registered day.
- What changes did you make to achieve the goal?
Introduced a 60 minutes timeout to check whether the day has elapsed
- What are the indirect and direct consequences of the change?
Users won't have to manually refresh or reopen the app when arriving to work on the following day

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?
I know the callback works, because I set the timer to 1s and it didn't stop refreshing :P
