### PR TITLE
Set preference window size to 460px

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ ipcMain.on('PREFERENCE_SAVE_DATA_NEEDED', (event, preferences) => {
 });
 
 ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) => {
+    /*eslint-disable no-undef*/
     if (!isNan(waiverDay))
     {
         global.waiverDay = waiverDay;  
@@ -185,7 +186,7 @@ function createWindow() {
                     click() {
                         const htmlPath = path.join('file://', __dirname, 'src/preferences.html');
                         let prefWindow = new BrowserWindow({ width: 400,
-                            height: 448,
+                            height: 460,
                             parent: win,
                             resizable: true,
                             icon: iconpath,


### PR DESCRIPTION
#### Related issue
#211

#### Context / Background
- Width is a tiny bit smaller than it should, which makes the "working days" row become two

#### What change is being introduced by this PR?
- I have changed the height to 460. In a future feature, let's consider dynamically handling this somehow.
- Changed the height of preferenceWindow
- incidental: please eslint - /*eslint-disable no-undef*/

#### How will this be tested?
- Increase the width a bit to not create two rows, tested visually
