### PR TITLE
Fix #229: Fixing Count Today in Totals

### DIFF
--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -541,14 +541,18 @@ class Calendar {
             workingDaysToCompute = 0,
             monthTotalWorked = '00:00';
         var countDays = false;
+        var isNextDay = false;
 
         for (var day = 1; day <= monthLength; ++day) {
             if (!this._showDay(this._year, this._month, day)) {
                 continue;
             }
             var isToday = (now.getDate() === day && now.getMonth() === this._month && now.getFullYear() === this._year);
-            if (isToday && !!this._getCountToday()) {
+            if (isToday && !this._getCountToday()) {
                 //balance considers only up until yesterday
+                break;
+            }
+            else if (isNextDay && this._getCountToday()) {
                 break;
             }
 
@@ -561,6 +565,7 @@ class Calendar {
             if (countDays) {
                 workingDaysToCompute += 1;
             }
+            isNextDay = isToday;
         }
         var monthTotalToWork = multiplyTime(this._getHoursPerDay(), workingDaysToCompute * -1);
         var balance = sumTime(monthTotalToWork, monthTotalWorked);


### PR DESCRIPTION
#### Related issue
#229 

#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

The issue is described on #229. This is simply making the behavior work as expected.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?
Just tested with today's amount :)

Ignore the date icons there, they're coming from another pull request. Focus only on the balance totals.
![balance](https://user-images.githubusercontent.com/37311270/82620310-85d27b00-9bae-11ea-8788-4427ff35e0f3.gif)

