### PR TITLE
Fix #209: Click on punch button adds multiple entries

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -204,27 +204,27 @@ class Calendar {
         }
 
         this.updateLeaveBy();
-        $('input[type=\'time\']').on('input propertychange', function() {
+        $('input[type=\'time\']').off('input propertychange').on('input propertychange', function() {
             updateTimeDayCallback(this.id, this.value);
         });
 
-        $('#punch-button').on('click', function() {
+        $('#punch-button').off('click').on('click', function() {
             punchDate();
         });
 
-        $('#next-month').on('click', function() {
+        $('#next-month').off('click').on('click', function() {
             nextMonth();
         });
 
-        $('#prev-month').on('click', function() {
+        $('#prev-month').off('click').on('click', function() {
             prevMonth();
         });
 
-        $('#current-month').on('click', function() {
+        $('#current-month').off('click').on('click', function() {
             goToCurrentDate();
         });
 
-        $('.waiver-trigger').on('click', function() {
+        $('.waiver-trigger').off('click').on('click', function() {
             const dayId = $(this).closest('tr').attr('id').substr(3);
             const waiverDay = formatDayId(dayId);
             sendWaiverDay(waiverDay);


### PR DESCRIPTION
#### Related issue
#209 

#### Context / Background
Every time you did any one action that triggered the calendar to be refreshed, it called the `initCalendar()` function and registered all callbacks again.

#### What change is being introduced by this PR?
I'm turning off any callbacks before turning them on again. It's not pretty, but the ultimate solution is to split off the `init` method to not do everything that it currently does to avoid registering the callbacks on all redraws, which is a bit more lengthy.

#### How will this be tested?
My manual tests worked: punching from start and getting only 1 entry in, then opening preferences or workday waiver manager and punching, making sure just one entry gets added also.