### PR TITLE
replaced key string generation with single function

### DIFF
--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -18,7 +18,7 @@ const {
     displayWaiverWindow
 } = require('../workday-waiver-aux.js');
 const { computeAllTimeBalanceUntilAsync } = require('../time-balance.js');
-const { generateKey } = require('../import-export.js');
+const { generateKey } = require('../date-db-formatter');
 
 // Global values for calendar
 const store = new Store();

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -18,6 +18,7 @@ const {
     displayWaiverWindow
 } = require('../workday-waiver-aux.js');
 const { computeAllTimeBalanceUntilAsync } = require('../time-balance.js');
+const { generateKey } = require('../import-export.js');
 
 // Global values for calendar
 const store = new Store();
@@ -134,8 +135,7 @@ class Calendar {
      * Gets value from internal store.
      */
     _getStore(day, month, year, key) {
-        var idTag = year + '-' + month + '-' + day + '-' + key;
-
+        var idTag = generateKey(year, month, day, key);
         return this._internalStore[idTag];
     }
 
@@ -143,7 +143,7 @@ class Calendar {
      * Saves value on store and updates internal store.
      */
     _setStore(day, month, year, key, newValue) {
-        var idTag = year + '-' + month + '-' + day + '-' + key;
+        var idTag = generateKey(year, month, day, key);
 
         this._internalStore[idTag] = newValue;
         store.set(idTag, newValue);
@@ -153,7 +153,7 @@ class Calendar {
      * Removes value from store and from internal store.
      */
     _removeStore(day, month, year, key) {
-        var idTag = year + '-' + month + '-' + day + '-' + key;
+        var idTag = generateKey(year, month, day, key);
 
         this._internalStore[idTag] = undefined;
         store.delete(idTag);
@@ -181,7 +181,7 @@ class Calendar {
      * Returns the time input HTML code of a date.
      */
     static _getInputCode(year, month, day, type) {
-        var idTag = year + '-' + month + '-' + day + '-' + type;
+        var idTag = generateKey(year, month, day, type);
 
         return '<input type="time" id="' + idTag + '"' +
                (type.endsWith('total') ? ' disabled' : '') +
@@ -193,7 +193,7 @@ class Calendar {
      * Returns the total field HTML code of a date.
      */
     static _getTotalCode(year, month, day, type) {
-        var idTag = year + '-' + month + '-' + day + '-' + type;
+        var idTag = generateKey(year, month, day, type);
 
         return '<input type="text" class="total-input" id="' +
                idTag + '" size="5"' +
@@ -246,7 +246,7 @@ class Calendar {
             weekDay = currentDay.getDay(),
             today = new Date(),
             isToday = (today.getDate() === day && today.getMonth() === month && today.getFullYear() === year),
-            trID = ('tr-' + year + '-' + month + '-' + day);
+            trID = ('tr-' + generateKey(year, month, day));
 
         if (!this._showDay(year, month, day)) {
             if (!this._getHideNonWorkingDays()) {
@@ -594,7 +594,7 @@ class Calendar {
             return;
         }
 
-        var dayStr = year + '-' + month + '-' + day + '-';
+        var dayStr = generateKey(year, month, day) + '-';
         var entry = '';
         if ($('#' + dayStr + 'day-end').val() === '') {
             entry = 'day-end';
@@ -820,7 +820,7 @@ class Calendar {
     * Updates the DB with the information of computed total lunch time and day time.
     */
     _updateTimeDay(year, month, day, key, newValue) {
-        var baseStr = year + '-' + month + '-' + day + '-';
+        var baseStr = generateKey(year, month, day) + '-';
 
         this._updateDbEntry(year, month, day, key, newValue);
 
@@ -884,7 +884,7 @@ class Calendar {
     * Toggles the color of a row based on input error.
     */
     _colorErrorLine(year, month, day, dayBegin, lunchBegin, lunchEnd, dayEnd) {
-        var trID = ('#tr-' + year + '-' + month + '-' + day);
+        var trID = ('#tr-' + generateKey(year, month, day));
         $(trID).toggleClass('error-tr', this._hasInputError(dayBegin, lunchBegin, lunchEnd, dayEnd));
     }
 

--- a/js/classes/FixedDayCalendar.js
+++ b/js/classes/FixedDayCalendar.js
@@ -8,6 +8,7 @@ const {
 } = require('../time-math.js');
 const { getDateStr, getMonthLength } = require('../date-aux.js');
 const { Calendar } = require('./Calendar.js');
+const { generateKey } = require('../import-export');
 
 class FixedDayCalendar extends Calendar {
     /**
@@ -127,7 +128,7 @@ class FixedDayCalendar extends Calendar {
     _getInputsRowCode(year, month, day) {
         let today = new Date(),
             isToday = (today.getDate() === day && today.getMonth() === month && today.getFullYear() === year),
-            trID = ('tr-' + year + '-' + month + '-' + day);
+            trID = ('tr-' + generateKey(year, month, day));
 
         if (!this._showDay(year, month, day)) {
             return '<div class="today-non-working" id="' + trID + '">' +

--- a/js/classes/FixedDayCalendar.js
+++ b/js/classes/FixedDayCalendar.js
@@ -8,7 +8,7 @@ const {
 } = require('../time-math.js');
 const { getDateStr, getMonthLength } = require('../date-aux.js');
 const { Calendar } = require('./Calendar.js');
-const { generateKey } = require('../import-export');
+const { generateKey } = require('../date-db-formatter');
 
 class FixedDayCalendar extends Calendar {
     /**

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -17,6 +17,7 @@ const {
 } = require('../workday-waiver-aux.js');
 const { showDialog } = require('../window-aux.js');
 const { Calendar } = require('./Calendar.js');
+const { generateKey } = require('../import-export');
 
 // Global values for calendar
 const flexibleStore = new Store({name: 'flexible-store'});
@@ -130,7 +131,7 @@ class FlexibleMonthCalendar extends Calendar {
             weekDay = currentDay.getDay();
         let today = new Date(),
             isToday = (today.getDate() === day && today.getMonth() === month && today.getFullYear() === year),
-            dateKey = (year + '-' + month + '-' + day);
+            dateKey = generateKey(year, month, day);
 
         if (!this._showDay(year, month, day)) {
             return '<div><div class="weekday">' + this._options.dayAbbrs[weekDay] + '</div>' +
@@ -340,7 +341,7 @@ class FlexibleMonthCalendar extends Calendar {
         }
 
         const value = hourMinToHourFormatted(hour, min);
-        const key = year + '-' + month + '-' + day;
+        const key = generateKey(year, month, day);
         const inputs = $('#' + key + ' input[type="time"]');
         for (const element of inputs) {
             if ($(element).val().length === 0) {

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -17,7 +17,7 @@ const {
 } = require('../workday-waiver-aux.js');
 const { showDialog } = require('../window-aux.js');
 const { Calendar } = require('./Calendar.js');
-const { generateKey } = require('../import-export');
+const { generateKey } = require('../date-db-formatter');
 
 // Global values for calendar
 const flexibleStore = new Store({name: 'flexible-store'});

--- a/js/date-db-formatter.js
+++ b/js/date-db-formatter.js
@@ -1,0 +1,8 @@
+function generateKey(year, month, day, key) {
+    const dbKey = year + '-' + month + '-' + day;
+    return key === undefined ? dbKey : dbKey + '-' + key;
+}
+
+module.exports = {
+    generateKey,
+};

--- a/js/import-export.js
+++ b/js/import-export.js
@@ -21,7 +21,7 @@ function _getRegularEntries() {
             const [year, month, day, stage, step] = key.split('-');
             //The main database uses a JS-based month index (0-11)
             //So we need to adjust it to human month index (1-12)
-            const date = year + '-' + (parseInt(month) + 1) + '-' + day;
+            const date = generateKey(year, (parseInt(month) - 1), day);
             const data = stage + '-' + step;
 
             output.push({'type': 'regular', 'date': date, 'data': data, 'hours': value});
@@ -46,7 +46,7 @@ function _getFlexibleEntries() {
         const [year, month, day] = key.split('-');
         //The main database uses a JS-based month index (0-11)
         //So we need to adjust it to human month index (1-12)
-        const date = year + '-' + (parseInt(month) + 1) + '-' + day;
+        const date = generateKey(year, (parseInt(month) - 1), day);
 
         output.push({'type': 'flexible', 'date': date, 'values': value.values});
     }
@@ -133,7 +133,7 @@ function importDatabaseFromFile(filename) {
                 let [year, month, day] = entry.date.split('-');
                 //The main database uses a JS-based month index (0-11)
                 //So we need to adjust it from human month index (1-12)
-                let date = year + '-' + (parseInt(month) - 1) + '-' + day;
+                let date = generateKey(year, (parseInt(month) - 1), day);
                 if (entry.type === 'flexible') {
                     const flexibleEntry = { values: entry.values };
                     flexibleStore.set(date, flexibleEntry);
@@ -164,7 +164,7 @@ function migrateFixedDbToFlexible() {
 
         const [year, month, day, /*stage*/, step] = key.split('-');
         if (['begin', 'end'].indexOf(step) !== -1) {
-            const date = year + '-' + month + '-' + day;
+            const date = generateKey(year, month, day);
             if (regularEntryArray[date] === undefined) {
                 regularEntryArray[date] = { values: []};
             }
@@ -183,9 +183,15 @@ function migrateFixedDbToFlexible() {
     return true;
 }
 
+function generateKey(year, month, day, key) {
+    const dbKey = year + '-' + month + '-' + day;
+    return key === undefined ? dbKey : dbKey + '-' + key;
+}
+
 module.exports = {
     importDatabaseFromFile,
     exportDatabaseToFile,
     migrateFixedDbToFlexible,
-    validEntry
+    validEntry,
+    generateKey
 };

--- a/js/import-export.js
+++ b/js/import-export.js
@@ -24,7 +24,7 @@ function _getRegularEntries() {
             const [year, month, day, stage, step] = key.split('-');
             //The main database uses a JS-based month index (0-11)
             //So we need to adjust it to human month index (1-12)
-            const date = generateKey(year, (parseInt(month) - 1), day);
+            const date = generateKey(year, (parseInt(month) + 1), day);
             const data = stage + '-' + step;
 
             output.push({'type': 'regular', 'date': date, 'data': data, 'hours': value});
@@ -135,7 +135,7 @@ function importDatabaseFromFile(filename) {
                 let [year, month, day] = entry.date.split('-');
                 //The main database uses a JS-based month index (0-11)
                 //So we need to adjust it from human month index (1-12)
-                let date = generateKey(year, (parseInt(month) + 1), day);
+                let date = generateKey(year, (parseInt(month) - 1), day);
                 if (entry.type === 'flexible') {
                     const flexibleEntry = { values: entry.values };
                     flexibleStore.set(date, flexibleEntry);

--- a/js/import-export.js
+++ b/js/import-export.js
@@ -2,6 +2,7 @@
 const Store = require('electron-store');
 const fs = require('fs');
 const { validateTime } = require('./time-math.js');
+const { generateKey } = require('./date-db-formatter');
 
 /**
  * Returns the database (only regular entries) as an array of:
@@ -46,8 +47,7 @@ function _getFlexibleEntries() {
         const [year, month, day] = key.split('-');
         //The main database uses a JS-based month index (0-11)
         //So we need to adjust it to human month index (1-12)
-        const date = generateKey(year, (parseInt(month) - 1), day);
-
+        const date = generateKey(year, (parseInt(month) + 1), day);
         output.push({'type': 'flexible', 'date': date, 'values': value.values});
     }
     return output;
@@ -133,7 +133,7 @@ function importDatabaseFromFile(filename) {
                 let [year, month, day] = entry.date.split('-');
                 //The main database uses a JS-based month index (0-11)
                 //So we need to adjust it from human month index (1-12)
-                let date = generateKey(year, (parseInt(month) - 1), day);
+                let date = generateKey(year, (parseInt(month) + 1), day);
                 if (entry.type === 'flexible') {
                     const flexibleEntry = { values: entry.values };
                     flexibleStore.set(date, flexibleEntry);
@@ -183,15 +183,9 @@ function migrateFixedDbToFlexible() {
     return true;
 }
 
-function generateKey(year, month, day, key) {
-    const dbKey = year + '-' + month + '-' + day;
-    return key === undefined ? dbKey : dbKey + '-' + key;
-}
-
 module.exports = {
     importDatabaseFromFile,
     exportDatabaseToFile,
     migrateFixedDbToFlexible,
-    validEntry,
-    generateKey
+    validEntry
 };


### PR DESCRIPTION
#### Related issue
Closes #310 

#### Context / Background
In a lot of places around TTL we concatenate strings to format the DB key in the form: YYYY-MM-DD or YYYY-MM-DD-SOME-ATTR.

#### What change is being introduced by this PR?
Created a new function in import-export.js
Replaced all the key generation with the function

#### How will this be tested?
Ran the test cases using npm run test and did a manual test.
