### PR TITLE
Fix #220: Adding npm ci to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Build/Install in Windows or MacOS:
 ```bash
 git clone https://github.com/thamara/time-to-leave.git
 cd time-to-leave
+npm ci
 npm install
 ```
 


### PR DESCRIPTION
Adding
`npm ci`
to README as discussed in #220.
That was enough for me to be able to use npm :)