### PR TITLE
Fix #395: Fixing uncaught exception in main.js on day refresh

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,15 @@
 ## 1.5.6 (in development)
 
+-   Fix: [#214] Check that lunch has beginning and end, if there is lunch
 -   Fix: [#377] Fixed the layout which was broken when width < 768px
 -   Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
 -   Fix: [#334] Improving performance of overall balance calculation and fixing balance target date after month change
 -   Fix: [#362] Fixed initial size of preferences window
--   Fix: [#214] Check that lunch has beginning and end, if there is lunch
+-   Fix: [#395] Fixing uncaught exception in main.js on day refresh
 -   Enhancement: [#328] Swap position for overall and month balance on day view
 -   Enhancement: [#333] Adding start date for overall balance on preferences
 -   Enhancement: [#357] Adding flexible table format for month calendar with variable number of entries per day
 -   Enhancement: [#383] Add system default theme that auto-detect if dark or light mode is set
-
 
 Who built 1.5.6:
 

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -13,7 +13,15 @@ const {
     getMainMenuTemplate,
     getViewMenuTemplate
 } = require('./menus');
-let { contextMenu, mainWindow, tray } = require('./windows');
+let { contextMenu, tray } = require('./windows.js');
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow = null;
+
+function getMainWindow() {
+    return mainWindow;
+}
 
 function createWindow()
 {
@@ -123,5 +131,6 @@ function createWindow()
 
 
 module.exports = {
-    createWindow
+    createWindow,
+    getMainWindow
 };

--- a/js/windows.js
+++ b/js/windows.js
@@ -2,14 +2,12 @@
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow = null;
 let waiverWindow = null;
 let prefWindow = null;
 let tray = null;
 let contextMenu = null;
 
 module.exports = {
-    mainWindow,
     waiverWindow,
     prefWindow,
     tray,

--- a/main.js
+++ b/main.js
@@ -2,8 +2,7 @@
 'use strict';
 
 const { app, ipcMain } = require('electron');
-const { createWindow } = require('./js/main-window');
-const { mainWindow } = require('./js/windows');
+const { createWindow, getMainWindow } = require('./js/main-window');
 const { notify } = require('./js/notification');
 
 ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) => {
@@ -32,7 +31,13 @@ function checkIdleAndNotify() {
 }
 
 function refreshOnDayChange() {
-    var today = new Date();
+    const mainWindow = getMainWindow();
+    if (mainWindow === null)
+    {
+        return;
+    }
+
+    let today = new Date();
     if (today > launchDate)
     {
         let oldDate = launchDate.getDate();
@@ -54,6 +59,7 @@ if (!app.requestSingleInstanceLock()) {
 } else {
     app.on('second-instance', () => {
         // Someone tried to run a second instance, we should focus our window.
+        const mainWindow = getMainWindow();
         if (mainWindow) {
             if (mainWindow.isMinimized()) {
                 mainWindow.restore();
@@ -84,6 +90,7 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
+    const mainWindow = getMainWindow();
     if (mainWindow === null) {
         createWindow();
     } else {


### PR DESCRIPTION
#### Related issue
Closes #395

#### Context / Background
Missing if guard for "mainWindow" variable, which could be undefined, caused a crash.

#### How will this be tested?
jest :)