### PR TITLE
Enhancement #241: Changing input format for notification interval and hours per day on preferences

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 - Fix: [#213] Count today preference fixed to work as expected.
 - Fix: [#209] Punch time button to only fill one entry (not the entire row)
 - Fix: [#215] Fixed exception: isNan is not defined
-- Fix: [#27] Adding day balance on when to leave bar after day is done 
+- Fix: [#27] Adding day balance on when to leave bar after day is done
 - Fix: [#210] Count today preference is respected
 - Fix: [#211] Adjusted preferences window size to fit the whole content
 - Fix: [#233] Fixes crash when opening the waiver for a day
@@ -15,8 +15,8 @@
 - Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
 - Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
 - Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
+- Enhancement: [#241] Changing input format for notification interval and hours per day on preferences
 - Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day
 - Enhancement: [#245] DevTools shortcut (Ctrl+Shift+I) on Preferences and Waiver windows
 - Upgrade: Upgrading jquery to 3.5.0
 - Upgrade: [#236] Upgrade all dependencies
-  

--- a/css/styles.css
+++ b/css/styles.css
@@ -498,6 +498,10 @@ input:disabled + .slider {
   color: #fff;
 }
 
+#preferences-window input[type=text]:invalid{
+  color: rgb(255, 71, 71);
+}
+
 #preferences-window .flex-box {
   display: flex;
   height: 25px;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -18,9 +18,10 @@ let calendar = null;
 /*
  * Get nofified when preferences has been updated.
  */
-ipcRenderer.on('PREFERENCE_SAVED', function(event, preferences) {
-    calendar = CalendarFactory.getInstance(preferences, calendar);
-    applyTheme(preferences.theme);
+ipcRenderer.on('PREFERENCE_SAVED', function(event, prefs) {
+    preferences = prefs;
+    calendar = CalendarFactory.getInstance(prefs, calendar);
+    applyTheme(prefs.theme);
 });
 
 /*
@@ -52,7 +53,7 @@ function notifyTimeToLeave() {
          * How many minutes should pass before the Time-To-Leave notification should be presented again.
          * @type {number} Minutes post the clockout time
          */
-        const notificationInterval = hourToMinutes(preferences['notifications-interval']);
+        const notificationInterval = preferences['notifications-interval'];
         var now = new Date();
         var curTime = String(now.getHours()).padStart(2, '0') + ':' + String(now.getMinutes()).padStart(2, '0');
 

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -11,7 +11,7 @@ const defaultPreferences = {
     'hours-per-day': '08:00',
     'notification': true,
     'repetition': true,
-    'notifications-interval': '00:05',
+    'notifications-interval': '5',
     'start-at-login': false,
     'theme': 'light',
     'update-remind-me-after' : '2019-01-01',
@@ -62,7 +62,7 @@ function readPreferences() {
 function getDerivedPrefsFromLoadedPrefs(loadedPreferences) {
     var derivedPreferences = {};
     Object.keys(defaultPreferences).forEach(function(key) {
-        derivedPreferences[key] = loadedPreferences[key] || defaultPreferences[key];
+        derivedPreferences[key] = (typeof loadedPreferences[key] !== 'undefined') ? loadedPreferences[key] : defaultPreferences[key];
     });
 
     return derivedPreferences;
@@ -95,6 +95,11 @@ function initPreferencesFileIfNotExistsOrInvalid() {
         switch (key) {
         // Handle Time Inputs
         case 'notifications-interval':
+            if (isNaN(Number(value)) || value < 1 || value > 30) {
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
+            }
+            break;
         case 'hours-per-day': {
             if (!validateTime(value)) {
                 derivedPrefs[key] = defaultPreferences[key];

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -42,7 +42,9 @@
             </div>
             <div class="flex-box">
                 <p>Hours per day</p>
-                <input type="time" name="hours-per-day" id="hours-per-day" min="00:00" max="24:00" value="08:00" required>
+                <input type="text" name="hours-per-day" id="hours-per-day" maxlength=5
+                    pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" placeholder="HH:mm" value="08:00"
+                    size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
             </div>
         </section>
 
@@ -57,8 +59,9 @@
                 <label class="switch"><input type="checkbox" id="repetition" name="repetition"><span class="slider round"></span></label>
             </div>
             <div class="flex-box mb-2">
-                <p>Time between notifications</p>
-                <input type="time" id="notifications-interval" name="notifications-interval" min="00:01" max="00:30" />
+                <p>Minutes between notifications</p>
+                <input type="number" name="notifications-interval" id="notifications-interval"
+                    min="1" max="30" value="5" required onblur="this.value = this.checkValidity() ? this.value : 5">
             </div>
             <div class="flex-box">
                 <p>Start on Login</p>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -27,7 +27,14 @@ $(() => {
         ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
     });
 
-    $('input[type="time"]').change(function() {
+    $('#hours-per-day').change(function() {
+        if (this.checkValidity() === true) {
+            preferences[this.name] = this.value;
+            ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
+        }
+    });
+
+    $('input[type="number"]').change(function() {
         preferences[this.name] = this.value;
         ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
     });
@@ -51,7 +58,7 @@ $(() => {
                 input.prop('checked', usersStyles[name]);
             }
             preferences[name] = input.prop('checked');
-        } else if (input.attr('type') === 'time') {
+        } else if (['text', 'number'].indexOf(input.attr('type')) > -1) {
             if (name in usersStyles) {
                 input.val(usersStyles[name]);
             }


### PR DESCRIPTION
#### Related issue
Closes #241 

#### Context / Background
- Briefly explain the purpose of the PR by providing a summary of the context

Notification interval and hours per day were a little bit strange with AM/PM settings. This PR is changing them to more customized text and number inputs. I'm also fixing a bug where preference saving didn't update the notification interval timeout function.

#### What change is being introduced by this PR?
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?

Hours per day became a text field with regex validation. It's colored red when out of bounds and goes back to a default "08:00".
Notification interval is a number field for a minutes value, limited between 1 and 30 minutes. Validation also forces the correct interval.
On calendar.js, I'm saving the preferences variable now every time, since the timeout function relied on the contents of the variable.

![prefs](https://user-images.githubusercontent.com/37311270/83827809-922dfc00-a6b5-11ea-8a0b-2ad5ff30c289.gif)
