### PR TITLE
Fixing count totals for weekends

### DIFF
--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -544,9 +544,6 @@ class Calendar {
         var isNextDay = false;
 
         for (var day = 1; day <= monthLength; ++day) {
-            if (!this._showDay(this._year, this._month, day)) {
-                continue;
-            }
             var isToday = (now.getDate() === day && now.getMonth() === this._month && now.getFullYear() === this._year);
             if (isToday && !this._getCountToday()) {
                 //balance considers only up until yesterday
@@ -554,6 +551,11 @@ class Calendar {
             }
             else if (isNextDay && this._getCountToday()) {
                 break;
+            }
+            isNextDay = isToday;
+
+            if (!this._showDay(this._year, this._month, day)) {
+                continue;
             }
 
             var dayStr = this._year + '-' + this._month + '-' + day + '-' + 'day-total';
@@ -565,7 +567,6 @@ class Calendar {
             if (countDays) {
                 workingDaysToCompute += 1;
             }
-            isNextDay = isToday;
         }
         var monthTotalToWork = multiplyTime(this._getHoursPerDay(), workingDaysToCompute * -1);
         var balance = sumTime(monthTotalToWork, monthTotalWorked);


### PR DESCRIPTION
This is an improvement upon https://github.com/thamara/time-to-leave/pull/237.
The way the balance count continued evaluation on weekends on the balance count function broke the count totals if you open the program on a weekend.
Moving things up in the loop fixes it.