### PR TITLE
Expect vX.X.X tags instead of v.X.X.X

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - ci/*
     tags:
-      - latest/v.*
-      - stable/v.*
+      - latest/v*
+      - stable/v*
 
 jobs:
 


### PR DESCRIPTION
All of our versions have been in the format `vX.X.X` so we might just as well use it in the CI