### PR TITLE
Fix date when moving to next/prev month

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
 1.5.6 (in development)
 ------------------------------------------------------------------------
+- Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
 
 Who built 1.5.6:
+- thamara
 
 
 1.5.5

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -447,6 +447,9 @@ class Calendar {
      * Display next month.
      */
     _nextMonth() {
+        // Set day as 1 to avoid problem when the current day on the _calendar_date
+        // is not a day in the next month day's range
+        this._calendarDate.setDate(1);
         this._calendarDate.setMonth(this._getCalendarMonth() + 1);
         this.redraw();
     }
@@ -455,6 +458,9 @@ class Calendar {
      * Display previous month.
      */
     _prevMonth() {
+        // Set day as 1 to avoid problem when the current day on the _calendar_date
+        // is not a day in the prev month day's range
+        this._calendarDate.setDate(1);
         this._calendarDate.setMonth(this._getCalendarMonth() - 1);
         this.redraw();
     }


### PR DESCRIPTION
#### Context / Background
When setting the month of a Javascript date, it will consider the current day set. For example: if we are currently on day 31 of month 0 (january), and we set month(1), for February, because February has only 28 days, it will consider 31 to be 3 days of the next month, leaving the date as march 2.

#### How will this be tested?
Manual tests and unit tests passes.
