### PR TITLE
Fix #258: Fixing crash when changing network while opening TTL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
 - Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
 - Fix: [#255] Avoiding issue when closing preferences window without changing anything
+- Fix: [#258] Fixing crash when changing network while opening TTL
 - Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
 - Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
 - Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day

--- a/main.js
+++ b/main.js
@@ -39,6 +39,14 @@ var launchDate = new Date();
 var recommendPunchIn = false;
 setTimeout(() => { recommendPunchIn = true; }, 30 * 60 * 1000);
 
+process.on('uncaughtException', function(err) {
+    if (!err.message.includes('net::ERR_NETWORK_CHANGED')) {
+        console.error((new Date).toUTCString() + ' uncaughtException:', err.message);
+        console.error(err.stack);
+        process.exit(1);
+    }
+});
+
 function checkIdleAndNotify() {
     if (recommendPunchIn) {
         recommendPunchIn = false;


### PR DESCRIPTION
#### Related issue
Closes #258: Fixing crash when changing network while opening TTL

#### Context / Background
While changing network and opening TTL at the same time, a network err exception is thrown and never caught anywhere.

#### What change is being introduced by this PR?
This PR adds a global catcher just for this exception.

#### How will this be tested?
Forced the same conditions that caused the issue and didn't see it happen :)
