### PR TITLE
add check for preferences['count-today'] after checking for current date

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -278,7 +278,7 @@ class Calendar {
                 continue;
             }
             var isToday = (now.getDate() === day && now.getMonth() === this.month && now.getFullYear() === this.year);
-            if (isToday) {
+            if (isToday && !!preferences['count-today']) {
                 //balance considers only up until yesterday
                 break;
             }


### PR DESCRIPTION
#### Related issue
#210 

#### Context / Background
- Currently, there is a bug wherein the count-today preference is not respected, as if always on.

#### What change is being introduced by this PR?
- Add check for preferences['count-today'] after checking for current date.

#### How will this be tested?
1. Log all the hours in the current day
1. Notice the total changing, but not the balance
1. Toggle it off/on
1. Close preference window
1. See that it changes
