### PR TITLE
Fix #232 - Automatically advance internal date on day change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#27] Adding day balance on when to leave bar after day is done
 - Fix: [#210] Count today preference is respected
 - Fix: [#211] Adjusted preferences window size to fit the whole content
+- Fix: [#232] Calendar not advancing to next day when system clock does
 - Fix: [#233] Fixes crash when opening the waiver for a day
 - Fix: [#229] Count Today in totals no longer causes problem in the month balance
 - Fix: [#239] Punch button is disabled when current day is waived

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -406,6 +406,10 @@ class Calendar {
         this._draw();
     }
 
+    goToCurrentDate() {
+        this._goToCurrentDate();
+    }
+
     /*
      * Display next month.
      */

--- a/main.js
+++ b/main.js
@@ -107,7 +107,7 @@ function refreshOnDayChange() {
     {
         launchDate = today;
         // Reload only the calendar itself to avoid a flash
-        win.webContents.executeJavaScript('calendar.redraw()');
+        win.webContents.executeJavaScript('calendar.goToCurrentDate()');
     }
 }
 


### PR DESCRIPTION
#### Related issue
#232 

#### Context / Background
We lost the feature of automatically transitioning the day when the user leaves TTL open and the day changes when we stopped redrawing everything from scratch.

#### What change is being introduced by this PR?
We now skip again to the current date when the day changes

#### How will this be tested?
We'll know at midnight :D