### PR TITLE
Fix jquery bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,9 @@
   <link rel="stylesheet" href="css/styles.css">
 
   <!-- Scripts -->
-  <script>
-    delete module.exports
-  </script>
-  <script>let $ = require('jquery');</script>
+  <!-- First we need to declare jQuery and $ globals with jquery -->
+  <script>window.$ = window.jQuery = require('jquery');</script>
+  <script src="node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
   <script src="js/calendar.js" charset="utf-8"></script>
 </head>
 

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -5,10 +5,9 @@
     <link rel="stylesheet" href="../css/themes.css">
     <link rel="stylesheet" href="preferences.css">
 
-    <script>
-        delete module.exports
-    </script>
-    <script>let $ = require('jquery');</script>
+    <!-- First we need to declare jQuery and $ globals with jquery -->
+    <script>window.$ = window.jQuery = require('jquery');</script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
     <script src="preferences.js"></script>
 </header>
 <body>

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -5,10 +5,9 @@
     <link rel="stylesheet" href="../css/themes.css">
     <link rel="stylesheet" href="workday-waiver.css">
 
-    <script>
-        delete module.exports
-    </script>
-    <script>let $ = require('jquery');</script>
+<!-- First we need to declare jQuery and $ globals with jquery -->
+<script>window.$ = window.jQuery = require('jquery');</script>
+  <script src="node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
     <script src="workday-waiver.js"></script>
 </header>
 <body>


### PR DESCRIPTION
#### Context / Background
- The current way of loading in jquery wasn't reliably making $ available, and now does.

#### What change is being introduced by this PR?
- Instead of deleting the modules before loading, and thus killing off node, I have explicitly set window.$ and window.jQuery, which are both looked for.

#### How will this be tested?
- The current test set will be used; though these sorts of changes are not yet tooled for.
