### PR TITLE
use font family Montserrat, sans-serif as in the other two windows

### DIFF
--- a/src/preferences.css
+++ b/src/preferences.css
@@ -34,6 +34,7 @@ input {
 }
 
 .preferences {
+  font-family: 'Montserrat', sans-serif;
   padding-right: 10px;
   padding-left: 10px;
   width: 100%;


### PR DESCRIPTION
#### Context / Background
- Currently, the app appears like this:
![Screen Shot 2020-01-30 at 9 20 58 AM](https://user-images.githubusercontent.com/46304146/73474144-d2b1ed80-4342-11ea-8726-787b1dce5f4d.png)

#### What change is being introduced by this PR?
- I've added the same font-family for the preferences container as for the workday-waiver container.
- Also suggest that we move toward one css file for styling all windows.

#### How will this be tested?
- This is how it looks after:
![Screen Shot 2020-01-30 at 9 22 54 AM](https://user-images.githubusercontent.com/46304146/73474252-fd9c4180-4342-11ea-8c9d-0f5aedb6913f.png)
