### PR TITLE
Fix #152: adding copy button to about

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 /*eslint-disable no-useless-escape*/
-const { app, BrowserWindow, dialog, ipcMain, Menu, net, shell, Tray } = require('electron');
+const { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, net, shell, Tray } = require('electron');
 const path = require('path');
 const Store = require('electron-store');
 const isOnline = require('is-online');
@@ -376,8 +376,16 @@ function createWindow() {
                                 message: 'Time to Leave',
                                 type: 'info',
                                 icon: iconpath,
-                                detail: `\n${detail}`
-                            });
+                                detail: `\n${detail}`,
+                                buttons: ['Copy', 'OK'],
+                                noLink: true
+                            }
+                        ).then((result) => {
+                            const buttonId = result.response;
+                            if (buttonId === 0) {
+                                clipboard.writeText(detail);
+                            }
+                        });
                     }
                 }
             ]


### PR DESCRIPTION
#### Related issue
#152 

#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

Adding a copy button to copy the contents of the about section into the clipboard.
Very simple commit, adds a handler to the onSuccess of the About dialog Promise, that handles the pressing of the copy button. The clipboard module is used, from electron.
