### PR TITLE
#28: Introducing import/export feature

### DIFF
--- a/js/import-export.js
+++ b/js/import-export.js
@@ -44,7 +44,7 @@ function getWaivedEntries() {
         const reason = entry[1]['reason'];
         const hours = entry[1]['hours'];
 
-        //The waived workday database human month index (1-12)
+        //The waived workday database uses human month index (1-12)
         output.push({'type': 'waived', 'date': date, 'data': reason, 'hours': hours});
     }
     return output;

--- a/js/import-export.js
+++ b/js/import-export.js
@@ -1,0 +1,61 @@
+const Store = require('electron-store');
+const fs = require('fs');
+
+const store = new Store();
+const waivedWorkdays = new Store({name: 'waived-workdays'});
+
+/**
+ * Returns the database (only regular entries) as a array of:
+ *   . type: regular
+ *   . date
+ *   . data: (day-begin, day-end, day-total, lunch-begin, lunch-end, lunch-total)
+ *   . hours
+ */
+function getRegularEntries() {
+    
+    var output = [];
+    for (const entry of store) {
+        const key = entry[0];
+        const value = entry[1];
+
+        var [year, month, day, stage, step] = key.split('-');
+        //The main database uses a JS-based month index (0-11)
+        //So we need to adjust it to human month index (1-12)
+        var date = year + '-' + (month + 1) + '-' + day;
+        var data = stage + '-' + step;
+
+        output.push({'type': 'regular', 'date': date, 'data': data, 'hours': value});
+    }
+    return output;
+}
+
+/**
+ * Returns the database (only waived workday entries) as a array of:
+ *   . type: waived
+ *   . date
+ *   . data: (reason)
+ *   . hours
+ */
+function getWaivedEntries() {
+    
+    var output = [];
+    for (const entry of waivedWorkdays) {
+        const date = entry[0];
+        const reason = entry[1]['reason'];
+        const hours = entry[1]['hours'];
+
+        //The waived workday database human month index (1-12)
+        output.push({'type': 'waived', 'date': date, 'data': reason, 'hours': hours});
+    }
+    return output;
+}
+
+function exportDatabaseToFile(filename) {
+    var information = getRegularEntries();
+    information = information.concat(getWaivedEntries());
+    fs.writeFileSync(filename, JSON.stringify(information, null,'\t'), 'utf-8');
+}
+
+module.exports = {
+    exportDatabaseToFile
+};

--- a/js/import-export.js
+++ b/js/import-export.js
@@ -56,6 +56,26 @@ function exportDatabaseToFile(filename) {
     fs.writeFileSync(filename, JSON.stringify(information, null,'\t'), 'utf-8');
 }
 
+function importDatabaseFromFile(filename) {
+    const information = JSON.parse(fs.readFileSync(filename[0], 'utf-8'));
+    for (var i = 0; i < information.length; ++i) {
+        var entry = information[i];
+        if (entry.type === 'waived') {
+            waivedWorkdays.set(entry.date, { 'reason' : entry.data, 'hours' : entry.hours });
+        } else if (entry.type === 'regular') {
+            var [year, month, day] = entry.date.split('-');
+            //The main database uses a JS-based month index (0-11)
+            //So we need to adjust it from human month index (1-12)
+            var date = year + '-' + (month - 1) + '-' + day;
+            var key = date + '-' + entry.data;
+            store.set(key, entry.hours);
+        } else {
+            //ERROR
+        }
+    }
+}
+
 module.exports = {
+    importDatabaseFromFile,
     exportDatabaseToFile
 };

--- a/main.js
+++ b/main.js
@@ -206,8 +206,8 @@ function createWindow() {
                             buttonLabel : 'Export',
                   
                             filters :[
-                              {name: '.ttldb', extensions: ['ttldb',]},
-                              {name: 'All Files', extensions: ['*']}
+                                { name: '.ttldb', extensions: ['ttldb',] },
+                                { name: 'All Files', extensions: ['*'] }
                             ]
                         };
                         let response = dialog.showSaveDialogSync(options);

