### PR TITLE
Adding Window-aux tests

### DIFF
--- a/__mocks__/mock.html
+++ b/__mocks__/mock.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html data-theme="">
+
+<head>
+    <script>window.$ = window.jQuery = require('jquery');</script>
+</head>
+
+<body></body>
+
+</html>

--- a/__tests__/__renderer__/window-aux.js
+++ b/__tests__/__renderer__/window-aux.js
@@ -1,0 +1,123 @@
+/* eslint-disable no-undef */
+const path = require('path');
+const { remote } = require('electron');
+const { BrowserWindow } = remote;
+
+describe('window-aux.js Testing', function() {
+    process.env.NODE_ENV = 'test';
+
+    // No idea why it's failing on mac, but issue #268 tracks this problem. Jest requires at least one test.
+    const isMacOS = process.platform === 'darwin';
+    if (isMacOS) {
+        test('Empty test', () => {});
+        return;
+    }
+
+    const mockHtmlPath = path.join(__dirname, '../../__mocks__/mock.html');
+    const devToolsShortcut = new KeyboardEvent('keyup', {keyCode: 73, ctrlKey: true, shiftKey: true});
+    const badDevToolsShortcut = new KeyboardEvent('keyup', {keyCode: 74, ctrlKey: true, shiftKey: true});
+    const browserWindowOptions = {
+        webPreferences: {
+            enableRemoteModule: true,
+            nodeIntegration: true
+        }
+    };
+    const timeoutValue = 1500;
+
+    describe('bindDevToolsShortcut(window)', function() {
+
+        test('No bind: should not open anything', async() => {
+            let testWindow = new BrowserWindow(browserWindowOptions);
+            testWindow.loadURL(mockHtmlPath);
+            expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+
+            testWindow.webContents.on('dom-ready', () => {
+                window.dispatchEvent(devToolsShortcut);
+            });
+
+            await new Promise(r => setTimeout(r, timeoutValue));
+            expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+        });
+
+        test('Bind: should open devTools', async() => {
+            let testWindow = new BrowserWindow(browserWindowOptions);
+            testWindow.loadURL(mockHtmlPath);
+            expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+
+            testWindow.webContents.on('dom-ready', () => {
+                const { bindDevToolsShortcut } = require('../../js/window-aux.js');
+                bindDevToolsShortcut(window);
+                window.dispatchEvent(devToolsShortcut);
+            });
+
+            await new Promise(r => setTimeout(r, timeoutValue));
+            expect(testWindow.webContents.isDevToolsOpened()).toBeTruthy();
+        });
+
+        test('Bind: bad shortcut, should not open devTools', async() => {
+            let testWindow = new BrowserWindow(browserWindowOptions);
+            testWindow.loadURL(mockHtmlPath);
+            expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+
+            testWindow.webContents.on('dom-ready', () => {
+                const { bindDevToolsShortcut } = require('../../js/window-aux.js');
+                bindDevToolsShortcut(window);
+                window.dispatchEvent(badDevToolsShortcut);
+            });
+
+            await new Promise(r => setTimeout(r, timeoutValue));
+            expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+        });
+    });
+
+    describe('showDialog(options, successCallback)', function() {
+
+        test('Does not crash', async() => {
+            let testWindow = new BrowserWindow(browserWindowOptions);
+            testWindow.loadURL(mockHtmlPath);
+
+            let spy;
+            testWindow.webContents.on('dom-ready', () => {
+                const windowAux = require('../../js/window-aux.js');
+                spy = jest.spyOn(windowAux, 'showDialog');
+
+                let options = {
+                    title: 'Time to Leave',
+                };
+                windowAux.showDialog(options, () => {
+                    return;
+                });
+            });
+
+            await new Promise(r => setTimeout(r, timeoutValue));
+            expect(testWindow).toBeDefined();
+            expect(spy).toHaveBeenCalled();
+
+            spy.mockRestore();
+        });
+    });
+
+    describe('showAlert(message)', function() {
+
+        test('Does not crash', async() => {
+            let testWindow = new BrowserWindow(browserWindowOptions);
+            testWindow.loadURL(mockHtmlPath);
+
+            let spy;
+            testWindow.webContents.on('dom-ready', () => {
+                const windowAux = require('../../js/window-aux.js');
+                const { dialog } = require('electron').remote;
+
+                spy = jest.spyOn(dialog, 'showMessageBoxSync').mockImplementation(() => {});
+
+                windowAux.showAlert('Test showAlert');
+            });
+
+            await new Promise(r => setTimeout(r, timeoutValue));
+            expect(testWindow).toBeDefined();
+            expect(spy).toHaveBeenCalled();
+
+            spy.mockRestore();
+        });
+    });
+});


### PR DESCRIPTION
#### Context / Background
<!--
- Briefly explain the purpose of the PR by providing a summary of the context
-->

Here I'm adding tests for windows-aux.js files.
Three methods are being tested: bindDevToolsShortcut, showDialog and showAlert.

To test bindDevToolsShortcut we create a new BrowserWindow instance, bind the method to it's window object in the 'onload' method, and then test if sending the expected keyboard event opens devtools, checking with electron functions.
To test showDialog and showAlert, the same idea is used, but since electron doesn't offer a way to see if there's an open dialog, we can only run the test and see if calling the functions doesn't crash anything.
showAlert is a blocking function, so I had to mock the blocking function or jest would never finish.

All three tests rely on waiting for some time after the window tests are done. I wish I could put the tests in a promise resolution, or inside a setTimeout call, but jest doesn't register any tests put in these situtations. In my windows machine, I can set some numbers for the expected time to wait, but it's failing here on macOs tests.