### PR TITLE
Add option to minimize to tray

### DIFF
--- a/js/main-window.js
+++ b/js/main-window.js
@@ -108,7 +108,7 @@ function createWindow()
 
     mainWindow.on('minimize', (event) =>
     {
-        let savedPreferences = getUserPreferences();
+        const savedPreferences = getUserPreferences();
         if (savedPreferences['minimize-to-tray'])
         {
             event.preventDefault();
@@ -119,7 +119,7 @@ function createWindow()
     // Emitted when the window is closed.
     mainWindow.on('close', (event) =>
     {
-        let savedPreferences = getUserPreferences();
+        const savedPreferences = getUserPreferences();
         if (!app.isQuitting && savedPreferences['close-to-tray'])
         {
             event.preventDefault();

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -98,10 +98,14 @@ function createWindow()
         tray.popUpContextMenu(contextMenu);
     });
 
-    mainWindow.on('minimize', () =>
+    mainWindow.on('minimize', (event) =>
     {
-        event.preventDefault();
-        mainWindow.hide();
+        let savedPreferences = getUserPreferences();
+        if (savedPreferences['minimize-to-tray'])
+        {
+            event.preventDefault();
+            mainWindow.hide();
+        }
     });
 
     // Emitted when the window is closed.

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -9,6 +9,7 @@ const { isValidTheme } = require('./themes.js');
 const defaultPreferences = {
     'count-today': false,
     'close-to-tray': true,
+    'minimize-to-tray': true,
     'hide-non-working-days': false,
     'hours-per-day': '08:00',
     'notification': true,
@@ -114,6 +115,7 @@ function initPreferencesFileIfNotExistsOrInvalid() {
         // Handle Boolean Inputs
         case 'count-today':
         case 'close-to-tray':
+        case 'minimize-to-tray':
         case 'hide-non-working-days':
         case 'notification':
         case 'repetition':

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -75,6 +75,10 @@
                 <label id='overall-balance-start-date'><input type="date" name="overall-balance-start-date"></label>
             </div>
             <div class="flex-box">
+                <p>Minimize button should minimize to tray</p>
+                <label id='minimize-to-tray' class="switch"><input type="checkbox" name="minimize-to-tray"><span class="slider round"></span></label>
+            </div>
+            <div class="flex-box">
                 <p>Close button should minimize to tray</p>
                 <label id='close-to-tray' class="switch"><input type="checkbox" name="close-to-tray"><span class="slider round"></span></label>
             </div>


### PR DESCRIPTION
#### Related issue
#350

#### Context / Background
The issue submitter wants to have the option to either minimize to the taskbar, or minimize to the tray.

#### What change is being introduced by this PR?
I mirrored the approach used for the close-to-tray feature.  An option was added to the preferences with similar wording in the same location.  It defaults to true (minimize-to-tray) as this keeps the behavior consistent with before.
![image](https://user-images.githubusercontent.com/738582/94894016-56295e80-043d-11eb-9c20-43db7eec94ac.png)

#### How will this be tested?
Tested manually.  I didn't see any tests for the similar close-to-tray feature to mirror.
