### PR TITLE
Fix #147: Differentiate headers and content on Waiver manager

### DIFF
--- a/src/workday-waiver.css
+++ b/src/workday-waiver.css
@@ -69,6 +69,11 @@ input {
     border-bottom: 1px solid var(--table-total-border);
 }
 
+th {
+    padding-right: 5px;
+    padding-left: 5px;
+}
+
 td {
     padding-right: 5px;
     padding-left: 5px;

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -25,24 +25,24 @@
                     <tbody>
                     <tr>
                         <td></td>
-                        <td>Start date</td>
+                        <th>Start date</th>
                         <td></td>
-                        <td>End date</td>
+                        <th>End date</th>
                     </tr>
                     <tr>
-                        <td>From</td>
+                        <th>From</th>
                         <td><input id="start_date" type="date"></td>
-                        <td>to</td>
+                        <th>to</th>
                         <td><input id="end_date" type="date"></td>
                     </tr>
                     <tr>
-                        <td>Hours</td>
+                        <th>Hours</th>
                         <td>
                             <input type="text" id="hours" maxlength=8 pattern="^\d+:\d+$" placeholder="HH:mm" size=8>
                         </td>
                     </tr>
                     <tr>
-                        <td>Reason</td>
+                        <th>Reason</th>
                         <td colspan="3"><input id="reason" type="text" maxlength="30" size="60" placeholder="Reason for the waiver"></td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
#### Related issue
#147 

#### Context / Background
- It was difficult to tell what was a header and content before, now it's properly distinguishable.

#### What change is being introduced by this PR?
Differentiating headers and content using `th` instead of `td`

#### How will this be tested?
Visually it looks better:

**Before**

![image](https://user-images.githubusercontent.com/6443427/70589713-2e67c200-1baf-11ea-9902-531817c6202a.png)

**After**

![with-headers](https://user-images.githubusercontent.com/6443427/70836186-39ed0000-1dde-11ea-8be9-023c65e5b77e.png)

