### PR TITLE
Fix #232: Total bar not updating on day change

### DIFF
--- a/__tests__/__renderer__/classes/Calendar.js
+++ b/__tests__/__renderer__/classes/Calendar.js
@@ -178,13 +178,13 @@ describe('Calendar class Tests', () => {
         waivedWorkdays.set(waivedEntries);
 
         testPreferences['view'] = 'day';
-        expect(calendar.constructor.name).toBe("Calendar");
+        expect(calendar.constructor.name).toBe('Calendar');
 
         // last state of the internal store was 10 elements
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(10);
 
         calendar = CalendarFactory.getInstance(testPreferences, calendar);
-        expect(calendar.constructor.name).toBe("DayCalendar");
+        expect(calendar.constructor.name).toBe('DayCalendar');
 
         // internal store is again set with 9 elements after store reset
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(9);

--- a/__tests__/__renderer__/classes/Calendar.js
+++ b/__tests__/__renderer__/classes/Calendar.js
@@ -145,6 +145,31 @@ describe('Calendar class Tests', () => {
         expect(calendar._getCalendarYear()).toBe(today.getFullYear());
     });
 
+    describe('Calendar RefreshOnDayChange', () => {
+        test('Calendar refresh set correctly', () => {
+            // Calendar is set as if someone was looking at previous month
+            calendar._prevMonth();
+            let prevMonthDate = calendar._calendarDate;
+
+            // Refreshing with the date being looked at should push it to today
+            calendar.refreshOnDayChange(prevMonthDate.getDate(), prevMonthDate.getMonth(), prevMonthDate.getFullYear());
+
+            expect(calendar._getCalendarDate()).toBe(today.getDate());
+            expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+            expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        });
+
+        test('Calendar refresh set to another month', () => {
+            // Calendar is set as if someone was looking at previous month
+            calendar._prevMonth();
+
+            // Refreshing with a date not being looked at should not push it to today
+            calendar.refreshOnDayChange(today.getDate(), today.getMonth(), today.getFullYear());
+
+            expect(calendar._getCalendarMonth()).not.toBe(today.getMonth());
+        });
+    });
+
     test('Calendar to DayCalendar', () => {
         store.clear();
         store.set(regularEntries);
@@ -305,6 +330,31 @@ describe('Calendar class Tests', () => {
         expect(calendar._getCalendarDate()).toBe(today.getDate());
         expect(calendar._getCalendarMonth()).toBe(today.getMonth());
         expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+    });
+
+    describe('DayCalendar RefreshOnDayChange', () => {
+        test('DayCalendar refresh set correctly', () => {
+            // Calendar is set as if someone was looking at previous day
+            calendar._prevDay();
+            let prevDayDate = calendar._calendarDate;
+
+            // Refreshing with the date being looked at should push it to today
+            calendar.refreshOnDayChange(prevDayDate.getDate(), prevDayDate.getMonth(), prevDayDate.getFullYear());
+
+            expect(calendar._getCalendarDate()).toBe(today.getDate());
+            expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+            expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        });
+
+        test('DayCalendar refresh set to another day', () => {
+            // Calendar is set as if someone was looking at previous day
+            calendar._prevDay();
+
+            // Refreshing with a date not being looked at should not push it to today
+            calendar.refreshOnDayChange(today.getDate(), today.getMonth(), today.getFullYear());
+
+            expect(calendar._getCalendarDate()).not.toBe(today.getDate());
+        });
     });
 });
 

--- a/__tests__/__renderer__/classes/Calendar.js
+++ b/__tests__/__renderer__/classes/Calendar.js
@@ -39,9 +39,9 @@ describe('Calendar class Tests', () => {
     let calendar = CalendarFactory.getInstance(testPreferences);
 
     test('Calendar creates with today\'s date', () => {
-        expect(calendar._today.getDate()).toBe(today.getDate());
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._month).toBe(today.getMonth());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
     });
 
     test('Calendar internal storage correct loading', () => {
@@ -96,30 +96,25 @@ describe('Calendar class Tests', () => {
     });
 
     test('Calendar Month Changes', () => {
-        expect(calendar._month).toBe(today.getMonth());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
         const expectedNextMonth = today.getMonth() + 1 === 12 ? 0 : (today.getMonth() + 1);
         const expectedPrevMonth = today.getMonth() === 0 ? 11 : (today.getMonth() - 1);
 
         calendar._nextMonth();
-        expect(calendar._month).toBe(expectedNextMonth);
-        expect(calendar._getMonth()).toBe(expectedNextMonth);
+        expect(calendar._getCalendarMonth()).toBe(expectedNextMonth);
 
         calendar._prevMonth();
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._getMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
 
         calendar._prevMonth();
-        expect(calendar._month).toBe(expectedPrevMonth);
-        expect(calendar._getMonth()).toBe(expectedPrevMonth);
+        expect(calendar._getCalendarMonth()).toBe(expectedPrevMonth);
 
         calendar._goToCurrentDate();
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._getMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
     });
 
     test('Calendar Year Changes', () => {
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._getYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
         const expectedNextYear = today.getFullYear() + 1;
         const expectedPrevYear = today.getFullYear() - 1;
 
@@ -127,27 +122,21 @@ describe('Calendar class Tests', () => {
             calendar._nextMonth();
         }
 
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._getMonth()).toBe(today.getMonth());
-        expect(calendar._year).toBe(expectedNextYear);
-        expect(calendar._getYear()).toBe(expectedNextYear);
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarYear()).toBe(expectedNextYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._getYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
 
         for (let i = 0; i < 12; i++) {
             calendar._prevMonth();
         }
 
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._getMonth()).toBe(today.getMonth());
-        expect(calendar._year).toBe(expectedPrevYear);
-        expect(calendar._getYear()).toBe(expectedPrevYear);
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarYear()).toBe(expectedPrevYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._getYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
     });
 
     test('Calendar to DayCalendar', () => {
@@ -171,9 +160,9 @@ describe('Calendar class Tests', () => {
     });
 
     test('DayCalendar starts with today\'s date', () => {
-        expect(calendar._today.getDate()).toBe(today.getDate());
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._month).toBe(today.getMonth());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
     });
 
     test('DayCalendar internal storage correct loading', () => {
@@ -228,7 +217,7 @@ describe('Calendar class Tests', () => {
     });
 
     test('DayCalendar Day Changes', () => {
-        expect(calendar._today.getDate()).toBe(today.getDate());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
 
         let expectedNextDay = new Date(today);
         expectedNextDay.setDate(expectedNextDay.getDate() + 1);
@@ -236,20 +225,20 @@ describe('Calendar class Tests', () => {
         expectedPrevDay.setDate(expectedPrevDay.getDate() - 1);
 
         calendar._nextDay();
-        expect(calendar._today.getDate()).toBe(expectedNextDay.getDate());
+        expect(calendar._getCalendarDate()).toBe(expectedNextDay.getDate());
 
         calendar._prevDay();
-        expect(calendar._today.getDate()).toBe(today.getDate());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
 
         calendar._prevDay();
-        expect(calendar._today.getDate()).toBe(expectedPrevDay.getDate());
+        expect(calendar._getCalendarDate()).toBe(expectedPrevDay.getDate());
 
         calendar._goToCurrentDate();
-        expect(calendar._today.getDate()).toBe(today.getDate());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
     });
 
     test('DayCalendar Month Changes', () => {
-        expect(calendar._month).toBe(today.getMonth());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
         const expectedNextMonth = today.getMonth() + 1 === 12 ? 0 : (today.getMonth() + 1);
         const expectedPrevMonth = today.getMonth() === 0 ? 11 : (today.getMonth() - 1);
 
@@ -257,30 +246,25 @@ describe('Calendar class Tests', () => {
             calendar._nextDay();
         }
 
-        expect(calendar._month).toBe(expectedNextMonth);
-        expect(calendar._getMonth()).toBe(expectedNextMonth);
+        expect(calendar._getCalendarMonth()).toBe(expectedNextMonth);
 
         calendar._goToCurrentDate();
-        expect(calendar._today.getDate()).toBe(today.getDate());
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._getMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
 
         for (let i = 0; i < 31; i++) {
             calendar._prevDay();
         }
 
-        expect(calendar._month).toBe(expectedPrevMonth);
-        expect(calendar._getMonth()).toBe(expectedPrevMonth);
+        expect(calendar._getCalendarMonth()).toBe(expectedPrevMonth);
 
         calendar._goToCurrentDate();
-        expect(calendar._today.getDate()).toBe(today.getDate());
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._getMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
     });
 
     test('DayCalendar Year Changes', () => {
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._getYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
         const expectedNextYear = today.getFullYear() + 1;
         const expectedPrevYear = today.getFullYear() - 1;
 
@@ -288,27 +272,23 @@ describe('Calendar class Tests', () => {
             calendar._nextDay();
         }
 
-        expect(calendar._year).toBe(expectedNextYear);
-        expect(calendar._getYear()).toBe(expectedNextYear);
+        expect(calendar._getCalendarYear()).toBe(expectedNextYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._today.getDate()).toBe(today.getDate());
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._getYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
 
         for (let i = 0; i < 365; i++) {
             calendar._prevDay();
         }
 
-        expect(calendar._year).toBe(expectedPrevYear);
-        expect(calendar._getYear()).toBe(expectedPrevYear);
+        expect(calendar._getCalendarYear()).toBe(expectedPrevYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._today.getDate()).toBe(today.getDate());
-        expect(calendar._month).toBe(today.getMonth());
-        expect(calendar._year).toBe(today.getFullYear());
-        expect(calendar._getYear()).toBe(today.getFullYear());
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
     });
 });
 

--- a/__tests__/__renderer__/classes/Calendar.js
+++ b/__tests__/__renderer__/classes/Calendar.js
@@ -44,6 +44,12 @@ describe('Calendar class Tests', () => {
         expect(calendar._getCalendarMonth()).toBe(today.getMonth());
     });
 
+    test('Calendar "today" methods return today\'s date', () => {
+        expect(calendar._getTodayDate()).toBe(today.getDate());
+        expect(calendar._getTodayYear()).toBe(today.getFullYear());
+        expect(calendar._getTodayMonth()).toBe(today.getMonth());
+    });
+
     test('Calendar internal storage correct loading', () => {
         expect(calendar._internalStore['2020-3-1-day-begin']).toBe('08:00');
         expect(calendar._getStore(1, 3, 2020, 'day-begin')).toBe('08:00');
@@ -226,12 +232,22 @@ describe('Calendar class Tests', () => {
 
         calendar._nextDay();
         expect(calendar._getCalendarDate()).toBe(expectedNextDay.getDate());
+        expect(calendar._isCalendarOnDate(expectedNextDay)).toBeTruthy();
+        expect(calendar._isCalendarOnDate(expectedPrevDay)).not.toBeTruthy();
 
         calendar._prevDay();
         expect(calendar._getCalendarDate()).toBe(today.getDate());
 
         calendar._prevDay();
         expect(calendar._getCalendarDate()).toBe(expectedPrevDay.getDate());
+        expect(calendar._isCalendarOnDate(expectedNextDay)).not.toBeTruthy();
+        expect(calendar._isCalendarOnDate(expectedPrevDay)).toBeTruthy();
+
+        calendar._goToCurrentDate();
+        expect(calendar._getCalendarDate()).toBe(today.getDate());
+
+        calendar._changeDay(1);
+        expect(calendar._getCalendarDate()).toBe(expectedNextDay.getDate());
 
         calendar._goToCurrentDate();
         expect(calendar._getCalendarDate()).toBe(today.getDate());

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#211] Adjusted preferences window size to fit the whole content
 - Fix: [#233] Fixes crash when opening the waiver for a day
 - Fix: [#229] Count Today in totals no longer causes problem in the month balance
+- Fix: [#232] Total bar not updating on day change
 - Fix: [#239] Punch button is disabled when current day is waived
 - Fix: [#240] Waiver using electron dialog instead of js confirm/alert
 - Fix: [#244] Waiver opens with filled date when clicking from calendar

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -404,6 +404,19 @@ class Calendar {
         this._draw();
     }
 
+    /**
+    * Every day change, if the calendar is showing the same month as that of the previous day,
+    * this function is called to redraw the calendar.
+    * @param {int} oldDayDate not used in MonthCalendar, just DayCalendar
+    * @param {int} oldMonthDate
+    * @param {int} oldYearDate
+    */
+    refreshOnDayChange(oldDayDate, oldMonthDate, oldYearDate) {
+        if (this._getCalendarMonth() === oldMonthDate && this._getCalendarYear() === oldYearDate) {
+            this._goToCurrentDate();
+        }
+    }
+
     /*
      * Display next month.
      */
@@ -1116,6 +1129,20 @@ class DayCalendar extends Calendar {
         if (!this._isCalendarOnDate(new Date())) {
             $('#punch-button').prop('disabled', true);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
+        }
+    }
+
+    /**
+    * Every day change, if the calendar is showing the same date as that of the previous date,
+    * this function is called to redraw the calendar.
+    * @param {int} oldDayDate
+    * @param {int} oldMonthDate
+    * @param {int} oldYearDate
+    */
+    refreshOnDayChange(oldDayDate, oldMonthDate, oldYearDate) {
+        let date = new Date(oldYearDate, oldMonthDate, oldDayDate);
+        if (this._isCalendarOnDate(date)) {
+            this._goToCurrentDate();
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -113,9 +113,12 @@ function refreshOnDayChange() {
     var today = new Date();
     if (today > launchDate)
     {
+        let oldDate = launchDate.getDate();
+        let oldMonth = launchDate.getMonth();
+        let oldYear = launchDate.getFullYear();
         launchDate = today;
         // Reload only the calendar itself to avoid a flash
-        win.webContents.executeJavaScript('calendar.redraw()');
+        win.webContents.executeJavaScript(`calendar.refreshOnDayChange(${oldDate},${oldMonth},${oldYear})`);
     }
 }
 


### PR DESCRIPTION
#### Related issue
Closes #232 

#### Context / Background
We lost the feature of automatically transitioning the day when the user leaves TTL open and the day changes when we stopped redrawing everything from scratch.

#### What change is being introduced by this PR?
First, I'm remodeling the internal counters of the day the calendar is. I'm using a member variable called _calendarDate that holds day, month and year information at once in a JS Date object.
Due to that, several methods were redone to rely on this, but class methods call getCalendarDate/Month/Year in order to reduce exposing the _calendarDate member variable.

After that, I'm adding some tests on new methods, and then implementing the fix by calling directly "_goToCurrentDate" if the MonthCalendar is set to yesterday's month, or if the DayCalendar is set to yesterday's date.

#### How will this be tested?
Tested by messing with my system clock and waiting for day changes. All changes proceeded as expected.
