### PR TITLE
Reduce flckering

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,7 +98,8 @@ function refreshOnDayChange() {
     if (today > launchDate)
     {
         launchDate = today;
-        win.reload();
+        // Reload only the calendar itself to avoid a flash
+        win.webContents.executeJavaScript('calendar.redraw()')
     }
 }
 
@@ -209,7 +210,8 @@ function createWindow() {
                         if (response === 1) {
                             store.clear();
                             waivedWorkdays.clear();
-                            win.reload();
+                            // Reload only the calendar itself to avoid a flash
+                            win.webContents.executeJavaScript('calendar.redraw()')
                             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                 {
                                     title: 'Time to Leave',

--- a/main.js
+++ b/main.js
@@ -130,7 +130,8 @@ function createWindow() {
                         waiverWindow.show();
                         waiverWindow.on('close', function() {
                             waiverWindow = null;
-                            win.reload();
+                            // Reload only the calendar itself to avoid a flash
+                            win.webContents.executeJavaScript('calendar.redraw()')
                         });
                     },
                 },

--- a/main.js
+++ b/main.js
@@ -99,7 +99,7 @@ function refreshOnDayChange() {
     {
         launchDate = today;
         // Reload only the calendar itself to avoid a flash
-        win.webContents.executeJavaScript('calendar.redraw()')
+        win.webContents.executeJavaScript('calendar.redraw()');
     }
 }
 
@@ -132,7 +132,7 @@ function createWindow() {
                         waiverWindow.on('close', function() {
                             waiverWindow = null;
                             // Reload only the calendar itself to avoid a flash
-                            win.webContents.executeJavaScript('calendar.redraw()')
+                            win.webContents.executeJavaScript('calendar.redraw()');
                         });
                     },
                 },
@@ -211,7 +211,7 @@ function createWindow() {
                             store.clear();
                             waivedWorkdays.clear();
                             // Reload only the calendar itself to avoid a flash
-                            win.webContents.executeJavaScript('calendar.redraw()')
+                            win.webContents.executeJavaScript('calendar.redraw()');
                             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                 {
                                     title: 'Time to Leave',


### PR DESCRIPTION
#### Context / Background
- Currently the app will reload the main window after any database changes
- The only part of the window which changes is the calendar itself

#### What change is being introduced by this PR?
- By replacing win.reload() calls with the calendar.redraw() you so politely included, there is no flash when reloading for changes.

#### How will this be tested?
- I can verify that it works as expected on osx, but beyond that I'm unable to visibly test that. I can confirm that it works, either way.

#### Notes:
- I suggest that you squash this before you merge. I have some strange git habits.