### PR TITLE
Only run UpdateDependencies CI on main repository

### DIFF
--- a/.github/workflows/UpdateDependencies.yml
+++ b/.github/workflows/UpdateDependencies.yml
@@ -2,6 +2,7 @@ on:
   schedule:
   - cron: '30 20 * * *'
 name: Update package dependencies
+if: github.repository == 'thamara/time-to-leave'
 jobs:
   package-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes sure that people with forks don't get an e-mail when it fails nor a PR when it suceeds