### PR TITLE
Fix #255: avoiding preferences save when still null

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#249] Fix loading preferences
 - Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
 - Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
+- Fix: [#255] Avoiding issue when closing preferences window without changing anything
 - Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
 - Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
 - Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day

--- a/main.js
+++ b/main.js
@@ -212,8 +212,10 @@ function createWindow() {
                         //prefWindow.webContents.openDevTools()
                         prefWindow.on('close', function() {
                             prefWindow = null;
-                            savePreferences(savedPreferences);
-                            win.webContents.send('PREFERENCE_SAVED', savedPreferences);
+                            if (savedPreferences !== null) {
+                                savePreferences(savedPreferences);
+                                win.webContents.send('PREFERENCE_SAVED', savedPreferences);
+                            }
                         });
                     },
                 },


### PR DESCRIPTION
#### Related issue
Closes #255

#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

On main.js, we only save the preferences if the value was previously set, avoiding an exception.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?

Works on my machine.
