### PR TITLE
Changing DOM manipulation to always use jQuery

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -113,23 +113,23 @@ function punchDate() {
 
     var dayStr = year + '-' + month + '-' + day + '-';
     var entry = '';
-    if (document.getElementById(dayStr + 'day-end').value === '') {
+    if ($('#' + dayStr + 'day-end').val() === '') {
         entry = 'day-end';
     }
-    if (document.getElementById(dayStr + 'lunch-end').value === '') {
+    if ($('#' + dayStr + 'lunch-end').val() === '') {
         entry = 'lunch-end';
     }
-    if (document.getElementById(dayStr + 'lunch-begin').value === '') {
+    if ($('#' + dayStr + 'lunch-begin').val() === '') {
         entry = 'lunch-begin';
     }
-    if (document.getElementById(dayStr + 'day-begin').value === '') {
+    if ($('#' + dayStr + 'day-begin').val() === '') {
         entry = 'day-begin';
     }
     if (entry.length <= 0) {
         return;
     }
     var value = hourMinToHourFormated(hour, min);
-    document.getElementById(dayStr + entry).value = value;
+    $('#' + dayStr + entry).val(value);
     updateTimeDayCallback(dayStr + entry, value);
 }
 
@@ -196,10 +196,10 @@ class Calendar {
         this.updateBasedOnDB();
 
         if (!showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate())) {
-            document.getElementById('punch-button').disabled = true;
+            $('#punch-button').prop('disabled', true);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         } else {
-            document.getElementById('punch-button').disabled = false;
+            $('#punch-button').prop('disabled', false);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
         }
 
@@ -262,7 +262,7 @@ class Calendar {
         if (store.has(key)) {
             value = store.get(key);
         }
-        document.getElementById(key).value = value;
+        $('#' + key).val(value);
         return value;
     }
 
@@ -284,7 +284,7 @@ class Calendar {
             }
 
             var dayStr = this.year + '-' + this.month + '-' + day + '-' + 'day-total';
-            var dayTotal = document.getElementById(dayStr).value;
+            var dayTotal = $('#' + dayStr).val();
             if (dayTotal) {
                 countDays = true;
                 monthTotalWorked = sumTime(monthTotalWorked, dayTotal);
@@ -295,12 +295,12 @@ class Calendar {
         }
         var monthTotalToWork = multiplyTime(getHoursPerDay(), workingDaysToCompute * -1);
         var balance = sumTime(monthTotalToWork, monthTotalWorked);
-        var balanceElement = document.getElementById('month-balance');
+        var balanceElement = $('#month-balance');
         if (balanceElement)
         {
-            balanceElement.value = balance;
-            balanceElement.classList.remove('text-success', 'text-danger');
-            balanceElement.classList.add(isNegative(balance) ? 'text-danger' : 'text-success');
+            balanceElement.val(balance);
+            balanceElement.removeClass('text-success text-danger');
+            balanceElement.addClass(isNegative(balance) ? 'text-danger' : 'text-success');
         }
     }
 
@@ -326,7 +326,7 @@ class Calendar {
             if (waivedWorkdays.has(dateStr)) {
                 var waivedInfo = waivedWorkdays.get(dateStr);
                 var waivedDayTotal = waivedInfo['hours'];
-                document.getElementById(dayStr + 'day-total').value = waivedDayTotal;
+                $('#' + dayStr + 'day-total').val(waivedDayTotal);
                 dayTotal = waivedDayTotal;
             } else {
                 var lunchBegin = this._setData(dayStr + 'lunch-begin');
@@ -350,20 +350,20 @@ class Calendar {
 
             this.workingDays += 1;
         }
-        var monthDayInput = document.getElementById('month-day-input');
+        var monthDayInput = $('#month-day-input');
         if (monthDayInput)
         {
-            monthDayInput.value = this._getBalanceRowPosition();
+            monthDayInput.val(this._getBalanceRowPosition());
         }
-        var monthDayTotal = document.getElementById('month-total');
+        var monthDayTotal = $('#month-total');
         if (monthDayTotal)
         {
-            monthDayTotal.value = monthTotal;
+            monthDayTotal.val(monthTotal);
         }
-        var monthWorkingDays = document.getElementById('month-working-days');
+        var monthWorkingDays = $('#month-working-days');
         if (monthWorkingDays)
         {
-            monthWorkingDays.value = this.workingDays;
+            monthWorkingDays.val(this.workingDays);
         }
         this.updateBalance();
 
@@ -384,39 +384,39 @@ class Calendar {
         var dayKey = this.today.getFullYear() + '-' + this.today.getMonth() + '-' + this.today.getDate() + '-';
         if (validateTime(dayBegin)) {
             var leaveBy = sumTime(dayBegin, getHoursPerDay());
-            var lunchTotal = document.getElementById(dayKey + 'lunch-total').value;
+            var lunchTotal = $('#' + dayKey + 'lunch-total').val();
             if (lunchTotal) {
                 leaveBy = sumTime(leaveBy, lunchTotal);
             }
-            document.getElementById('leave-by').value = leaveBy <= '23:59' ? leaveBy : '--:--';
+            $('#leave-by').val(leaveBy <= '23:59' ? leaveBy : '--:--');
         } else {
-            document.getElementById('leave-by').value = '';
+            $('#leave-by').val('');
         }
 
-        if (dayBegin.length && lunchBegin.length && lunchEnd.length && dayEnd.length) {
+        if (dayBegin.length && lunchBegin.length && lunchEnd.length && dayEnd.length) { 
             //All entries computed
-            document.getElementById('punch-button').disabled = true;
+            $('#punch-button').prop('disabled', true);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
 
-            var dayTotal = document.getElementById(dayKey + 'day-total').value;
+            var dayTotal = $('#' + dayKey + 'day-total').val();
             if (dayTotal) {
                 var dayBalance = subtractTime(getHoursPerDay(), dayTotal);
-                var leaveDayBalanceElement = document.getElementById('leave-day-balance');
-                leaveDayBalanceElement.value = dayBalance;
-                leaveDayBalanceElement.classList.remove('text-success', 'text-danger');
-                leaveDayBalanceElement.classList.add(isNegative(dayBalance) ? 'text-danger' : 'text-success');
-                document.getElementById('summary-unfinished-day').classList.add('hidden');
-                document.getElementById('summary-finished-day').classList.remove('hidden');
+                var leaveDayBalanceElement = $('#leave-day-balance');
+                leaveDayBalanceElement.val(dayBalance);
+                leaveDayBalanceElement.removeClass('text-success text-danger');
+                leaveDayBalanceElement.addClass(isNegative(dayBalance) ? 'text-danger' : 'text-success');
+                $('#summary-unfinished-day').addClass('hidden');
+                $('#summary-finished-day').removeClass('hidden');
             } else {
-                document.getElementById('summary-unfinished-day').classList.remove('hidden');
-                document.getElementById('summary-finished-day').classList.add('hidden');
+                $('#summary-unfinished-day').removeClass('hidden');
+                $('#summary-finished-day').addClass('hidden');
             }
         } else {
-            document.getElementById('punch-button').disabled = false;
+            $('#punch-button').prop('disabled', false);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
 
-            document.getElementById('summary-unfinished-day').classList.remove('hidden');
-            document.getElementById('summary-finished-day').classList.add('hidden');
+            $('#summary-unfinished-day').removeClass('hidden');
+            $('#summary-finished-day').addClass('hidden');
         }
     }
 
@@ -425,7 +425,7 @@ class Calendar {
      */
     _generateTemplate() {
         var body = this._getBody();
-        document.getElementById('calendar').innerHTML = body;
+        $('#calendar').html(body);
     }
 
     /*
@@ -641,19 +641,15 @@ function getDaysEntries(year, month, day) {
  */
 function getDaysEntriesFromHTML(year, month, day) {
     var dayStr = year + '-' + month + '-' + day + '-';
-    return [document.getElementById(dayStr + 'day-begin').value,
-        document.getElementById(dayStr + 'lunch-begin').value,
-        document.getElementById(dayStr + 'lunch-end').value,
-        document.getElementById(dayStr + 'day-end').value];
+    return [$('#' + dayStr + 'day-begin').val(),
+        $('#' + dayStr + 'lunch-begin').val(),
+        $('#' + dayStr + 'lunch-end').val(),
+        $('#' + dayStr + 'day-end').val()];
 }
 
 function colorErrorLine(year, month, day, dayBegin, lunchBegin, lunchEnd, dayEnd) {
-    var trID = ('tr-' + year + '-' + month + '-' + day);
-    if (hasInputError(dayBegin, lunchBegin, lunchEnd, dayEnd)) {
-        document.getElementById(trID).classList.add('error-tr');
-    } else if (document.getElementById(trID).classList.contains('error-tr')) {
-        document.getElementById(trID).classList.remove('error-tr');
-    }
+    var trID = ('#tr-' + year + '-' + month + '-' + day);
+    $(trID).toggleClass('error-tr', hasInputError(dayBegin, lunchBegin, lunchEnd, dayEnd));
 }
 
 /*
@@ -702,16 +698,16 @@ function updateTimeDay(year, month, day, key, newValue) {
     } else {
         store.delete(baseStr + 'lunch-total');
     }
-    document.getElementById(baseStr + 'lunch-total').value = lunchTime;
+    $('#' + baseStr + 'lunch-total').val(lunchTime);
 
     if (dayTotal.length > 0) {
         store.set(baseStr + 'day-total', dayTotal);
     } else {
         store.delete(baseStr + 'day-total');
     }
-    document.getElementById(baseStr + 'day-total').value = dayTotal;
+    $('#' + baseStr + 'day-total').val(dayTotal);
 
-    var displayedMonthTotal = document.getElementById('month-total').value;
+    var displayedMonthTotal = $('#month-total').val();
     var currentMonthTotal = displayedMonthTotal;
     if (validateTime(oldDayTotal)) {
         currentMonthTotal = subtractTime(oldDayTotal, currentMonthTotal);
@@ -719,7 +715,7 @@ function updateTimeDay(year, month, day, key, newValue) {
     if (dayTotal.length > 0) {
         currentMonthTotal = sumTime(currentMonthTotal, dayTotal);
     }
-    document.getElementById('month-total').value = currentMonthTotal;
+    $('#month-total').val(currentMonthTotal);
 
     colorErrorLine(year, month, day, dayBegin, lunchBegin, lunchEnd, dayEnd);
 }
@@ -739,11 +735,11 @@ function updateTimeDayCallback(key, value) {
  * Notify user if it's time to leave
  */
 function notifyTimeToLeave() {
-    if (!notificationIsEnabled() || document.getElementById('leave-by') === null) {
+    if (!notificationIsEnabled() || $('#leave-by').length === 0) {
         return;
     }
 
-    var timeToLeave = document.getElementById('leave-by').value;
+    var timeToLeave = $('#leave-by').val();
     if (validateTime(timeToLeave)) {
         /**
          * How many minutes should pass before the Time-To-Leave notification should be presented again.

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -16,8 +16,6 @@ $(() => {
     preferences[theme] = selectedThemeOption;
     document.querySelector('html').setAttribute('data-theme', selectedThemeOption);
 
-    let inputs = document.getElementsByTagName('input');
-
     $('input[type="checkbox"]').change(function() {
         preferences[this.name] = this.checked;
         ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
@@ -35,24 +33,25 @@ $(() => {
     });
 
 
-    for (let i = 0; i < inputs.length; i++) {
-        let input = inputs[i];
-        if (inputs[i].type === 'checkbox') {
-            if (input.name in usersStyles) {
-                input.checked = usersStyles[input.name];
+    $('input').each(function() {
+        let input = $(this);
+        let name = input.attr('name');
+        if (input.attr('type') === 'checkbox') {
+            if (name in usersStyles) {
+                input.prop('checked', usersStyles[name]);
             }
-            preferences[input.name] = input.checked;
-        } else if (inputs[i].type === 'time') {
-            if (input.name in usersStyles) {
-                input.value = usersStyles[input.name];
+            preferences[name] = input.prop('checked');
+        } else if (input.attr('type') === 'time') {
+            if (name in usersStyles) {
+                input.val(usersStyles[name]);
             }
-            preferences[input.name] = input.value;
+            preferences[name] = input.val();
         }
-    }
+    });
 
-    const notification = $(document.getElementById('notification'));
-    const repetition = $(document.getElementById('repetition'));
-    const notificationsInterval = $(document.getElementById('notifications-interval'));
+    const notification = $('#notification');
+    const repetition = $('#repetition');
+    const notificationsInterval = $('#notifications-interval');
 
     repetition.prop('disabled', !notification.is(':checked'));
     repetition.prop('checked', notification.is(':checked') && usersStyles['repetition']);

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -11,16 +11,16 @@ const store = new Store({name: 'waived-workdays'});
 let usersStyles =  getUserPreferences();
 
 function setDates(day) {
-    document.getElementById('start_date').value = day;
-    document.getElementById('end_date').value = day;
+    $('#start_date').val(day);
+    $('#end_date').val(day);
 }
 
 function setHours() {
-    document.getElementById('hours').value = usersStyles['hours-per-day'];
+    $('#hours').val(usersStyles['hours-per-day']);
 }
 
 function toggleAddButton() {
-    var value = document.getElementById('reason').value;
+    var value = $('#reason').val();
     if (value.length > 0) {
         $('#waive-button').removeAttr('disabled');
     } 
@@ -30,7 +30,7 @@ function toggleAddButton() {
 }
 
 function addRowToListTable(day, reason, hours) {
-    var table = document.getElementById('waiver-list-table'),
+    var table = $('#waiver-list-table')[0],
         row = table.insertRow(1),
         dayCell = row.insertCell(0),
         reasonCell = row.insertCell(1),
@@ -62,13 +62,13 @@ function getDateFromISOStr(isoStr) {
 }
 
 function addWaiver() {
-    var [start_year, start_month, start_day] = getDateFromISOStr(document.getElementById('start_date').value);
-    var [end_year, end_month, end_day] = getDateFromISOStr(document.getElementById('end_date').value);
+    var [start_year, start_month, start_day] = getDateFromISOStr($('#start_date').val());
+    var [end_year, end_month, end_day] = getDateFromISOStr($('#end_date').val());
     
     var start_date = new Date(start_year, start_month-1, start_day),
         end_date = new Date(end_year, end_month-1, end_day),
-        reason = document.getElementById('reason').value,
-        hours = document.getElementById('hours').value;
+        reason = $('#reason').val(),
+        hours = $('#hours').val();
 
     if (!(validateTime(hours))) {
         // The error is shown in the page, no need to handle it here
@@ -106,7 +106,7 @@ function addWaiver() {
     }
 
     //Cleanup
-    document.getElementById('reason').value = '';
+    $('#reason').val('');
     toggleAddButton();
 }
 
@@ -115,7 +115,7 @@ function deleteEntry(day) {
         return;
     }
     store.delete(day);
-    var table = document.getElementById('waiver-list-table');
+    var table = $('#waiver-list-table')[0];
     while (table.rows.length > 1) {
         table.deleteRow(1);
     }


### PR DESCRIPTION
#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

This PR has the purpose of changing DOM manipulation to always use jQuery, instead of pure JavaScript, as some pieces of code were doing.
Both forms were already present in the code of TTL, which creates an inconsistency in the way DOM elements are handled in the entirety of the source code.
Since jQuery is already a dependency, and it offers multiple improvements in DOM manipulation in regards to vanilla JS, I am proposing that it becomes the default way to manipulate the DOM.

#### What change is being introduced by this PR?
- How did you approach this problem? / What changes did you make to achieve the goal?

Replacing all instances of JavaScript DOM manipulation with jQuery equivalent instances.

- What are the indirect and direct consequences of the change?

In all future changesets, jQuery should be used in favor of vanilla JS, to maintain consistency on the project.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?

All tests passed as expected. So long as behavior is kept the same, it's tested.

### More information on changes:
- Using $('#' + key) instead of document.getElementById(key), which offers a much simpler interface of getting DOM elements.
- Using .prop() calls on jQuery elements instead of .checked and .disabled attributes on DOM elements.
- Using $().each() for element iteration instead of normal for loops across DOM element lists.
- Using .val() for value retrieval and .val(string) for value setting instead of .value =
- Using .addClass(), .toggleClass() and .removeClass() instead of editing the .classList of a DOM element.
