### PR TITLE
Fix punch button not being disabled when current day is waived

### DIFF
--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -63,13 +63,7 @@ class Calendar {
         this._updateTableBody();
         this._updateBasedOnDB();
 
-        if (!this._showDay(this._today.getFullYear(), this._today.getMonth(), this._today.getDate())) {
-            $('#punch-button').prop('disabled', true);
-            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
-        } else {
-            $('#punch-button').prop('disabled', false);
-            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
-        }
+        this._togglePunchButton(this._showDay(this._today.getFullYear(), this._today.getMonth(), this._today.getDate()));
 
         this._updateLeaveBy();
 
@@ -666,8 +660,7 @@ class Calendar {
 
         if (dayBegin !== undefined && lunchBegin !== undefined && lunchEnd !== undefined && dayEnd !== undefined) {
             //All entries computed
-            $('#punch-button').prop('disabled', true);
-            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
+            this._togglePunchButton(false);
 
             var dayTotal = $('#' + dayKey + 'day-total').val();
             if (dayTotal) {
@@ -683,8 +676,7 @@ class Calendar {
                 $('#summary-finished-day').addClass('hidden');
             }
         } else {
-            $('#punch-button').prop('disabled', false);
-            ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', true);
+            this._togglePunchButton(true);
 
             $('#summary-unfinished-day').removeClass('hidden');
             $('#summary-finished-day').addClass('hidden');
@@ -802,7 +794,14 @@ class Calendar {
         }
         return false;
     }
-
+    
+    /*
+    * Toggles the state of the punch butttons and actions on or off
+    */
+    _togglePunchButton(enable) {
+        $('#punch-button').prop('disabled', !enable);
+        ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', enable);
+    }
     /*
     * Toggles the color of a row based on input error.
     */

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -63,7 +63,9 @@ class Calendar {
         this._updateTableBody();
         this._updateBasedOnDB();
 
-        this._togglePunchButton(this._showDay(this._today.getFullYear(), this._today.getMonth(), this._today.getDate()));
+        var waivedInfo = this._getWaiverStore(this._today.getDate(), this._today.getMonth(), this._today.getFullYear());
+        var showCurrentDay = this._showDay(this._today.getFullYear(), this._today.getMonth(), this._today.getDate());
+        this._togglePunchButton(showCurrentDay && waivedInfo === undefined);
 
         this._updateLeaveBy();
 


### PR DESCRIPTION
#### Related issue
Closes #239

#### Context / Background
- If a day was waived, the punch button continued to be active, even though it wouldn't do anything

#### What change is being introduced by this PR?
- Commit 1: I've refactored the logic to toggle the punch buttons and actions into a function
- Commit 2: I started disabling them when the current day is waived.

#### How will this be tested?
- I tested this manually, cause I don't know how to add a test for it :(
