### PR TITLE
Allow Close to Tray to be configurable

### DIFF
--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -84,6 +84,7 @@ function initPreferencesFileIfNotExistsOrInvalid() {
     for (var key of derivedPrefsKeys) {
         var value = derivedPrefs[key];
         switch (key) {
+        // Handle Time Inputs
         case 'hours-per-day': {
             if (!validateTime(value)) {
                 derivedPrefs[key] = defaultPreferences[key];
@@ -91,13 +92,11 @@ function initPreferencesFileIfNotExistsOrInvalid() {
             }
             break;
         }
-        case 'notification': {
-            if (value !== true && value !== false) {
-                derivedPrefs[key] = defaultPreferences[key];
-                shouldSaveDerivedPrefs = true;
-            }
-            break;
-        }
+        // Handle Boolean Inputs
+        case 'close-to-tray':
+        case 'hide-non-working-days':
+        case 'notification':
+        case 'start-at-login':
         case 'working-days-monday':
         case 'working-days-tuesday':
         case 'working-days-wednesday':
@@ -111,27 +110,7 @@ function initPreferencesFileIfNotExistsOrInvalid() {
             }
             break;
         }
-        case 'hide-non-working-days': {
-            if (value !== true && value !== false) {
-                derivedPrefs[key] = defaultPreferences[key];
-                shouldSaveDerivedPrefs = true;
-            }
-            break;
-        }
-        case 'start-at-login': {
-            if (value !== true && value !== false) {
-                derivedPrefs[key] = defaultPreferences[key];
-                shouldSaveDerivedPrefs = true;
-            }
-            break;
-        }
-        case 'close-to-tray': {
-            if (value !== true && value !== false) {
-                derivedPrefs[key] = defaultPreferences[key];
-                shouldSaveDerivedPrefs = true;
-            }
-            break;
-        }
+        // Handle Enum Inputs
         case 'theme' : {
             shouldSaveDerivedPrefs |= !isValidTheme(value);
         }

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -9,6 +9,9 @@ const defaultPreferences = {
     'hide-non-working-days': false,
     'hours-per-day': '08:00',
     'notification': true,
+    'start-at-login': false,
+    'theme': 'light',
+    'update-remind-me-after' : '2019-01-01',
     'working-days-monday': true,
     'working-days-tuesday': true,
     'working-days-wednesday': true,
@@ -16,9 +19,6 @@ const defaultPreferences = {
     'working-days-friday': true,
     'working-days-saturday': false,
     'working-days-sunday': false,
-    'start-at-login': false,
-    'theme': 'light',
-    'update-remind-me-after' : '2019-01-01',
 };
 
 /*

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -5,6 +5,7 @@ const { validateTime } = require('./time-math.js');
 const { isValidTheme } = require('./themes.js');
 
 const defaultPreferences = {
+    'close-to-tray': true,
     'hide-non-working-days': false,
     'hours-per-day': '08:00',
     'notification': true,
@@ -118,6 +119,13 @@ function initPreferencesFileIfNotExistsOrInvalid() {
             break;
         }
         case 'start-at-login': {
+            if (value !== true && value !== false) {
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
+            }
+            break;
+        }
+        case 'close-to-tray': {
             if (value !== true && value !== false) {
                 derivedPrefs[key] = defaultPreferences[key];
                 shouldSaveDerivedPrefs = true;

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ const isOnline = require('is-online');
 const { importDatabaseFromFile, exportDatabaseToFile } = require('./js/import-export.js');
 const { notify } = require('./js/notification');
 const { getDateStr } = require('./js/date-aux.js');
-const { savePreferences } = require('./js/user-preferences.js');
+const { getUserPreferences, savePreferences } = require('./js/user-preferences.js');
 const os = require('os');
 
 let savedPreferences = null;
@@ -461,7 +461,8 @@ function createWindow() {
 
     // Emitted when the window is closed.
     win.on('close', function(event) {
-        if (!app.isQuitting) {
+        savedPreferences = getUserPreferences();
+        if (!app.isQuitting && savedPreferences['close-to-tray']) {
             event.preventDefault();
             win.hide();
         }

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -51,6 +51,10 @@
                 <label id='start-at-login' class="switch"><input type="checkbox" name="start-at-login"><span class="slider round"></span></label>
             </div>
             <div class="flex-box">
+                <p>Close button should minimize to tray</p>
+                <label id='close-to-tray' class="switch"><input type="checkbox" name="close-to-tray"><span class="slider round"></span></label>
+            </div>
+            <div class="flex-box">
                 <p>Themes</p>
                 <select id="theme" name="theme">
                     <option value="light" selected>Light</option>


### PR DESCRIPTION
#### Related issue
Closes #180 

#### Context / Background
Not everyone wants to have the app minimize when clicking the X button.

#### What change is being introduced by this PR?
- There is now an option to configure whether X closes or minimizes the app. It defaults to "minimize", to keep compatibility with old behavior.

On separate commits, I:
- Simplified validation of boolean logic on preferences
- Sorted the default preferences, somewhat. I didn't touch the order of the working days, because they seem more intuitive the way they are.

#### How will this be tested?
- I closed the app with the setting on and off and validated that it works.

#### Screenshot
![image](https://user-images.githubusercontent.com/6443427/74605302-a964c180-50a5-11ea-89d9-121baa983522.png)

