### PR TITLE
Fix #148: Prevent app from going fullscreen on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -286,19 +286,25 @@ function createWindow () {
     ]);
 
     win = new BrowserWindow({
+        width: 1000,
+        height: 1000,
         useContentSize: true,
-        zoomToPageWidth: true,
+        zoomToPageWidth: true, //MacOS only
         icon: iconpath,
+        show: false,
         webPreferences: {
             nodeIntegration: true
         }
     });
-    win.maximize();
 
     Menu.setApplicationMenu(menu);
-    if (!macOS) {
+    if (macOS) {
+        win.maximize();
+    } else {
         win.setMenu(menu);
     }
+    // Prevents flickering from maximize
+    win.show();
 
     // and load the index.html of the app.
     win.loadFile(path.join(__dirname, 'index.html'));


### PR DESCRIPTION
#### Related issue
Closes #148 

#### Context / Background
- The app was using `maximize()` indiscriminately. This works to fit to content on MacOS, but makes the app fullscreen on Windows, which is undesired.

#### What change is being introduced by this PR?
- Restored the fixed height/width
- Made the app invisible on startup, to prevent flickering upon MacOS' `maximize`

#### How will this be tested?
- Tested manually on Windows and behavior on Mac should be the same
