### PR TITLE
Closes #333: Adding start date for overall balance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 - Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
 - Fix: [#334] Improving performance of overall balance calculation and fixing balance target date after month change
 - Enhancement: [#328] Swap position for overall and month balance on day view
+- Enhancement: [#333] Adding start date for overall balance on preferences
 
 Who built 1.5.6:
 - thamara

--- a/js/time-balance.js
+++ b/js/time-balance.js
@@ -12,8 +12,15 @@ const waivedWorkdays = new Store({ name: 'waived-workdays' });
 
 function getFirstInputInDb() {
     var inputs = [];
+    const startDateStr = _getOverallBalanceStartDate();
+    let [startYear, startMonth, startDay] = startDateStr.split('-');
+    const startDate = new Date(startYear, startMonth - 1, startDay);
+
     for (let value of store) {
-        inputs.push(value[0]);
+        let [year, month, day] = value[0].split('-');
+        if (new Date(year, month, day) >= startDate) {
+            inputs.push(value[0]);
+        }
     }
     inputs.sort(function(a, b) {
         var [aYear, aMonth, aDay] = a.split('-');
@@ -40,6 +47,11 @@ function _getDateFromWaivedWorkdayDb(dbKey) {
     // and has the month described by 1-12 (jan - dec)
     const [year, month, day] = dbKey.split('-');
     return new Date(year, month-1, day);
+}
+
+function _getOverallBalanceStartDate() {
+    const savedPreferences = getUserPreferences();
+    return savedPreferences['overall-balance-start-date'];
 }
 
 function _getHoursPerDay() {

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -14,6 +14,7 @@ const defaultPreferences = {
     'notifications-interval': '5',
     'start-at-login': false,
     'theme': 'light',
+    'overall-balance-start-date' : '2019-01-01',
     'update-remind-me-after' : '2019-01-01',
     'working-days-monday': true,
     'working-days-tuesday': true,

--- a/main.js
+++ b/main.js
@@ -207,7 +207,7 @@ function createWindow() {
                       
                         const htmlPath = path.join('file://', __dirname, 'src/preferences.html');
                         prefWindow = new BrowserWindow({ width: 400,
-                            height: 500,
+                            height: 540,
                             parent: win,
                             resizable: true,
                             icon: iconpath,

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -70,6 +70,10 @@
                 <p>Count Today in Totals</p>
                 <label id='count-today' class="switch"><input type="checkbox" name="count-today"><span class="slider round"></span></label>
             </div>
+            <div class="flex-box mb-2">
+                <p>Overall Balance Start Date</p>
+                <label id='overall-balance-start-date'><input type="date" name="overall-balance-start-date"></label>
+            </div>
             <div class="flex-box">
                 <p>Close button should minimize to tray</p>
                 <label id='close-to-tray' class="switch"><input type="checkbox" name="close-to-tray"><span class="slider round"></span></label>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -34,7 +34,7 @@ $(() => {
         }
     });
 
-    $('input[type="number"]').change(function() {
+    $('input[type="number"], input[type="date"]').change(function() {
         preferences[this.name] = this.value;
         ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
     });
@@ -58,7 +58,7 @@ $(() => {
                 input.prop('checked', usersStyles[name]);
             }
             preferences[name] = input.prop('checked');
-        } else if (['text', 'number'].indexOf(input.attr('type')) > -1) {
+        } else if (['text', 'number', 'date'].indexOf(input.attr('type')) > -1) {
             if (name in usersStyles) {
                 input.val(usersStyles[name]);
             }


### PR DESCRIPTION
#### Related issue
Closes #333 

#### Context / Background
Adds a new option on Preferences to set the start date for overall balance calculation.
Useful when you just want a clean slate :)

#### What change is being introduced by this PR?
Adds start date option on Preferences.
Changes calculation to rely on this.

#### How will this be tested?
Manual tests.

![image](https://user-images.githubusercontent.com/37311270/89742694-76a6ef00-da72-11ea-9df7-89413ecfc994.png)

