### PR TITLE
Fixing preferences derived loading

### DIFF
--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -64,7 +64,7 @@ function getDerivedPrefsFromLoadedPrefs(loadedPreferences) {
         derivedPreferences[key] = loadedPreferences[key] || defaultPreferences[key];
     });
 
-    return defaultPreferences;
+    return derivedPreferences;
 }
 
 /*


### PR DESCRIPTION
### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context
 
This is fixing an issue in the getDerivedPrefsFromLoadedPrefs method on the user-preferences.js file.
The method was evaluating the loaded preferences in regards to the default ones, but ignoring all the changes it did at the end by returning the wrong variable.
This caused issues when changing the number of keys in the default preferences: for instance, the new key for view in the other PR.

#### What change is being introduced by this PR?
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?

Returning the correct "derived" variable now.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?

All tests ran fine. Adding or removing lines from preferences stops it from being reset to default.