### PR TITLE
Only run UpdateDependencies on main repository

### DIFF
--- a/.github/workflows/UpdateDependencies.yml
+++ b/.github/workflows/UpdateDependencies.yml
@@ -2,6 +2,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 name: Update package dependencies
+if: github.repository == 'thamara/time-to-leave'
 jobs:
   package-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to prevent it from running on forks 
