### PR TITLE
Only show one database import successful message

### DIFF
--- a/main.js
+++ b/main.js
@@ -253,6 +253,8 @@ function createWindow() {
                             let confirmation = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);
                             if (confirmation === /*Yes*/0) {
                                 if (importDatabaseFromFile(response)) {
+                                    // Reload only the calendar itself to avoid a flash
+                                    win.webContents.executeJavaScript('calendar.redraw()');
                                     dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                         {
                                             title: 'Time to Leave',
@@ -262,17 +264,6 @@ function createWindow() {
                                             detail: '\Yay! Import successful!'
                                         });
                                 }
-                                // Reload only the calendar itself to avoid a flash
-                                win.webContents.executeJavaScript('calendar.redraw()');
-                                dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
-                                    {
-                                        title: 'Time to Leave',
-                                        message: 'Database imported',
-                                        type: 'info',
-                                        icon: iconpath,
-                                        detail: '\Yay! Import successful!'
-                                    }
-                                );
                             }
                         }
                     },


### PR DESCRIPTION
When importing a database, only show one successful message.

<img width="721" alt="Screen Shot 2020-02-26 at 20 25 26" src="https://user-images.githubusercontent.com/846063/75397781-7eb10f00-58d6-11ea-80db-4468f62c18a2.png">
