### PR TITLE
Fix #252: Don't allow multiple auxiliary windows to be opened

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#240] Waiver using electron dialog instead of js confirm/alert
 - Fix: [#249] Fix loading preferences
 - Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
+- Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
 - Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
 - Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
 - Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day

--- a/main.js
+++ b/main.js
@@ -28,6 +28,8 @@ ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) => {
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let win;
+let waiverWindow = null;
+let prefWindow = null;
 let tray;
 const store = new Store();
 const waivedWorkdays = new Store({name: 'waived-workdays'});
@@ -123,12 +125,17 @@ function createWindow() {
                     label: 'Workday Waiver Manager',
                     id: 'workday-waiver-manager',
                     click(item, window, event) {
+                        if (waiverWindow !== null) {
+                            waiverWindow.show();
+                            return;
+                        }
+                        
                         if (event) {
                             const today = new Date();
                             global.waiverDay = getDateStr(today);
                         }
                         const htmlPath = path.join('file://', __dirname, 'src/workday-waiver.html');
-                        let waiverWindow = new BrowserWindow({ width: 600,
+                        waiverWindow = new BrowserWindow({ width: 600,
                             height: 500,
                             parent: win,
                             resizable: true,
@@ -183,8 +190,13 @@ function createWindow() {
                     label: 'Preferences',
                     accelerator: macOS ? 'Command+,' : 'Control+,',
                     click() {
+                        if (prefWindow !== null) {
+                            prefWindow.show();
+                            return;
+                        }
+                      
                         const htmlPath = path.join('file://', __dirname, 'src/preferences.html');
-                        let prefWindow = new BrowserWindow({ width: 400,
+                        prefWindow = new BrowserWindow({ width: 400,
                             height: 500,
                             parent: win,
                             resizable: true,


### PR DESCRIPTION
#### Related issue
#252 

#### Context / Background
- It was possible to open multiple preferences windows at the same time
- It was possible to open multiple workday waiver manager windows at the same time

#### What change is being introduced by this PR?
- We check if the window already exists before opening it.

#### How will this be tested?
- Works on my machine :D
