### PR TITLE
Fix #244: waiver opens with filled date when clicking from calendar

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#229] Count Today in totals no longer causes problem in the month balance
 - Fix: [#239] Punch button is disabled when current day is waived
 - Fix: [#240] Waiver using electron dialog instead of js confirm/alert
+- Fix: [#244] Waiver opens with filled date when clicking from calendar
 - Fix: [#249] Fix loading preferences
 - Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
 - Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened

--- a/main.js
+++ b/main.js
@@ -18,11 +18,7 @@ ipcMain.on('PREFERENCE_SAVE_DATA_NEEDED', (event, preferences) => {
 });
 
 ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) => {
-    /*eslint-disable no-undef*/
-    if (!isNaN(waiverDay))
-    {
-        global.waiverDay = waiverDay;  
-    }
+    global.waiverDay = waiverDay;
 });
 
 // Keep a global reference of the window object, if you don't, the window will


### PR DESCRIPTION
#### Related issue
Closes #244 

#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

When clicking from the calendar to open a waiver with the date pre-filled, it now works as expected.

#### What change is being introduced by this PR?
- How did you approach this problem?

Just removing a check that was avoiding the filling to happen.

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?

Works here.