### PR TITLE
Revamp preferences window (#186)

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -15,6 +15,11 @@ html, html[data-theme="light"] {
   --punch-bground: var(--table-total-border);
   --punch-color: black;
   --punch-disable-bground: rgb(134, 134, 134);
+  --slider-background-color: rgb(220, 220, 220);
+  --slider-checked-color: var(--table-total-border);
+  --slider-unchecked-color: white;
+  --weekday-background: var(--slider-background-color);
+  --weekday-selected: var(--punch-bground);
   --svg-invert: 0;
 }
 
@@ -34,5 +39,10 @@ html[data-theme="dark"] {
   --punch-bground: rgb(164, 158, 207);
   --punch-color: white;
   --punch-disable-bground: rgb(134, 134, 134);
+  --slider-background-color: var(--table-cell-offtime-bground);
+  --slider-checked-color: var(--punch-bground);
+  --slider-unchecked-color: white;
+  --weekday-background: var(--slider-background-color);
+  --weekday-selected: var(--punch-bground);
   --svg-invert: 1;
 }

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -7,7 +7,7 @@ const { isValidTheme } = require('./themes.js');
 const defaultPreferences = {
     'hide-non-working-days': false,
     'hours-per-day': '08:00',
-    'notification': 'enabled',
+    'notification': true,
     'working-days-monday': true,
     'working-days-tuesday': true,
     'working-days-wednesday': true,
@@ -91,7 +91,7 @@ function initPreferencesFileIfNotExistsOrInvalid() {
             break;
         }
         case 'notification': {
-            if (value !== 'enabled' && value !== 'disabled') {
+            if (value !== true && value !== false) {
                 derivedPrefs[key] = defaultPreferences[key];
                 shouldSaveDerivedPrefs = true;
             }

--- a/main.js
+++ b/main.js
@@ -181,8 +181,8 @@ function createWindow() {
                     accelerator: macOS ? 'Command+,' : 'Control+,',
                     click() {
                         const htmlPath = path.join('file://', __dirname, 'src/preferences.html');
-                        let prefWindow = new BrowserWindow({ width: 600,
-                            height: 600,
+                        let prefWindow = new BrowserWindow({ width: 400,
+                            height: 400,
                             parent: win,
                             resizable: true,
                             icon: iconpath,
@@ -208,7 +208,7 @@ function createWindow() {
                             title: 'Export DB to file',
                             defaultPath : 'time_to_leave',
                             buttonLabel : 'Export',
-                  
+
                             filters : [
                                 { name: '.ttldb', extensions: ['ttldb',] },
                                 { name: 'All Files', extensions: ['*'] }
@@ -234,7 +234,7 @@ function createWindow() {
                         var options = {
                             title: 'Import DB from file',
                             buttonLabel : 'Import',
-                  
+
                             filters : [
                               {name: '.ttldb', extensions: ['ttldb',]},
                               {name: 'All Files', extensions: ['*']}
@@ -249,7 +249,7 @@ function createWindow() {
                                 title: 'Import database',
                                 message: 'Are you sure you want to import a database? It will override any current information.',
                             };
-    
+
                             let confirmation = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);
                             if (confirmation === /*Yes*/0) {
                                 if (importDatabaseFromFile(response)) {

--- a/src/preferences.css
+++ b/src/preferences.css
@@ -17,22 +17,6 @@ body {
   color: var(--page-color);
 }
 
-.preferences-page {
-  font-size: 25px;
-  height: 60px;
-  border-bottom: 4px solid var(--table-total-border);
-}
-
-.header-help {
-  font-variant-caps: all-petite-caps;
-  font-size: 15px;
-}
-
-input {
-  color: var(--page-color);
-  border: none;
-}
-
 .preferences {
   font-family: 'Montserrat', sans-serif;
   padding-right: 10px;
@@ -41,50 +25,118 @@ input {
   height: 90%;
 }
 
-.notification-setting,
-.theme-setting,
-.notification-option,
-.theme-option {
-  display: flex;
-  line-height: 30px;
+.preferences-page {
+  font-size: 25px;
+  height: 35px;
+  border-bottom: 4px solid var(--table-total-border);
 }
 
 .preference-title {
   font-size: 20px;
   color: var(--title-color);
-  margin-bottom: 15px;
-  margin-top: 30px;
+  margin-bottom: 5px;
+  margin-top: 15px;
   border-bottom: 1px solid var(--table-total-border);
 }
 
-.working-days {
-  font-family: 'Montserrat', sans-serif;
+select, option, input {
+  font-variant-caps: all-petite-caps;
+  color: var(--page-color);
+  background-color: var(--page-bground);
+  border: solid 1px var(--input-border);
+  height: inherit;
+}
+
+.weekDays-selector input {
+  display: none;
+}
+
+.weekDays-selector input[type=checkbox] + label {
+  font-variant-caps: all-petite-caps;
+  display: inline-block;
+  border-radius: 10px;
+  background: var(--weekday-background);
+  height: 40px;
+  width: 45px;
+  margin-right: 3px;
+  line-height: 40px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.weekDays-selector input[type=checkbox]:checked + label {
+  background: var(--weekday-selected);
+  color: #fff;
+}
+
+.flex-box {
+  display: flex;
+  height: 25px;
+  justify-content: space-between;
+}
+
+p {
+  font-variant-caps: all-petite-caps;
   text-align: center;
 }
 
-td {
-  padding-right: 5px;
-  padding-left: 5px;
-  font-variant-caps: all-petite-caps;
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 15px;
 }
 
-#non-working-label {
-  display: block;
-  font-weight: normal;
-  text-align: left;
-  margin: 40px 0px 0px 8px;
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
-select, option, input {
-  color: var(--page-color);
-  background-color: var(--page-bground);
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--slider-background-color);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
 }
 
-select, input {
-  color: var(--page-color);
-  border: solid 1px var(--input-border);
+.slider::before {
+  position: absolute;
+  content: "";
+  height: 15px;
+  width: 15px;
+  background-color: var(--slider-unchecked-color);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
 }
 
-#non-working-label input {
-  margin-right: 8px;
+input:checked + .slider {
+  background-color: var(--slider-checked-color);
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px var(--slider-checked-color);
+}
+
+input:checked + .slider::before {
+  -webkit-transform: translateX(15px);
+  -ms-transform: translateX(15px);
+  transform: translateX(15px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 30px;
+}
+
+.slider.round::before {
+  border-radius: 50%;
 }

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -14,62 +14,45 @@
     <div class="preferences">
         <div class="preferences-page">
             User preferences
-            <p class="header-help">Preferences are saved automatically when closing this window</p>
         </div>
 
         <div class="preference-title">Working days</div>
-        <div class="working-days">
-            <table>
-                <tbody>
-                <tr>
-                    <td><label for="sunday">Sunday</label></td>
-                    <td><label for="monday">Monday</label></td>
-                    <td><label for="tuesday">Tuesday</label></td>
-                    <td><label for="wednesday">Wednesday</label></td>
-                    <td><label for="thursday">Thursday</label></td>
-                    <td><label for="friday">Friday</label></td>
-                    <td><label for="saturday">Saturday</label></td>
-
-                <tr style="text-align: center;">
-                    <td><input type="checkbox" id="sunday" name="working-days-sunday"></td>
-                    <td><input type="checkbox" id="monday" name="working-days-monday" checked></td>
-                    <td><input type="checkbox" id="tuesday" name="working-days-tuesday" checked></td>
-                    <td><input type="checkbox" id="wednesday" name="working-days-wednesday" checked></td>
-                    <td><input type="checkbox" id="thursday" name="working-days-thursday" checked></td>
-                    <td><input type="checkbox" id="friday" name="working-days-friday" checked></td>
-                    <td><input type="checkbox" id="saturday" name="working-days-saturday"></td>
-                </tr>
-                </tbody>
-            </table>
-            <label id='non-working-label'><input type="checkbox" name="hide-non-working-days" value="value">Hide non-working days</label>
+        <div class="weekDays-selector">
+            <input type="checkbox" id="sunday" name="working-days-sunday" class="weekday"/>
+            <label for="sunday">Sun</label>
+            <input type="checkbox" id="monday" name="working-days-monday" class="weekday"/>
+            <label for="monday">Mon</label>
+            <input type="checkbox" id="tuesday" name="working-days-tuesday" class="weekday"/>
+            <label for="tuesday">Tue</label>
+            <input type="checkbox" id="wednesday" name="working-days-wednesday" class="weekday"/>
+            <label for="wednesday">Wed</label>
+            <input type="checkbox" id="thursday" name="working-days-thursday" class="weekday"/>
+            <label for="thursday">Thu</label>
+            <input type="checkbox" id="friday" name="working-days-friday" class="weekday"/>
+            <label for="friday">Fri</label>
+            <input type="checkbox" id="saturday" name="working-days-saturday" class="weekday"/>
+            <label for="saturday">Sat</label>
         </div>
-
-        <div class="preference-title">Hours per day</div>
-        <div class="hours-per-day">
+        <div class="flex-box">
+            <p>Hide non-working days</p>
+            <label id='non-working-label' class="switch"><input type="checkbox" name="hide-non-working-days"><span class="slider round"></span></label>
+        </div>
+        <div class="flex-box">
+            <p>Hours per day</p>
             <input type="time" name="hours-per-day" id="hours-per-day" min="00:00" max="24:00" value="08:00" required>
         </div>
-
-        <div class="preference-title">Notification</div>
-        <div class="notification-setting">
-            <div class="notification-option">
-                <select id="notification" name="notification">
-                    <option value="enabled" selected>Notification enabled</option>
-                    <option value="disabled">Notification disabled</option>
-                </select>
+        <div class="preference-title">App Behavior</div>
+            <div class="flex-box">
+                <p>Notifications</p>
+                <label id="notification" class="switch"><input type="checkbox" name="notification"><span class="slider round"></span></label>
             </div>
-        </div>
-
-        <div class="preference-title">Start on Login</div>
-        <div class="start-at-login-setting">
-            <div class="start-at-login-option">
-            <label id='start-at-login'><input type="checkbox" name="start-at-login" value="value">  Enable opening the app on start-up.</label>
+            <div class="flex-box">
+                <p>Start on Login</p>
+                <label id='start-at-login' class="switch"><input type="checkbox" name="start-at-login"><span class="slider round"></span></label>
             </div>
-        </div>
-
-        <div class="preference-title">Themes</div>
-        <div class="theme-setting">
-            <div class="theme-option">
-                <select id="theme" name="notification">
+            <div class="flex-box">
+                <p>Themes</p>
+                <select id="theme" name="theme">
                     <option value="light" selected>Light</option>
                     <option value="dark">Dark</option>
                 </select>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -28,11 +28,6 @@ $(() => {
         ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
     });
 
-    $('#notification').change(function() {
-        preferences['notification'] = this.value;
-        ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
-    });
-
     $('#theme').change(function() {
         preferences['theme'] = this.value;
         ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
@@ -53,10 +48,4 @@ $(() => {
             preferences[input.name] = input.value;
         }
     }
-
-    let notification = 'notification';
-    if (notification in usersStyles) {
-        $('#' + notification).val(usersStyles[notification]);
-    }
-    preferences[notification] = $('#' + notification).children('option:selected').val();
 });


### PR DESCRIPTION
#### Related issue
Closes #186 

#### Context / Background
The preferences page was getting too big and cluttered, so we'd better revamp it to make better use of the space.

#### What change is being introduced by this PR?
- Preferences name and selector are now inline in most of the cases
- Grouped similar preferences under same title, instead of one title per preference
- Added sliders instead of checkboxes, to be prettier

#### How will this be tested?
- The behavior itself shouldn't change, just the visualization, as the elements underneath are mostly the same.

#### How it looked
![image](https://user-images.githubusercontent.com/6443427/74426041-68fe0d00-4e33-11ea-97a5-43b6ee6bf731.png)

#### How it looks
I did this quick version where I kept using table, so the layout is still a bit bad, ideally the texts will always align left and the input options right. The only difference would be the day selection, I don't know the best way to lay it out. If you have tips on how to do these fine adjustments, let me know!
![image](https://user-images.githubusercontent.com/6443427/74425847-1de3fa00-4e33-11ea-8a41-4adfac09d622.png)
