### PR TITLE
Removing preference file before running user preferences tests

### DIFF
--- a/__tests__/__main__/user-preferences.js
+++ b/__tests__/__main__/user-preferences.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 const { defaultPreferences, getDefaultWidthHeight, getPreferencesFilePath, getUserPreferences, savePreferences, showDay, switchCalendarView } = require('../../js/user-preferences');
+const fs = require('fs');
 
 describe('Preferences Main', () => {
     process.env.NODE_ENV = 'test';

--- a/__tests__/__main__/user-preferences.js
+++ b/__tests__/__main__/user-preferences.js
@@ -8,7 +8,7 @@ describe('Preferences Main', () => {
     // Remove preferences file to guarantee equal execution of tests
     const preferencesFilePath = getPreferencesFilePath();
     if (fs.existsSync(preferencesFilePath))
-        fs.unlink(preferencesFilePath);
+        fs.unlinkSync(preferencesFilePath);
 
     let days = getUserPreferences();
 

--- a/__tests__/__main__/user-preferences.js
+++ b/__tests__/__main__/user-preferences.js
@@ -1,8 +1,13 @@
 /* eslint-disable no-undef */
-const { defaultPreferences, getDefaultWidthHeight, getUserPreferences, savePreferences, showDay, switchCalendarView } = require('../../js/user-preferences');
+const { defaultPreferences, getDefaultWidthHeight, getPreferencesFilePath, getUserPreferences, savePreferences, showDay, switchCalendarView } = require('../../js/user-preferences');
 
 describe('Preferences Main', () => {
     process.env.NODE_ENV = 'test';
+
+    // Remove preferences file to guarantee equal execution of tests
+    const preferencesFilePath = getPreferencesFilePath();
+    if (fs.existsSync(preferencesFilePath))
+        fs.unlink(preferencesFilePath);
 
     let days = getUserPreferences();
 

--- a/__tests__/__renderer__/user-preferences.js
+++ b/__tests__/__renderer__/user-preferences.js
@@ -5,6 +5,7 @@ const {
     getUserPreferences,
     savePreferences,
 } = require('../../js/user-preferences');
+const fs = require('fs');
 
 describe('User Preferences save/load', () => {
     process.env.NODE_ENV = 'test';

--- a/__tests__/__renderer__/user-preferences.js
+++ b/__tests__/__renderer__/user-preferences.js
@@ -13,7 +13,7 @@ describe('User Preferences save/load', () => {
     // Remove preferences file to guarantee equal execution of tests
     const preferencesFilePath = getPreferencesFilePath();
     if (fs.existsSync(preferencesFilePath))
-        fs.unlink(preferencesFilePath);
+        fs.unlinkSync(preferencesFilePath);
 
     let testPreferences = defaultPreferences;
     testPreferences['working-days-sunday'] = true;

--- a/__tests__/__renderer__/user-preferences.js
+++ b/__tests__/__renderer__/user-preferences.js
@@ -1,12 +1,18 @@
 /* eslint-disable no-undef */
 const {
     defaultPreferences,
+    getPreferencesFilePath,
     getUserPreferences,
     savePreferences,
 } = require('../../js/user-preferences');
 
 describe('User Preferences save/load', () => {
     process.env.NODE_ENV = 'test';
+
+    // Remove preferences file to guarantee equal execution of tests
+    const preferencesFilePath = getPreferencesFilePath();
+    if (fs.existsSync(preferencesFilePath))
+        fs.unlink(preferencesFilePath);
 
     let testPreferences = defaultPreferences;
     testPreferences['working-days-sunday'] = true;

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -205,6 +205,7 @@ module.exports = {
     defaultPreferences,
     getDefaultWidthHeight,
     getUserPreferences: getLoadedOrDerivedUserPreferences,
+    getPreferencesFilePath,
     savePreferences,
     showDay,
     switchCalendarView


### PR DESCRIPTION
The idea here is to remove the preference file before running tests, in the hope it will reduce the strange results we see in code coverage.