### PR TITLE
    Use the macOS dock if we have it

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,7 +50,7 @@ async function checkForUpdates(showUpToDateDialog) {
     if (!online) {
         return;
     }
-    
+
     const request = net.request('https://api.github.com/repos/thamara/time-to-leave/releases/latest');
     request.on('response', (response) => {
         response.on('data', (chunk) => {
@@ -86,7 +86,7 @@ async function checkForUpdates(showUpToDateDialog) {
                             title: 'TTL Check for updates',
                             message: 'Your TTL is up to date.'
                         };
-                        dialog.showMessageBox(null, options);  
+                        dialog.showMessageBox(null, options);
                     }
                 }
             }
@@ -119,8 +119,8 @@ function createWindow () {
                             global.waiverDay = today.toISOString().substr(0, 10);
                         }
                         const htmlPath = path.join('file://', __dirname, 'src/workday-waiver.html');
-                        let waiverWindow = new BrowserWindow({ width: 600, 
-                            height: 500, 
+                        let waiverWindow = new BrowserWindow({ width: 600,
+                            height: 500,
                             parent: win,
                             resizable: true,
                             icon: iconpath,
@@ -131,7 +131,7 @@ function createWindow () {
                         waiverWindow.loadURL(htmlPath);
                         waiverWindow.show();
                         waiverWindow.on('close', function () {
-                            waiverWindow = null; 
+                            waiverWindow = null;
                             win.reload();
                         });
                     },
@@ -196,8 +196,8 @@ function createWindow () {
                     },
                 },
                 {
-                    label:'Clear database', 
-                    click() { 
+                    label:'Clear database',
+                    click() {
                         const options = {
                             type: 'question',
                             buttons: ['Cancel', 'Yes, please', 'No, thanks'],
@@ -302,8 +302,24 @@ function createWindow () {
         }
     });
 
+
     Menu.setApplicationMenu(menu);
+
+    const dockMenu = Menu.buildFromTemplate([
+        {
+            label: 'Punch time', click: function () {
+                var now = new Date();
+
+                win.webContents.executeJavaScript('punchDate()');
+                // Slice keeps "HH:MM" part of "HH:MM:SS GMT+HHMM (GMT+HH:MM)" time string
+                notify(`Punched time ${now.toTimeString().slice(0,5)}`);
+            }
+        }
+    ]);
+
     if (macOS) {
+        // Use the macOS dock if we've got it
+        app.dock.setMenu(dockMenu);
         win.maximize();
     } else {
         win.setMenu(menu);


### PR DESCRIPTION
	modified:   main.js

#### Context / Background
- It's customary for a quick menu to exist in the context menu for the dock's icon itself, as well as the tray. This simply adds a punch-in function since the rest is native.

#### What change is being introduced by this PR?
- How did you approach this problem?
    I used the app.dock api
- What changes did you make to achieve the goal?
    I added a Menu.
- What are the indirect and direct consequences of the change?
    For macOS users, a new convenience. For everyone else, nothing.

#### How will this be tested?
- With pictures!

BEFORE:
![Screen Shot 2019-12-29 at 9 06 35 AM](https://user-images.githubusercontent.com/46304146/71560185-5c585d80-2a1b-11ea-98ba-a9e058cca48f.png)

AFTER:
![Screen Shot 2019-12-29 at 9 05 53 AM](https://user-images.githubusercontent.com/46304146/71560192-65e1c580-2a1b-11ea-8609-3f0acc5bae6c.png)

