### PR TITLE
Fix #250: Don't allow waiver to be added to non-working day

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,9 @@
 - Fix: [#239] Punch button is disabled when current day is waived
 - Fix: [#240] Waiver using electron dialog instead of js confirm/alert
 - Fix: [#249] Fix loading preferences
+- Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
 - Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
 - Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
 - Upgrade: Upgrading jquery to 3.5.0
 - Upgrade: [#236] Upgrade all dependencies
+  

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -86,8 +86,11 @@ function addWaiver() {
     }
 
     var temp_date = new Date(start_date);
+    var noWorkingDaysOnRange = true;
     for (var i = 0; i <= diff; i++) {
         var temp_date_str = getDateStr(temp_date);
+        var [temp_year, temp_month, temp_day] = getDateFromISOStr(temp_date_str);
+        noWorkingDaysOnRange &= !showDay(temp_year, temp_month-1, temp_day) && !store.has(temp_date_str);
         if (store.has(temp_date_str)) {
             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                 {
@@ -101,11 +104,21 @@ function addWaiver() {
         temp_date.setDate(temp_date.getDate() + 1);
     }
 
+    if (noWorkingDaysOnRange) {
+        dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
+            {
+                message: `You already have a waiver on ${temp_date_str}. Remove it before adding a new one.`
+            }
+        ).then(() => {
+            return;
+        });
+    }
+
     temp_date = new Date(start_date);
 
     for (i = 0; i <= diff; i++) {
         temp_date_str = getDateStr(temp_date);
-        var [temp_year, temp_month, temp_day] = getDateFromISOStr(temp_date_str);
+        [temp_year, temp_month, temp_day] = getDateFromISOStr(temp_date_str);
         if (showDay(temp_year, temp_month-1, temp_day) && !store.has(temp_date_str)) {
             store.set(temp_date_str, { 'reason' : reason, 'hours' : hours });
             addRowToListTable(temp_date_str, reason, hours);


### PR DESCRIPTION
#### Related issue
#250

#### Context / Background
- Adding a waiver to a non working day was silently failing/returning
- Should wait for #246 to be merged so we don't introduce `alert` again

#### What change is being introduced by this PR?
- Pop-up that waiver addition on invalid/non-working day is not possible

#### How will this be tested?
Manually
