### PR TITLE
Fix #240: waiver using electron dialog instead of js confirm

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#233] Fixes crash when opening the waiver for a day
 - Fix: [#229] Count Today in totals no longer causes problem in the month balance
 - Fix: [#239] Punch button is disabled when current day is waived
+- Fix: [#240] Waiver using electron dialog instead of js confirm/alert
 - Fix: [#249] Fix loading preferences
 - Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
 - Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -76,16 +76,26 @@ function addWaiver() {
 
     var diff = diffDays(start_date, end_date);
     if (diff < 0) {
-        alert('End date cannot be less than start date.');
-        return;
+        dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+            {
+                message: 'End date cannot be less than start date.'
+            }
+        ).then(() => {
+            return;
+        });
     }
 
     var temp_date = new Date(start_date);
     for (var i = 0; i <= diff; i++) {
         var temp_date_str = getDateStr(temp_date);
         if (store.has(temp_date_str)) {
-            alert(`You already have a waiver on ${temp_date_str}. Remove it before adding a new one.`);
-            return;
+            dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+                {
+                    message: `You already have a waiver on ${temp_date_str}. Remove it before adding a new one.`
+                }
+            ).then(() => {
+                return;
+            });
         }
 
         temp_date.setDate(temp_date.getDate() + 1);

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -41,11 +41,9 @@ function addRowToListTable(day, reason, hours) {
     reasonCell.innerHTML = reason;
     hoursCell.innerHTML = hours;
     var id = 'delete-' + day;
-    delButtonCell.innerHTML = '<input class="delete-btn" id="' + id + '" type="image" src="../assets/delete.svg" alt="Delete entry" height="12" width="12"></input>';
+    delButtonCell.innerHTML = '<input class="delete-btn" data-day="' + day + '" id="' + id + '" type="image" src="../assets/delete.svg" alt="Delete entry" height="12" width="12"></input>';
     
-    $('#'+ id).on('click', function() {
-        deleteEntry(this.id.replace('delete-', ''));
-    });
+    $('#'+ id).on('click', deleteEntryOnClick);
 }
 
 function populateList() {
@@ -110,16 +108,16 @@ function addWaiver() {
     toggleAddButton();
 }
 
-function deleteEntry(day) {
+function deleteEntryOnClick(event) {
+    let deleteButton = $(event.target);
+    let day = deleteButton.data('day');
     if (!confirm('Are you sure you want to delete waiver on day ' + day + '?')) {
         return;
     }
     store.delete(day);
-    var table = $('#waiver-list-table')[0];
-    while (table.rows.length > 1) {
-        table.deleteRow(1);
-    }
-    populateList();
+
+    let row = deleteButton.closest('tr');
+    row.remove();
 }
 
 $(() => {

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -3,6 +3,7 @@ const { validateTime, diffDays } = require('../js/time-math.js');
 const { applyTheme } = require('../js/themes.js');
 const { getDateStr } = require('../js/date-aux.js');
 const { remote } = require('electron');
+const { BrowserWindow, dialog } = remote;
 const Store = require('electron-store');
 
 const store = new Store({name: 'waived-workdays'});
@@ -111,13 +112,23 @@ function addWaiver() {
 function deleteEntryOnClick(event) {
     let deleteButton = $(event.target);
     let day = deleteButton.data('day');
-    if (!confirm('Are you sure you want to delete waiver on day ' + day + '?')) {
-        return;
-    }
-    store.delete(day);
 
-    let row = deleteButton.closest('tr');
-    row.remove();
+    dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+        {
+            title: 'Time to Leave',
+            message: 'Are you sure you want to delete waiver on day ' + day + '?',
+            type: 'info',
+            buttons: ['Yes', 'No']
+        }).then((result) => {
+        const buttonId = result.response;
+        if (buttonId === 1) {
+            return;
+        }
+        store.delete(day);
+
+        let row = deleteButton.closest('tr');
+        row.remove();
+    });
 }
 
 $(() => {


### PR DESCRIPTION
#### Related issue
#240

#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

When using JS alert() or confirm() on electron apps, the threads get blocked and input becomes stuck unless the user switches windows.

#### What change is being introduced by this PR?

I'm using now electron's own dialog services, which avoid this type of issue AND add promises, which also solves a sync issue when clicking the button and stalling the JS thread (chrome reports this with a warning on dev tools).
I also stopped re-populating the entire table on every delete call, which will make it faster.

(I really hate this formatting on the promise part, it's totally unclear what is what, but that's what eslint gave)

#### How will this be tested?

Manually using, all fine.
