### PR TITLE
Table Performance Improvements

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -26,7 +26,7 @@ ipcRenderer.on('PREFERENCE_SAVED', function(event, inputs) {
 });
 
 /*
- * Get nofified when preferences has been updated.
+ * Get nofified when waivers get updated.
  */
 ipcRenderer.on('WAIVER_SAVED', function() {
     calendar.loadInternalWaiveStore();

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -26,6 +26,14 @@ ipcRenderer.on('PREFERENCE_SAVED', function(event, inputs) {
 });
 
 /*
+ * Get nofified when preferences has been updated.
+ */
+ipcRenderer.on('WAIVER_SAVED', function() {
+    calendar.loadInternalWaiveStore();
+    calendar.redraw();
+});
+
+/*
  * Returns true if the notification is enabled in preferences.
  */
 function notificationIsEnabled() {

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -45,6 +45,33 @@ class Calendar {
      */
     _initCalendar() {
         this._generateTemplate();
+
+        var calendar = this;
+        $('#punch-button').off('click').on('click', function() {
+            calendar.punchDate();
+        });
+
+        $('#next-month').off('click').on('click', function() {
+            calendar.nextMonth();
+        });
+
+        $('#prev-month').off('click').on('click', function() {
+            calendar.prevMonth();
+        });
+
+        $('#current-month').off('click').on('click', function() {
+            calendar.goToCurrentDate();
+        });
+
+        this._draw();
+    }
+
+    /*
+     * Draws elements of the Calendar that depend on data.
+     */
+    _draw() {
+        this.updateTableHeader();
+        this.updateTableBody();
         this.updateBasedOnDB();
 
         if (!showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate())) {
@@ -60,22 +87,6 @@ class Calendar {
         var calendar = this;
         $('input[type=\'time\']').off('input propertychange').on('input propertychange', function() {
             calendar.updateTimeDayCallback(this.id, this.value);
-        });
-
-        $('#punch-button').off('click').on('click', function() {
-            calendar.punchDate();
-        });
-
-        $('#next-month').off('click').on('click', function() {
-            calendar.nextMonth();
-        });
-
-        $('#prev-month').off('click').on('click', function() {
-            calendar.prevMonth();
-        });
-
-        $('#current-month').off('click').on('click', function() {
-            calendar.goToCurrentDate();
         });
 
         $('.waiver-trigger').off('click').on('click', function() {
@@ -228,10 +239,10 @@ class Calendar {
     /*
      * Returns the header of the page, with the image, name and a message.
      */
-    _getPageHeader(year, month) {
+    _getPageHeader() {
         var todayBut = '<input id="current-month" type="image" src="assets/calendar.svg" alt="Current Month" title="Go to Current Month" height="24" width="24"></input>';
         var leftBut = '<input id="prev-month" type="image" src="assets/left-arrow.svg" alt="Previous Month" height="24" width="24"></input>';
-        var rigthBut = '<input id="next-month" type="image" src="assets/right-arrow.svg" alt="Next Month" height="24" width="24"></input>';
+        var rightBut = '<input id="next-month" type="image" src="assets/right-arrow.svg" alt="Next Month" height="24" width="24"></input>';
         return '<div class="title-header">'+
                     '<div class="title-header title-header-img"><img src="assets/timer.svg" height="64" width="64"></div>' +
                     '<div class="title-header title-header-text">Time to Leave</div>' +
@@ -239,8 +250,8 @@ class Calendar {
                '</div>' +
                 '<table class="table-header"><tr>' +
                     '<th class="th but-left">' + leftBut + '</th>' +
-                    '<th class="th th-month-name" colspan="18"><div class="div-th-month-name" id="month-year">' + this.options.months[month] + ' ' + year + '</div></th>' +
-                    '<th class="th but-right">' + rigthBut + '</th>' +
+                    '<th class="th th-month-name" colspan="18"><div class="div-th-month-name" id="month-year"></div></th>' +
+                    '<th class="th but-right">' + rightBut + '</th>' +
                     '<th class="th but-today">' + todayBut + '</th>' +
                 '</tr></table>';
     }
@@ -281,14 +292,27 @@ class Calendar {
     }
 
     /*
-     * Returns the code of the body of the page.
+     * Returns the template code of the body of the page.
      */
     _getBody() {
-        var monthLength = this.getMonthLength();
         var html = '<div>';
         html += this._getPageHeader(this.year, this.month);
         html += '<table class="table-body">';
         html += Calendar._getTableHeaderCode();
+        html += '<tbody id="calendar-table-body">';
+        html += '</tbody>';
+        html += '</table><br>';
+        html += '</div>';
+
+        return html;
+    }
+
+    /*
+     * Returns the code of the table body of the calendar.
+     */
+    generateTableBody() {
+        var html;
+        var monthLength = this.getMonthLength();
         var balanceRowPosition = this._getBalanceRowPosition();
 
         for (var day = 1; day <= monthLength; ++day) {
@@ -297,14 +321,25 @@ class Calendar {
                 html += Calendar._getBalanceRowCode();
             }
         }
-        html += '</table><br>';
-        html += '</div>';
-
         return html;
     }
 
+    /*
+     * Updates the code of the table header of the calendar, to be called on demand.
+     */
+    updateTableHeader() {
+        $('#month-year').html(this.options.months[this.month] + ' ' + this.year);
+    }
+
+    /*
+     * Updates the code of the table body of the calendar, to be called on demand.
+     */
+    updateTableBody() {
+        $('#calendar-table-body').html(this.generateTableBody());
+    }
+
     redraw() {
-        this._initCalendar();
+        this._draw();
     }
 
     /*
@@ -317,7 +352,7 @@ class Calendar {
         } else {
             this.month += 1;
         }
-        this._initCalendar(this.month, this.year);
+        this.redraw();
     }
 
     /*
@@ -330,7 +365,7 @@ class Calendar {
         } else {
             this.month -= 1;
         }
-        this._initCalendar(this.month, this.year);
+        this.redraw();
     }
 
     /*
@@ -339,7 +374,7 @@ class Calendar {
     goToCurrentDate() {
         this.month = this.today.getMonth();
         this.year = this.today.getFullYear();
-        this._initCalendar(this.month, this.year);
+        this.redraw();
     }
 
     /*

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -74,7 +74,7 @@ class Calendar {
         this.updateTableBody();
         this.updateBasedOnDB();
 
-        if (!showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate())) {
+        if (!this.showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate())) {
             $('#punch-button').prop('disabled', true);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         } else {
@@ -189,7 +189,7 @@ class Calendar {
             trID = ('tr-' + year + '-' + month + '-' + day),
             dateStr = getDateStr(currentDay);
 
-        if (!showDay(year, month, day)) {
+        if (!this.showDay(year, month, day)) {
             if (!this.hideNonWorkingDays) {
                 return '<tr'+ (isToday ? ' class="today-non-working"' : '') + ' id="' + trID + '">' +
                         '<td class="weekday ti">' + this.options.dayAbbrs[weekDay] + '</td>' +
@@ -283,7 +283,7 @@ class Calendar {
 
         var balanceRowPosition = 0;
         for (var day = 1; day < this.today.getDate(); ++day) {
-            if (showDay(this.year, this.month, day)) {
+            if (this.showDay(this.year, this.month, day)) {
                 balanceRowPosition = day;
             }
         }
@@ -411,9 +411,17 @@ class Calendar {
     * @param {Object.<string, any>} preferences
     */
     updatePreferences(preferences) {
+        this.preferences = preferences;
         this.countToday = preferences['count-today'];
         this.hideNonWorkingDays = preferences['hide-non-working-days'];
         this.hoursPerDay = preferences['hours-per-day'];
+    }
+
+    /*
+    * Calls showDay from user-preferences.js passing the last preferences set.
+    */
+    showDay(year, month, day) {
+        return showDay(year, month, day, this.preferences);
     }
 
     /*
@@ -429,7 +437,7 @@ class Calendar {
 
         if (this.getMonth() !== month ||
             this.getYear() !== year ||
-            !showDay(year, month, day)) {
+            !this.showDay(year, month, day)) {
             return;
         }
 
@@ -466,7 +474,7 @@ class Calendar {
         var countDays = false;
 
         for (var day = 1; day <= monthLength; ++day) {
-            if (!showDay(this.year, this.month, day)) {
+            if (!this.showDay(this.year, this.month, day)) {
                 continue;
             }
             var isToday = (now.getDate() === day && now.getMonth() === this.month && now.getFullYear() === this.year);
@@ -505,7 +513,7 @@ class Calendar {
         this.workingDays = 0;
         var stopCountingMonthStats = false;
         for (var day = 1; day <= monthLength; ++day) {
-            if (!showDay(this.year, this.month, day)) {
+            if (!this.showDay(this.year, this.month, day)) {
                 continue;
             }
 
@@ -566,7 +574,7 @@ class Calendar {
      * Update contents of the "time to leave" bar.
      */
     updateLeaveBy() {
-        if (!showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate()) ||
+        if (!this.showDay(this.today.getFullYear(), this.today.getMonth(), this.today.getDate()) ||
             this.today.getMonth() !== this.getMonth() ||
             this.today.getFullYear() !== this.getYear() ||
             waivedWorkdays.has(getDateStr(this.today))) {

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -367,6 +367,12 @@ class Calendar {
         $('#calendar-table-body').html(this.generateTableBody());
     }
 
+    reload() {
+        this.loadInternalStore();
+        this.loadInternalWaiveStore();
+        this.redraw();
+    }
+
     redraw() {
         this._draw();
     }

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -48,22 +48,10 @@ class Calendar {
     _initCalendar() {
         this._generateTemplate();
 
-        var calendar = this;
-        $('#punch-button').off('click').on('click', function() {
-            calendar.punchDate();
-        });
-
-        $('#next-month').off('click').on('click', function() {
-            calendar.nextMonth();
-        });
-
-        $('#prev-month').off('click').on('click', function() {
-            calendar.prevMonth();
-        });
-
-        $('#current-month').off('click').on('click', function() {
-            calendar.goToCurrentDate();
-        });
+        $('#punch-button').click(() => { this.punchDate(); });
+        $('#next-month').click(() => { this.nextMonth(); });
+        $('#prev-month').click(() => { this.prevMonth(); });
+        $('#current-month').click(() => { this.goToCurrentDate(); });
 
         this._draw();
     }

--- a/js/date-aux.js
+++ b/js/date-aux.js
@@ -9,6 +9,14 @@ function getDateStr(date) {
     }
 }
 
+/*
+ * Given a a year and month, returns how many days the month has
+ */
+function getMonthLength(year, month) {
+    var d = new Date(year, month+1, 0);
+    return d.getDate();
+}
+
 module.exports = {
-    getDateStr
+    getDateStr, getMonthLength
 };

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -145,8 +145,10 @@ function getLoadedOrDerivedUserPreferences() {
 /*
  * Returns true if we should display week day.
  */
-function showWeekDay(weekDay) {
-    var preferences = getLoadedOrDerivedUserPreferences();
+function showWeekDay(weekDay, preferences = undefined) {
+    if (preferences === undefined) {
+        preferences = getLoadedOrDerivedUserPreferences();
+    }
     switch (weekDay) {
     case 0: return preferences['working-days-sunday'];
     case 1: return preferences['working-days-monday'];
@@ -162,9 +164,9 @@ function showWeekDay(weekDay) {
  * Returns true if we should display day.
  * @note: The month should be 0-based (i.e.: 0 is Jan, 11 is Dec).
  */
-function showDay(year, month, day)  {
+function showDay(year, month, day, preferences = undefined)  {
     var currentDay = new Date(year, month, day), weekDay = currentDay.getDay();
-    return showWeekDay(weekDay);
+    return showWeekDay(weekDay, preferences);
 }
 
 module.exports = {

--- a/main.js
+++ b/main.js
@@ -259,6 +259,7 @@ function createWindow() {
                                 const importResult = importDatabaseFromFile(response);
                                 if (importResult['result']) {
                                     // Reload only the calendar itself to avoid a flash
+                                    win.webContents.executeJavaScript('calendar.loadInternalStore()');
                                     win.webContents.executeJavaScript('calendar.redraw()');
                                     dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                         {
@@ -304,6 +305,7 @@ function createWindow() {
                             store.clear();
                             waivedWorkdays.clear();
                             // Reload only the calendar itself to avoid a flash
+                            win.webContents.executeJavaScript('calendar.loadInternalStore()');
                             win.webContents.executeJavaScript('calendar.redraw()');
                             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                 {

--- a/main.js
+++ b/main.js
@@ -258,8 +258,7 @@ function createWindow() {
                                 const importResult = importDatabaseFromFile(response);
                                 if (importResult['result']) {
                                     // Reload only the calendar itself to avoid a flash
-                                    win.webContents.executeJavaScript('calendar.loadInternalStore()');
-                                    win.webContents.executeJavaScript('calendar.redraw()');
+                                    win.webContents.executeJavaScript('calendar.reload()');
                                     dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                         {
                                             title: 'Time to Leave',
@@ -304,8 +303,7 @@ function createWindow() {
                             store.clear();
                             waivedWorkdays.clear();
                             // Reload only the calendar itself to avoid a flash
-                            win.webContents.executeJavaScript('calendar.loadInternalStore()');
-                            win.webContents.executeJavaScript('calendar.redraw()');
+                            win.webContents.executeJavaScript('calendar.reload()');
                             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                                 {
                                     title: 'Time to Leave',

--- a/main.js
+++ b/main.js
@@ -141,8 +141,7 @@ function createWindow() {
                         waiverWindow.show();
                         waiverWindow.on('close', function() {
                             waiverWindow = null;
-                            // Reload only the calendar itself to avoid a flash
-                            win.webContents.executeJavaScript('calendar.redraw()');
+                            win.webContents.send('WAIVER_SAVED');
                         });
                     },
                 },


### PR DESCRIPTION
### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

I'm improving the performance of the table when switching between months. On the last release, it takes around 1s to switch up every month. After these optimizations, it now takes around 40ms.

Memory consumption analysis with "Heap Snapshots" taken with Chrome Dev Tools showed use went from around 4MB to 6MB on an idle screen. However, on the last release the heap usage increases by 4MB when switching up pages due to re-reading from store, and on this version, it increases at most 1MB. Anyway, these memory values are so low for today's computers that I think this is negligible.

#### What change is being introduced by this PR?
- How did you approach this problem? What changes did you make to achieve the goal?

This is a series of commits.
1. First change makes the table headers static and succeeding month changes to only reload the table body and month on the header.
2. Second change lets the preference contents be reused, avoiding that the algorithms read up the preferences from the files on every API call to functions on user-preferences.js.
3. Third change loads up the entire electron store for the calendar in memory, avoiding .has and .get calls that would take precious milliseconds due to the nature of the storage.
4. Fourth change is similar, but on the Waiver store instead, also adding a waiver saved event to reload waiver changes.
5. Removing unneeded off('click').on('click') on initCalendar now that these don't get removed on each Calendar draw.

- What are the indirect and direct consequences of the change?

It's going to feel much better for the user to use the program and look back into previous months, improving user experience.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?

Ran tests and tested with my user experience flows.

Before:
![slow](https://user-images.githubusercontent.com/37311270/82002034-118a5b80-9633-11ea-84e2-6434c4009adb.gif)

After:
![fast](https://user-images.githubusercontent.com/37311270/82002026-0df6d480-9633-11ea-9a27-a419ad7eb21e.gif)
