### PR TITLE
Fix displaying today's data on window reload

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -315,12 +315,6 @@ class Calendar {
                 continue;
             }
 
-            var isToday = (this.today.getDate() == day && this.today.getMonth() == this.month && this.today.getFullYear() == this.year);
-            if (isToday) {
-                break;
-            }
-            this.workingDays += 1;
-
             var currentDay = new Date(this.year, this.month, day),
                 dateStr = currentDay.toISOString().substr(0, 10);
 
@@ -329,21 +323,28 @@ class Calendar {
                 var waivedInfo = waivedWorkdays.get(dateStr);
                 var waivedDayTotal = waivedInfo['hours'];
                 document.getElementById(dayStr + 'day-total').value = waivedDayTotal;
-                monthTotal = sumTime(monthTotal, waivedDayTotal);
+                var dayTotal = waivedDayTotal;
             } else {
                 var lunchBegin = this._setData(dayStr + 'lunch-begin');
                 var lunchEnd = this._setData(dayStr + 'lunch-end');
-                /*var lunchTotal = */this._setData(dayStr + 'lunch-total');
+                this._setData(dayStr + 'lunch-total');
                 var dayBegin = this._setData(dayStr + 'day-begin');
                 var dayEnd = this._setData(dayStr + 'day-end');
                 var dayTotal = this._setData(dayStr + 'day-total');
 
-                if (dayTotal) {
-                    monthTotal = sumTime(monthTotal, dayTotal);
-                }
-
                 colorErrorLine(this.year, this.month, day, dayBegin, lunchBegin, lunchEnd, dayEnd);
             }
+
+            var isToday = (this.today.getDate() == day && this.today.getMonth() == this.month && this.today.getFullYear() == this.year);
+            if (isToday) {
+                break;
+            }
+
+            if (dayTotal) {
+                monthTotal = sumTime(monthTotal, dayTotal);
+            }
+
+            this.workingDays += 1;
         }
         var monthDayInput = document.getElementById('month-day-input');
         if (monthDayInput)

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -318,19 +318,20 @@ class Calendar {
             var currentDay = new Date(this.year, this.month, day),
                 dateStr = currentDay.toISOString().substr(0, 10);
 
+            var dayTotal = null;
             var dayStr = this.year + '-' + this.month + '-' + day + '-';
             if (waivedWorkdays.has(dateStr)) {
                 var waivedInfo = waivedWorkdays.get(dateStr);
                 var waivedDayTotal = waivedInfo['hours'];
                 document.getElementById(dayStr + 'day-total').value = waivedDayTotal;
-                var dayTotal = waivedDayTotal;
+                dayTotal = waivedDayTotal;
             } else {
                 var lunchBegin = this._setData(dayStr + 'lunch-begin');
                 var lunchEnd = this._setData(dayStr + 'lunch-end');
                 this._setData(dayStr + 'lunch-total');
                 var dayBegin = this._setData(dayStr + 'day-begin');
                 var dayEnd = this._setData(dayStr + 'day-end');
-                var dayTotal = this._setData(dayStr + 'day-total');
+                dayTotal = this._setData(dayStr + 'day-total');
 
                 colorErrorLine(this.year, this.month, day, dayBegin, lunchBegin, lunchEnd, dayEnd);
             }


### PR DESCRIPTION
#### Related issue
- Closes #133

#### Context / Background
- Today's entries are registered on config.json, but disappear on window reload.

#### What change is being introduced by this PR?
- Changed ifs sequence and centered month total sum on updateBasedOnDB() calendar.js function.
- Today entries will be displayed on window reload.

#### How will this be tested?
- Inserting data on today's row and reloading the window.