### PR TITLE
Moving isQuitting config to event before-quit

### DIFF
--- a/main.js
+++ b/main.js
@@ -146,7 +146,6 @@ function createWindow() {
                     label:'Exit',
                     accelerator: macOS ? 'CommandOrControl+Q' : 'Control+Q',
                     click() {
-                        app.isQuitting = true;
                         app.quit();
                     }
                 }
@@ -422,8 +421,6 @@ function createWindow() {
         },
         {
             label: 'Quit', click: function() {
-                app.isQuitting = true;
-                win = null;
                 app.quit();
             }
         }
@@ -490,9 +487,14 @@ app.on('ready', () => {
     powerMonitor.on('resume', () => { checkIdleAndNotify(); });
 });
 
+// Emitted before the application starts closing its windows.
+// It's not emitted when closing the windows
+app.on('before-quit', () => {
+    app.isQuitting = true;
+});
+
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
-    app.isQuitting = true;
     app.quit();
 });
 


### PR DESCRIPTION
#### Related issue
[#193](https://github.com/thamara/time-to-leave/issues/#192)

In here I'm moving the isQuitting config to a event called before-quit, which seem to be what we want. To summarize, here is the behavior of TTL considering the multiple options of quitting the app with this PR:

| Action  | Close to tray enabled | Close to tray disabled |
| ------------- | ------------- | ------------- |
| Click [X]  | Continues running minimized  |  Closes app  |
| App menu (Cmd + Q)  | Closes app  |  Closes app  |
| Quit from the tray  | Closes app  |  Closes app |
| Quit from the dock  | Closes app  |  Closes app  |

This need testing on Windows, but I'm confident it will work as well.