--- a/main.js
+++ b/main.js
@@ -258,7 +258,8 @@ function createWindow() {
                                         type: 'info',
                                         icon: iconpath,
                                         detail: '\Yay! Import successful!'
-                                    });
+                                    }
+                                );
                             }
                         }
                     },

--- a/main.js
+++ b/main.js
@@ -231,7 +231,7 @@ function createWindow() {
                             title: 'Import DB from file',
                             buttonLabel : 'Import',
                   
-                            filters :[
+                            filters : [
                               {name: '.ttldb', extensions: ['ttldb',]},
                               {name: 'All Files', extensions: ['*']}
                             ]

--- a/main.js
+++ b/main.js
@@ -243,7 +243,7 @@ function createWindow() {
                                 buttons: ['Cancel', 'Yes, please', 'No, thanks'],
                                 defaultId: 2,
                                 title: 'Import database',
-                                message: 'Are you sure you want to import a database? It may override your information.',
+                                message: 'Are you sure you want to import a database? It will override any current information.',
                             };
     
                             let confirmation = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);

--- a/main.js
+++ b/main.js
@@ -212,6 +212,14 @@ function createWindow() {
                         let response = dialog.showSaveDialogSync(options);
                         if (response) {
                             exportDatabaseToFile(response);
+                            dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+                                {
+                                    title: 'Time to Leave',
+                                    message: 'Database export',
+                                    type: 'info',
+                                    icon: iconpath,
+                                    detail: '\Okay, database was exported.'
+                                });
                         }
                     },
                 },

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, dialog, ipcMain, Menu, net, shell, Tray } = require(
 const path = require('path');
 const Store = require('electron-store');
 const isOnline = require('is-online');
+const { exportDatabaseToFile } = require('./js/import-export.js');
 const { notify } = require('./js/notification');
 const { getDateStr } = require('./js/date-aux.js');
 const { savePreferences } = require('./js/user-preferences.js');
@@ -192,6 +193,24 @@ function createWindow() {
                             prefWindow = null;
                             savePreferences(savedPreferences);
                             win.webContents.send('PREFERENCE_SAVED', savedPreferences);
+                        });
+                    },
+                },
+                {
+                    label: 'Export database',
+                    click() {
+                        var options = {
+                            title: 'Export DB to file',
+                            defaultPath : 'time_to_leave',
+                            buttonLabel : 'Export',
+                  
+                            filters :[
+                              {name: '.ttldb', extensions: ['ttldb',]},
+                              {name: 'All Files', extensions: ['*']}
+                            ]
+                        };
+                        dialog.showSaveDialog( options, (filename) => {
+                            exportDatabaseToFile(filename);
                         });
                     },
                 },

--- a/main.js
+++ b/main.js
@@ -248,17 +248,18 @@ function createWindow() {
     
                             let confirmation = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);
                             if (confirmation === 1) {
-                                importDatabaseFromFile(response);
+                                if (importDatabaseFromFile(response)) {
+                                    dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+                                        {
+                                            title: 'Time to Leave',
+                                            message: 'Database imported',
+                                            type: 'info',
+                                            icon: iconpath,
+                                            detail: '\Yay! Import successful!'
+                                        });
+                                }
                                 // Reload only the calendar itself to avoid a flash
                                 win.webContents.executeJavaScript('calendar.redraw()');
-                                dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
-                                    {
-                                        title: 'Time to Leave',
-                                        message: 'Database imported',
-                                        type: 'info',
-                                        icon: iconpath,
-                                        detail: '\Yay! Import successful!'
-                                    });
                             }
                         }
                     },

