### PR TITLE
Add system default to auto-detect if dark or light mode is set

### DIFF
--- a/__tests__/__renderer__/themes.js
+++ b/__tests__/__renderer__/themes.js
@@ -9,6 +9,7 @@ describe('Theme Functions', function() {
 
     describe('isValidTheme()', function() {
         test('should validate', () => {
+            expect(isValidTheme('system-default')).toBeTruthy();
             expect(isValidTheme('light')).toBeTruthy();
             expect(isValidTheme('dark')).toBeTruthy();
             expect(isValidTheme('cadent-star')).toBeTruthy();
@@ -24,6 +25,7 @@ describe('Theme Functions', function() {
 
     describe('applyTheme()', function() {
         test('should apply', () => {
+            expect(applyTheme('system-default')).toBeTruthy();
             expect(applyTheme('light')).toBeTruthy();
             expect(applyTheme('dark')).toBeTruthy();
             expect(applyTheme('cadent-star')).toBeTruthy();

--- a/js/themes.js
+++ b/js/themes.js
@@ -1,4 +1,4 @@
-const themeOptions = ['light', 'dark', 'cadent-star'];
+const themeOptions = ['system-default', 'light', 'dark', 'cadent-star'];
 
 /**
  * Checks whether the provided theme is valid. This list should be reflected in the `styles.css` file.
@@ -17,6 +17,10 @@ function isValidTheme(testTheme) {
 function applyTheme(theme) {
     if (isValidTheme(theme) === false) {
         return false;
+    }
+
+    if (theme === 'system-default') {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
 
     // Applies to the Primary view

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -13,7 +13,7 @@ const defaultPreferences = {
     'repetition': true,
     'notifications-interval': '5',
     'start-at-login': false,
-    'theme': 'light',
+    'theme': 'system-default',
     'overall-balance-start-date' : '2019-01-01',
     'update-remind-me-after' : '2019-01-01',
     'working-days-monday': true,

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -81,7 +81,7 @@
             <div class="flex-box">
                 <p>Themes</p>
                 <select id="theme" name="theme">
-                    <option value="system-default" selected>System Default (experimental)</option>
+                    <option value="system-default" selected>System Default</option>
                     <option value="light">Light</option>
                     <option value="dark">Dark</option>
                     <option value="cadent-star">Cadent Star</option>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -81,7 +81,8 @@
             <div class="flex-box">
                 <p>Themes</p>
                 <select id="theme" name="theme">
-                    <option value="light" selected>Light</option>
+                    <option value="system-default" selected>System Default (experimental)</option>
+                    <option value="light">Light</option>
                     <option value="dark">Dark</option>
                     <option value="cadent-star">Cadent Star</option>
                 </select>


### PR DESCRIPTION
Add "system-default" theme which auto-detects if the a person has their system set to prefer dark or light mode and set the default theme to it.

Related to #69 
