### PR TITLE
Fix #27: Adding day balance on when to leave bar after day is done

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -232,3 +232,7 @@ html[data-theme="dark"] .text-danger {
 .waiver-trigger:hover + .day > .waiver-img {
   display: block;
 }
+
+.hidden {
+  display: none;
+}

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -397,9 +397,26 @@ class Calendar {
             //All entries computed
             document.getElementById('punch-button').disabled = true;
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
+
+            var dayTotal = document.getElementById(dayKey + 'day-total').value;
+            if (dayTotal) {
+                var dayBalance = subtractTime(getHoursPerDay(), dayTotal);
+                var leaveDayBalanceElement = document.getElementById('leave-day-balance');
+                leaveDayBalanceElement.value = dayBalance;
+                leaveDayBalanceElement.classList.remove('text-success', 'text-danger');
+                leaveDayBalanceElement.classList.add(isNegative(dayBalance) ? 'text-danger' : 'text-success');
+                document.getElementById('summary-unfinished-day').classList.add('hidden');
+                document.getElementById('summary-finished-day').classList.remove('hidden');
+            } else {
+                document.getElementById('summary-unfinished-day').classList.remove('hidden');
+                document.getElementById('summary-finished-day').classList.add('hidden');
+            }
         } else {
             document.getElementById('punch-button').disabled = false;
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
+
+            document.getElementById('summary-unfinished-day').classList.remove('hidden');
+            document.getElementById('summary-finished-day').classList.add('hidden');
         }
     }
 
@@ -440,10 +457,16 @@ class Calendar {
     static _getSummaryRowCode() {
         var leaveByCode = '<input type="text" id="leave-by" size="5" disabled>';
         var summaryStr = 'Based on the time you arrived today, you should leave by';
-        var code = '<tr class="summary">' +
+        var code = '<tr class="summary" id="summary-unfinished-day">' +
                      '<td class="leave-by-text" colspan="7">' + summaryStr + '</td>' +
                      '<td class="leave-by-time">' + leaveByCode + '</td>' +
                    '</tr>';
+        var finishedSummaryStr = 'All done for today. Balance of the day:';
+        var dayBalance = '<input type="text" id="leave-day-balance" size="5" disabled>';
+        code += '<tr class="summary hidden" id="summary-finished-day">' +
+                    '<td class="leave-by-text" colspan="7">' + finishedSummaryStr + '</td>' +
+                    '<td class="leave-by-time">' + dayBalance + '</td>' +
+                '</tr>';
         return code;
     }
     

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -461,7 +461,7 @@ class Calendar {
                      '<td class="leave-by-text" colspan="7">' + summaryStr + '</td>' +
                      '<td class="leave-by-time">' + leaveByCode + '</td>' +
                    '</tr>';
-        var finishedSummaryStr = 'All done for today. Balance of the day:';
+        var finishedSummaryStr = 'All done for today. The balance for today is:';
         var dayBalance = '<input type="text" id="leave-day-balance" size="5" disabled>';
         code += '<tr class="summary hidden" id="summary-finished-day">' +
                     '<td class="leave-by-text" colspan="7">' + finishedSummaryStr + '</td>' +


### PR DESCRIPTION
#### Related issue
#27: Behavior of when to leave bar

#### Context / Background
- When all the fields are filled for the day, the "When to leave bar" starts to instead display a day balance and a message that the day is done for.

#### What change is being introduced by this PR?
- How did you approach this problem?
Added the new behavior on the function that updates the value of the "when to leave bar".
There is now a new hidden div on the bar, and they get switched out when the day is done.

- What changes did you make to achieve the goal?
Changes in existing function to update value of "when to leave bar", new style for hidden divs.

- What are the indirect and direct consequences of the change?
People will get a clearer message after the day is done for, and be able to know their day balance.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?
Fill up my day and see if it works :)

Sample of how it'll be:
![image](https://user-images.githubusercontent.com/37311270/81456495-d981a500-9168-11ea-93b7-5fadcca3fc66.png)