--- a/main.js
+++ b/main.js
@@ -240,14 +240,14 @@ function createWindow() {
                         if (response) {
                             const options = {
                                 type: 'question',
-                                buttons: ['Cancel', 'Yes, please', 'No, thanks'],
+                                buttons: ['Yes, please', 'No, thanks'],
                                 defaultId: 2,
                                 title: 'Import database',
                                 message: 'Are you sure you want to import a database? It may override your information.',
                             };
     
                             let confirmation = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);
-                            if (confirmation === 1) {
+                            if (confirmation === /*Yes*/0) {
                                 if (importDatabaseFromFile(response)) {
                                     dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                         {

--- a/main.js
+++ b/main.js
@@ -196,6 +196,7 @@ function createWindow() {
                         });
                     },
                 },
+                {type: 'separator'},
                 {
                     label: 'Export database',
                     click() {

--- a/main.js
+++ b/main.js
@@ -205,7 +205,7 @@ function createWindow() {
                             defaultPath : 'time_to_leave',
                             buttonLabel : 'Export',
                   
-                            filters :[
+                            filters : [
                               {name: '.ttldb', extensions: ['ttldb',]},
                               {name: 'All Files', extensions: ['*']}
                             ]

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ const { app, BrowserWindow, dialog, ipcMain, Menu, net, shell, Tray } = require(
 const path = require('path');
 const Store = require('electron-store');
 const isOnline = require('is-online');
-const { exportDatabaseToFile } = require('./js/import-export.js');
+const { importDatabaseFromFile, exportDatabaseToFile } = require('./js/import-export.js');
 const { notify } = require('./js/notification');
 const { getDateStr } = require('./js/date-aux.js');
 const { savePreferences } = require('./js/user-preferences.js');
@@ -212,6 +212,45 @@ function createWindow() {
                         let response = dialog.showSaveDialogSync(options);
                         if (response) {
                             exportDatabaseToFile(response);
+                        }
+                    },
+                },
+                {
+                    label: 'Import database',
+                    click() {
+                        var options = {
+                            title: 'Import DB from file',
+                            buttonLabel : 'Import',
+                  
+                            filters :[
+                              {name: '.ttldb', extensions: ['ttldb',]},
+                              {name: 'All Files', extensions: ['*']}
+                            ]
+                        };
+                        let response = dialog.showOpenDialogSync(options);
+                        if (response) {
+                            const options = {
+                                type: 'question',
+                                buttons: ['Cancel', 'Yes, please', 'No, thanks'],
+                                defaultId: 2,
+                                title: 'Import database',
+                                message: 'Are you sure you want to import a database? It may override your information.',
+                            };
+    
+                            let confirmation = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);
+                            if (confirmation === 1) {
+                                importDatabaseFromFile(response);
+                                // Reload only the calendar itself to avoid a flash
+                                win.webContents.executeJavaScript('calendar.redraw()');
+                                dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+                                    {
+                                        title: 'Time to Leave',
+                                        message: 'Database imported',
+                                        type: 'info',
+                                        icon: iconpath,
+                                        detail: '\Yay! Import successful!'
+                                    });
+                            }
                         }
                     },
                 },

--- a/main.js
+++ b/main.js
@@ -209,9 +209,10 @@ function createWindow() {
                               {name: 'All Files', extensions: ['*']}
                             ]
                         };
-                        dialog.showSaveDialog( options, (filename) => {
-                            exportDatabaseToFile(filename);
-                        });
+                        let response = dialog.showSaveDialogSync(options);
+                        if (response) {
+                            exportDatabaseToFile(response);
+                        }
                     },
                 },
                 {


### PR DESCRIPTION
#### Related issue
[#28](https://github.com/thamara/time-to-leave/issues/#28)

#### Context / Background
Introducing the ability of exporting and importing a database.

#### What change is being introduced by this PR?
- User can now go into the Edit menu and find Import/Export options:
![Screen Shot 2020-02-11 at 00 44 06](https://user-images.githubusercontent.com/846063/74209708-af067580-4c67-11ea-983a-d8b5b95ce5a1.png)

On export, a JSON file is created that looks like:
![Screen Shot 2020-02-11 at 00 45 30](https://user-images.githubusercontent.com/846063/74209752-d5c4ac00-4c67-11ea-943d-ea0e9bd79618.png)

This same file can be loaded into TTL again (using import), and the data on it is redirected to the app's database.

#### How will this be tested?
- Manual tests so far. Once the infra for the unit tests is done I can add more complete tests.
