### PR TITLE
Adding test for workday-waiver

### DIFF
--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-undef */
 const Store = require('electron-store');
+const fs = require('fs');
+const path = require('path');
 /* eslint-disable-next-line no-global-assign */
 $ = require('jquery');
 const { 
@@ -11,68 +13,11 @@ const {
 function prepareMockup() {
     const waivedWorkdays = new Store({ name: 'waived-workdays' });
     waivedWorkdays.clear();
-    // There gotta be a bettwe way of doing this, but I just not getting it :(
-    document.body.innerHTML = `
-        <body id="workday-waiver-window" class="common-window">
-            <div class="container">
-                <div class="header-title">
-                    Workday Waiver Manager
-                    <p class="header-help">Changes take effect when closing this window</p>
-                </div>
-
-                <section>
-                    <div class="section-title">Add Waiver</div>
-                    <form>
-                        <table>
-                            <tbody>
-                                <tr>
-                                    <td></td>
-                                    <th>Start date</th>
-                                    <td></td>
-                                    <th>End date</th>
-                                </tr>
-                                <tr>
-                                    <th>From</th>
-                                    <td><input id="start-date" type="date"></td>
-                                    <th>to</th>
-                                    <td><input id="end-date" type="date"></td>
-                                </tr>
-                                <tr>
-                                    <th>Hours</th>
-                                    <td>
-                                        <input type="text" id="hours" maxlength=8 pattern="^\\d+:\\d+$" placeholder="HH:mm" size=8>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>Reason</th>
-                                    <td colspan="3"><input id="reason" type="text" maxlength="30" size="60" placeholder="Reason for the waiver"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <br>
-                        <button class="waive-button" id="waive-button" type="button">
-                            Waive
-                        </button>
-                    </form>
-                </section>
-
-                <section>
-                    <div class="section-title">Waived workday list</div>
-                    <table id="waiver-list-table">
-                        <thead>
-                            <tr>
-                                <th>Day</th>
-                                <th>Waiver Reason</th>
-                                <th>Hours Waived</th>
-                                <th>Delete</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </section>
-            </div>
-        </body>
-    `;
+    const workdayWaiverHtml = path.join(__dirname, '../../src/workday-waiver.html');
+    const content = fs.readFileSync(workdayWaiverHtml);
+    var parser = new DOMParser();
+    var htmlDoc = parser.parseFromString(content, 'text/html');
+    document.body.innerHTML = htmlDoc.body.innerHTML;
 }
 
 function addTestWaiver(day, hours, reason) {

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -66,15 +66,16 @@ function prepareMockup() {
     `;
 }
 
-beforeAll(() => {
-    prepareMockup();
-});
-
 describe('Test Workday Waiver Window', function() {
     process.env.NODE_ENV = 'test';
+    prepareMockup();
     /* eslint-disable-next-line no-global-assign */
     $ = require('jquery');
-    const { addWaiver } = require('../../src/workday-waiver');
+    const { 
+        addWaiver,
+        setDates,
+        setHours 
+    } = require('../../src/workday-waiver');
 
     describe('Adding new waivers update the db and the page', function() {
         test('New Waiver', () => {
@@ -85,9 +86,8 @@ describe('Test Workday Waiver Window', function() {
             var tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
             $('#reason').val('some reason');
-            $('#start-date').val('2020-07-16');
-            $('#end-date').val('2020-07-16');
-            $('#hours').val('08:00');
+            setDates('2020-07-16');
+            setHours('08:00');
 
             addWaiver();
 
@@ -106,9 +106,8 @@ describe('Test Workday Waiver Window', function() {
             var tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
             $('#reason').val('some other reason');
-            $('#start-date').val('2020-07-17');
-            $('#end-date').val('2020-07-17');
-            $('#hours').val('08:00');
+            setDates('2020-07-17');
+            setHours('08:00');
 
             addWaiver();
 

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -1,5 +1,12 @@
 /* eslint-disable no-undef */
 const Store = require('electron-store');
+/* eslint-disable-next-line no-global-assign */
+$ = require('jquery');
+const { 
+    addWaiver,
+    setDates,
+    setHours 
+} = require('../../src/workday-waiver');
 
 function prepareMockup() {
     // There gotta be a bettwe way of doing this, but I just not getting it :(
@@ -69,21 +76,14 @@ function prepareMockup() {
 describe('Test Workday Waiver Window', function() {
     process.env.NODE_ENV = 'test';
     prepareMockup();
-    /* eslint-disable-next-line no-global-assign */
-    $ = require('jquery');
-    const { 
-        addWaiver,
-        setDates,
-        setHours 
-    } = require('../../src/workday-waiver');
 
     describe('Adding new waivers update the db and the page', function() {
         test('New Waiver', () => {
             const waivedWorkdays = new Store({ name: 'waived-workdays' });
             waivedWorkdays.clear();
 
-            var beforeAddingWaiver = waivedWorkdays.size;
-            var tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+            let beforeAddingWaiver = waivedWorkdays.size;
+            let tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
             $('#reason').val('some reason');
             setDates('2020-07-16');
@@ -91,19 +91,19 @@ describe('Test Workday Waiver Window', function() {
 
             addWaiver();
 
-            var afterAddingWaiver = waivedWorkdays.size;
-            var tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+            let afterAddingWaiver = waivedWorkdays.size;
+            let tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
             expect(beforeAddingWaiver).toBe(0);
             expect(tableRowsBeforeAddingWaiver).toBe(0);
             expect(afterAddingWaiver).toBe(1);
             expect(tableRowsAfterAddingWaiver).toBe(1);
-
         });
+        
         test('One more Waiver', () => {
             const waivedWorkdays = new Store({ name: 'waived-workdays' });
-            var beforeAddingWaiver = waivedWorkdays.size;
-            var tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+            let beforeAddingWaiver = waivedWorkdays.size;
+            let tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
             $('#reason').val('some other reason');
             setDates('2020-07-17');
@@ -111,8 +111,8 @@ describe('Test Workday Waiver Window', function() {
 
             addWaiver();
 
-            var afterAddingWaiver = waivedWorkdays.size;
-            var tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+            let afterAddingWaiver = waivedWorkdays.size;
+            let tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
             expect(beforeAddingWaiver).toBe(1);
             expect(tableRowsBeforeAddingWaiver).toBe(1);

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -6,9 +6,11 @@ const path = require('path');
 $ = require('jquery');
 const { 
     addWaiver,
+    populateList,
     setDates,
     setHours 
 } = require('../../src/workday-waiver');
+const console = require('console');
 
 function prepareMockup() {
     const waivedWorkdays = new Store({ name: 'waived-workdays' });
@@ -18,6 +20,7 @@ function prepareMockup() {
     var parser = new DOMParser();
     var htmlDoc = parser.parseFromString(content, 'text/html');
     document.body.innerHTML = htmlDoc.body.innerHTML;
+    populateList();
 }
 
 function addTestWaiver(day, hours, reason) {
@@ -46,11 +49,17 @@ describe('Test Workday Waiver Window', function() {
             testWaiverCount(1);
         });
 
-        test('Three Waivers', () => {
+        test('One + two Waivers', () => {
             prepareMockup();
-
+            //Start with none
             testWaiverCount(0);
+
+            // Add one waiver and update the table on the page
             addTestWaiver('2020-07-16', '08:00', 'some reason');
+            populateList();
+            testWaiverCount(1);
+
+            // Add two more waiver
             addTestWaiver('2020-07-20', '08:00', 'some other reason');
             addTestWaiver('2020-07-21', '08:00', 'yet another reason');
             testWaiverCount(3);

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -1,0 +1,124 @@
+/* eslint-disable no-undef */
+const Store = require('electron-store');
+
+function prepareMockup() {
+    // There gotta be a bettwe way of doing this, but I just not getting it :(
+    document.body.innerHTML = `
+        <body id="workday-waiver-window" class="common-window">
+            <div class="container">
+                <div class="header-title">
+                    Workday Waiver Manager
+                    <p class="header-help">Changes take effect when closing this window</p>
+                </div>
+
+                <section>
+                    <div class="section-title">Add Waiver</div>
+                    <form>
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td></td>
+                                    <th>Start date</th>
+                                    <td></td>
+                                    <th>End date</th>
+                                </tr>
+                                <tr>
+                                    <th>From</th>
+                                    <td><input id="start-date" type="date"></td>
+                                    <th>to</th>
+                                    <td><input id="end-date" type="date"></td>
+                                </tr>
+                                <tr>
+                                    <th>Hours</th>
+                                    <td>
+                                        <input type="text" id="hours" maxlength=8 pattern="^\\d+:\\d+$" placeholder="HH:mm" size=8>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>Reason</th>
+                                    <td colspan="3"><input id="reason" type="text" maxlength="30" size="60" placeholder="Reason for the waiver"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <br>
+                        <button class="waive-button" id="waive-button" type="button">
+                            Waive
+                        </button>
+                    </form>
+                </section>
+
+                <section>
+                    <div class="section-title">Waived workday list</div>
+                    <table id="waiver-list-table">
+                        <thead>
+                            <tr>
+                                <th>Day</th>
+                                <th>Waiver Reason</th>
+                                <th>Hours Waived</th>
+                                <th>Delete</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </section>
+            </div>
+        </body>
+    `;
+}
+
+beforeAll(() => {
+    prepareMockup();
+});
+
+describe('Test Workday Waiver Window', function() {
+    process.env.NODE_ENV = 'test';
+    /* eslint-disable-next-line no-global-assign */
+    $ = require('jquery');
+    const { addWaiver } = require('../../src/workday-waiver');
+
+    describe('Adding new waivers update the db and the page', function() {
+        test('New Waiver', () => {
+            const waivedWorkdays = new Store({ name: 'waived-workdays' });
+            waivedWorkdays.clear();
+
+            var beforeAddingWaiver = waivedWorkdays.size;
+            var tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+
+            $('#reason').val('some reason');
+            $('#start-date').val('2020-07-16');
+            $('#end-date').val('2020-07-16');
+            $('#hours').val('08:00');
+
+            addWaiver();
+
+            var afterAddingWaiver = waivedWorkdays.size;
+            var tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+
+            expect(beforeAddingWaiver).toBe(0);
+            expect(tableRowsBeforeAddingWaiver).toBe(0);
+            expect(afterAddingWaiver).toBe(1);
+            expect(tableRowsAfterAddingWaiver).toBe(1);
+
+        });
+        test('One more Waiver', () => {
+            const waivedWorkdays = new Store({ name: 'waived-workdays' });
+            var beforeAddingWaiver = waivedWorkdays.size;
+            var tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+
+            $('#reason').val('some other reason');
+            $('#start-date').val('2020-07-17');
+            $('#end-date').val('2020-07-17');
+            $('#hours').val('08:00');
+
+            addWaiver();
+
+            var afterAddingWaiver = waivedWorkdays.size;
+            var tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
+
+            expect(beforeAddingWaiver).toBe(1);
+            expect(tableRowsBeforeAddingWaiver).toBe(1);
+            expect(afterAddingWaiver).toBe(2);
+            expect(tableRowsAfterAddingWaiver).toBe(2);
+        });
+    });
+});

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -9,6 +9,8 @@ const {
 } = require('../../src/workday-waiver');
 
 function prepareMockup() {
+    const waivedWorkdays = new Store({ name: 'waived-workdays' });
+    waivedWorkdays.clear();
     // There gotta be a bettwe way of doing this, but I just not getting it :(
     document.body.innerHTML = `
         <body id="workday-waiver-window" class="common-window">
@@ -73,51 +75,40 @@ function prepareMockup() {
     `;
 }
 
+function addTestWaiver(day, hours, reason) {
+    $('#reason').val(reason);
+    setDates(day);
+    setHours(hours);
+
+    addWaiver();
+}
+
+function testWaiverCount(expected) {
+    const waivedWorkdays = new Store({ name: 'waived-workdays' });
+    expect(waivedWorkdays.size).toBe(expected);
+    expect($('#waiver-list-table tbody')[0].rows.length).toBe(expected);
+}
+
 describe('Test Workday Waiver Window', function() {
     process.env.NODE_ENV = 'test';
-    prepareMockup();
 
     describe('Adding new waivers update the db and the page', function() {
-        test('New Waiver', () => {
-            const waivedWorkdays = new Store({ name: 'waived-workdays' });
-            waivedWorkdays.clear();
+        test('One Waiver', () => {
+            prepareMockup();
 
-            let beforeAddingWaiver = waivedWorkdays.size;
-            let tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
-
-            $('#reason').val('some reason');
-            setDates('2020-07-16');
-            setHours('08:00');
-
-            addWaiver();
-
-            let afterAddingWaiver = waivedWorkdays.size;
-            let tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
-
-            expect(beforeAddingWaiver).toBe(0);
-            expect(tableRowsBeforeAddingWaiver).toBe(0);
-            expect(afterAddingWaiver).toBe(1);
-            expect(tableRowsAfterAddingWaiver).toBe(1);
+            testWaiverCount(0);
+            addTestWaiver('2020-07-16', '08:00', 'some reason');
+            testWaiverCount(1);
         });
-        
-        test('One more Waiver', () => {
-            const waivedWorkdays = new Store({ name: 'waived-workdays' });
-            let beforeAddingWaiver = waivedWorkdays.size;
-            let tableRowsBeforeAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
 
-            $('#reason').val('some other reason');
-            setDates('2020-07-17');
-            setHours('08:00');
+        test('Three Waivers', () => {
+            prepareMockup();
 
-            addWaiver();
-
-            let afterAddingWaiver = waivedWorkdays.size;
-            let tableRowsAfterAddingWaiver = $('#waiver-list-table tbody')[0].rows.length;
-
-            expect(beforeAddingWaiver).toBe(1);
-            expect(tableRowsBeforeAddingWaiver).toBe(1);
-            expect(afterAddingWaiver).toBe(2);
-            expect(tableRowsAfterAddingWaiver).toBe(2);
+            testWaiverCount(0);
+            addTestWaiver('2020-07-16', '08:00', 'some reason');
+            addTestWaiver('2020-07-20', '08:00', 'some other reason');
+            addTestWaiver('2020-07-21', '08:00', 'yet another reason');
+            testWaiverCount(3);
         });
     });
 });

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -344,3 +344,7 @@ $(() => {
 
     bindDevToolsShortcut(window);
 });
+
+module.exports = {
+    addWaiver
+};

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -47,6 +47,7 @@ function addRowToListTable(day, reason, hours) {
 }
 
 function populateList() {
+    clearWaiverList();
     for (const elem of waiverStore) {
         let date = elem[0],
             reason = elem[1]['reason'],
@@ -247,7 +248,15 @@ function addHolidayToList(day, reason, workingDay, conflicts) {
 }
 
 function clearHolidayTable() {
-    let table = $('#holiday-list-table tbody')[0];
+    clearTable('holiday-list-table');
+}
+
+function clearWaiverList() {
+    clearTable('waiver-list-table');
+}
+
+function clearTable(id) {
+    let table = $(`#${id} tbody`)[0];
     // Clear all rows before adding new ones
     while (table.rows.length >= 1) {
         table.rows[0].remove();
@@ -347,6 +356,7 @@ $(() => {
 
 module.exports = {
     addWaiver,
+    populateList,
     setDates,
     setHours
 };

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -346,5 +346,7 @@ $(() => {
 });
 
 module.exports = {
-    addWaiver
+    addWaiver,
+    setDates,
+    setHours
 };


### PR DESCRIPTION
There might be some better way of loading the HTML, but I could not find one that works. Ideally, we would just source the HTML for the workday waiver.
But I'm already glad this allows us to test and improve the coverage of the project.