### PR TITLE
Add a check to make sure the app won't start up two instances

### DIFF
--- a/main.js
+++ b/main.js
@@ -393,8 +393,14 @@ function createWindow() {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow);
 app.on('ready', () => {
+    // Check first to see if the app is aleady running,
+    // fail out gracefully if so.
+    if (!app.requestSingleInstanceLock()) {
+        app.exit(0)
+    }
+
+    createWindow();
     setInterval(refreshOnDayChange, 60 * 60 * 1000);
     const { powerMonitor } = require('electron');
     powerMonitor.on('unlock-screen', () => { checkIdleAndNotify(); });

--- a/main.js
+++ b/main.js
@@ -393,13 +393,22 @@ function createWindow() {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', () => {
     // Check first to see if the app is aleady running,
     // fail out gracefully if so.
-    if (!app.requestSingleInstanceLock()) {
-        app.exit(0)
-    }
+if (!app.requestSingleInstanceLock()) {
+    app.exit(0);
+} else {
+    app.on('second-instance', () => {
+        // Someone tried to run a second instance, we should focus our window.
+        if (win) {
+            if (win.isMinimized()) {
+                win.restore();
+            }
+            win.focus();
+        } });
+}
 
+app.on('ready', () => {
     createWindow();
     setInterval(refreshOnDayChange, 60 * 60 * 1000);
     const { powerMonitor } = require('electron');


### PR DESCRIPTION
#### Context / Background
- Currently, if you start up the app twice over, it will run two instances. This will probably lead to corrupt data, and is almost definitely not what someone would want to be happening in this case.

#### What change is being introduced by this PR?
- How did you approach this problem?
I added a check for `app.requestSingleInstanceLock()` and exit silently if we don't have the lock.
- What changes did you make to achieve the goal?
A short line in app.on(ready) functions

#### How will this be tested?
- Attempt to run the app with it already running, and it will close silently.