### PR TITLE
Start on login

### DIFF
--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -15,6 +15,7 @@ const defaultPreferences = {
     'working-days-friday': true,
     'working-days-saturday': false,
     'working-days-sunday': false,
+    'start-at-login': false,
     'theme': 'light',
     'update-remind-me-after' : '2019-01-01',
 };
@@ -110,6 +111,13 @@ function initPreferencesFileIfNotExistsOrInvalid() {
             break;
         }
         case 'hide-non-working-days': {
+            if (value !== true && value !== false) {
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
+            }
+            break;
+        }
+        case 'start-at-login': {
             if (value !== true && value !== false) {
                 derivedPrefs[key] = defaultPreferences[key];
                 shouldSaveDerivedPrefs = true;

--- a/main.js
+++ b/main.js
@@ -10,7 +10,11 @@ const os = require('os');
 let savedPreferences = null;
 ipcMain.on('PREFERENCE_SAVE_DATA_NEEDED', (event, preferences) => {
     savedPreferences = preferences;
+    app.setLoginItemSettings({
+        openAtLogin: preferences['start-at-login']
+    });
 });
+
 ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) => {
     global.waiverDay = waiverDay;
 });

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -59,6 +59,13 @@
             </div>
         </div>
 
+        <div class="preference-title">Start on Login</div>
+        <div class="start-at-login-setting">
+            <div class="start-at-login-option">
+            <label id='start-at-login'><input type="checkbox" name="start-at-login" value="value">  Enable opening the app on start-up.</label>
+            </div>
+        </div>
+
         <div class="preference-title">Themes</div>
         <div class="theme-setting">
             <div class="theme-option">


### PR DESCRIPTION
#### Related issue
Fixes #179 

#### Context / Background
- This will allow checking a box to start the app on login.

#### What change is being introduced by this PR?
- I've essentially copied the method for applying the themes.

#### How will this be tested?
- Configuring the setting and then performing a login/logout on your system should either start it on login or no. This should also be tested within the preferences tests.

#### Known issue:
- The initial setting is false, but if you've just installed over a previous version it would be better if it were to get the value from  app.getLoginItemSettings(). This is essentially a visual glitch, which happens if you've changed settings outside of the app. If you've got ideas, please say!
