### PR TITLE
When releasing, use as tag the version of the app

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -16,6 +16,8 @@ jobs:
       run: |
         npm ci
         npm run package:mac
+    - name: set env
+      run: echo "::set-env name=APP_VERSION::$(node -p "require('./package.json').version")"
     - name: 'Packing DMG...'
       if: success()
       run: npx electron-installer-dmg 'release-builds/Time to Leave-darwin-x64/Time to Leave.app' time-to-leave --out 'packages/' --icon=assets/icon-mac.icns
@@ -27,7 +29,7 @@ jobs:
         artifacts: 'packages/**.dmg'
         artifactContentType: application/x-apple-diskimage
         draft: true
-        tag: ci
+        tag: ${{ env.APP_VERSION }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
   'Linux':
@@ -39,6 +41,8 @@ jobs:
       run: |
         npm ci
         npm run package:deb
+    - name: set env
+      run: echo "::set-env name=APP_VERSION::$(node -p "require('./package.json').version")"
     - name: 'Packing DEB...'
       if: success()
       run: npx electron-installer-debian --src 'release-builds/time-to-leave-linux-x64/' --dest 'packages/' --arch amd64 --verbose
@@ -50,7 +54,7 @@ jobs:
         artifacts: 'packages/**.deb'
         artifactContentType: application/vnd.debian.binary-package
         draft: true
-        tag: ci
+        tag: ${{ env.APP_VERSION }}
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Packing RPM'
       if: success()
@@ -65,7 +69,7 @@ jobs:
         artifacts: 'packages/**.rpm'
         artifactContentType: application/x-redhat-package-manager
         draft: true
-        tag: ci
+        tag: ${{ env.APP_VERSION }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
   'Windows':
@@ -77,6 +81,8 @@ jobs:
         run: |
           npm ci
           npm run package:win
+      - name: set env
+        run: echo "::set-env name=APP_VERSION::$(node -p "require('./package.json').version")"
       - name: 'Packing MSI, EXE, etc'
         if: success()
         run: npx electron-installer-windows --src 'release-builds\time-to-leave-win32-ia32\' --dest 'packages\' --verbose
@@ -88,7 +94,7 @@ jobs:
           artifacts: 'packages/**.msi'
           artifactContentType: application/x-msi
           draft: true
-          tag: ci
+          tag: ${{ env.APP_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Release EXE to GH'
         if: success()
@@ -98,5 +104,5 @@ jobs:
           artifacts: 'packages/**.exe'
           artifactContentType: application/x-executable
           draft: true
-          tag: ci
+          tag: ${{ env.APP_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Instead of a ci tag, use the version provided by the package.