### PR TITLE
Tray settings when minimized / closed

### DIFF
--- a/js/main-window.js
+++ b/js/main-window.js
@@ -98,7 +98,7 @@ function createWindow()
 
     mainWindow.on('minimize', (event) =>
     {
-        let savedPreferences = getUserPreferences();
+        const savedPreferences = getUserPreferences();
         if (savedPreferences['tray-allowed'])
         {
             event.preventDefault();

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -96,7 +96,7 @@ function createWindow()
         tray.popUpContextMenu(contextMenu);
     });
 
-    mainWindow.on('minimize', () =>
+    mainWindow.on('minimize', (event) =>
     {
         event.preventDefault();
         mainWindow.hide();

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -106,7 +106,7 @@ function createWindow()
     mainWindow.on('close', (event) =>
     {
         let savedPreferences = getUserPreferences();
-        if (!app.isQuitting && savedPreferences['close-to-tray'])
+        if (!app.isQuitting && savedPreferences['tray-allowed'])
         {
             event.preventDefault();
             mainWindow.hide();

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -98,8 +98,12 @@ function createWindow()
 
     mainWindow.on('minimize', (event) =>
     {
-        event.preventDefault();
-        mainWindow.hide();
+        let savedPreferences = getUserPreferences();
+        if (savedPreferences['tray-allowed'])
+        {
+            event.preventDefault();
+            mainWindow.hide();
+        }
     });
 
     // Emitted when the window is closed.

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -6,7 +6,7 @@ const { isValidTheme } = require('./themes.js');
 
 const defaultPreferences = {
     'count-today': false,
-    'close-to-tray': true,
+    'tray-allowed': true,
     'hide-non-working-days': false,
     'hours-per-day': '08:00',
     'notification': true,
@@ -111,7 +111,7 @@ function initPreferencesFileIfNotExistsOrInvalid() {
         }
         // Handle Boolean Inputs
         case 'count-today':
-        case 'close-to-tray':
+        case 'tray-allowed':
         case 'hide-non-working-days':
         case 'notification':
         case 'repetition':

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -75,8 +75,8 @@
                 <label id='overall-balance-start-date'><input type="date" name="overall-balance-start-date"></label>
             </div>
             <div class="flex-box">
-                <p>Close button should minimize to tray</p>
-                <label id='close-to-tray' class="switch"><input type="checkbox" name="close-to-tray"><span class="slider round"></span></label>
+                <p>Allow TTL to be displayed on the tray</p>
+                <label id='tray-allowed' class="switch"><input type="checkbox" name="tray-allowed"><span class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Themes</p>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -40,14 +40,11 @@
             </div>
             <div class="flex-box">
                 <p>Hide non-working days (Month View)</p>
-                <label id='non-working-label' class="switch"><input type="checkbox" name="hide-non-working-days"><span
-                        class="slider round"></span></label>
+                <label id='non-working-label' class="switch"><input type="checkbox" name="hide-non-working-days"><span class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Hours per day</p>
-                <input type="text" name="hours-per-day" id="hours-per-day" maxlength=5
-                    pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" placeholder="HH:mm" value="08:00" size=5 required
-                    oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
+                <input type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" placeholder="HH:mm" value="08:00" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
             </div>
         </section>
 
@@ -55,37 +52,31 @@
             <div class="section-title">App Behavior</div>
             <div class="flex-box">
                 <p>Notification</p>
-                <label class="switch"><input type="checkbox" id="notification" name="notification"><span
-                        class="slider round"></span></label>
+                <label class="switch"><input type="checkbox" id="notification" name="notification"><span class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Allow recurring notifications</p>
-                <label class="switch"><input type="checkbox" id="repetition" name="repetition"><span
-                        class="slider round"></span></label>
+                <label class="switch"><input type="checkbox" id="repetition" name="repetition"><span class="slider round"></span></label>
             </div>
             <div class="flex-box mb-2">
                 <p>Minutes between notifications</p>
-                <input type="number" name="notifications-interval" id="notifications-interval" min="1" max="30"
-                    value="5" required onblur="this.value = this.checkValidity() ? this.value : 5">
+                <input type="number" name="notifications-interval" id="notifications-interval" min="1" max="30" value="5" required onblur="this.value = this.checkValidity() ? this.value : 5">
             </div>
             <div class="flex-box">
                 <p>Start on Login</p>
-                <label id='start-at-login' class="switch"><input type="checkbox" name="start-at-login"><span
-                        class="slider round"></span></label>
+                <label id='start-at-login' class="switch"><input type="checkbox" name="start-at-login"><span class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Count Today in Totals</p>
-                <label id='count-today' class="switch"><input type="checkbox" name="count-today"><span
-                        class="slider round"></span></label>
+                <label id='count-today' class="switch"><input type="checkbox" name="count-today"><span class="slider round"></span></label>
             </div>
             <div class="flex-box mb-2">
                 <p>Overall Balance Start Date</p>
                 <label id='overall-balance-start-date'><input type="date" name="overall-balance-start-date"></label>
             </div>
             <div class="flex-box">
-                <p>Allow TTL to be displayed on the tray</p>
-                <label id=tray-allowed' class="switch"><input type="checkbox" name="close-to-tray"><span
-                        class="slider round"></span></label>
+                <p>Close button should minimize to tray</p>
+                <label id='close-to-tray' class="switch"><input type="checkbox" name="close-to-tray"><span class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Themes</p>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -40,11 +40,14 @@
             </div>
             <div class="flex-box">
                 <p>Hide non-working days (Month View)</p>
-                <label id='non-working-label' class="switch"><input type="checkbox" name="hide-non-working-days"><span class="slider round"></span></label>
+                <label id='non-working-label' class="switch"><input type="checkbox" name="hide-non-working-days"><span
+                        class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Hours per day</p>
-                <input type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" placeholder="HH:mm" value="08:00" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
+                <input type="text" name="hours-per-day" id="hours-per-day" maxlength=5
+                    pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" placeholder="HH:mm" value="08:00" size=5 required
+                    oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
             </div>
         </section>
 
@@ -52,31 +55,37 @@
             <div class="section-title">App Behavior</div>
             <div class="flex-box">
                 <p>Notification</p>
-                <label class="switch"><input type="checkbox" id="notification" name="notification"><span class="slider round"></span></label>
+                <label class="switch"><input type="checkbox" id="notification" name="notification"><span
+                        class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Allow recurring notifications</p>
-                <label class="switch"><input type="checkbox" id="repetition" name="repetition"><span class="slider round"></span></label>
+                <label class="switch"><input type="checkbox" id="repetition" name="repetition"><span
+                        class="slider round"></span></label>
             </div>
             <div class="flex-box mb-2">
                 <p>Minutes between notifications</p>
-                <input type="number" name="notifications-interval" id="notifications-interval" min="1" max="30" value="5" required onblur="this.value = this.checkValidity() ? this.value : 5">
+                <input type="number" name="notifications-interval" id="notifications-interval" min="1" max="30"
+                    value="5" required onblur="this.value = this.checkValidity() ? this.value : 5">
             </div>
             <div class="flex-box">
                 <p>Start on Login</p>
-                <label id='start-at-login' class="switch"><input type="checkbox" name="start-at-login"><span class="slider round"></span></label>
+                <label id='start-at-login' class="switch"><input type="checkbox" name="start-at-login"><span
+                        class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Count Today in Totals</p>
-                <label id='count-today' class="switch"><input type="checkbox" name="count-today"><span class="slider round"></span></label>
+                <label id='count-today' class="switch"><input type="checkbox" name="count-today"><span
+                        class="slider round"></span></label>
             </div>
             <div class="flex-box mb-2">
                 <p>Overall Balance Start Date</p>
                 <label id='overall-balance-start-date'><input type="date" name="overall-balance-start-date"></label>
             </div>
             <div class="flex-box">
-                <p>Close button should minimize to tray</p>
-                <label id='close-to-tray' class="switch"><input type="checkbox" name="close-to-tray"><span class="slider round"></span></label>
+                <p>Allow TTL to be displayed on the tray</p>
+                <label id=tray-allowed' class="switch"><input type="checkbox" name="close-to-tray"><span
+                        class="slider round"></span></label>
             </div>
             <div class="flex-box">
                 <p>Themes</p>


### PR DESCRIPTION
#### Related issue
Closes #350
#### Context / Background

I tried to solve problem stated in the #350. 

#### What change is being introduced by this PR?
At first, `minimize` event was throwing error. The `event` variable was missing so I added one to callback to fix that.
`close-to-tray` is now `tray-allowed`. It affects both `minimize` event as well `close`. If the setting is toggled on, the program window hides to tray when minimized or closed. If the setting is toggled off,  the window goes to the taskbar when minimized and just closes when close button is clicked.


#### How will this be tested?
I did a manual test at Windows and it works.