### PR TITLE
Creating an workflow to update changelog more easily

### DIFF
--- a/.github/workflows/ChangelogUpdater.yml
+++ b/.github/workflows/ChangelogUpdater.yml
@@ -1,0 +1,43 @@
+name: Changelog Updater
+on:
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  update-changelog:
+    runs-on: macos-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '\changelog-update'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Clone git repo
+        uses: actions/checkout@v2
+        if: steps.check.outputs.triggered == 'true'
+      - name: Configure Git Agent
+        run: |
+          git config --global user.name 'Changelog Bot'
+          git config --global user.email 'changelog-bot@users.noreply.github.com'
+      - name: Update Changelog
+        if: github.event.comment.user.login == 'thamara' && steps.check.outputs.triggered == 'true'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          USER: ${{ github.event.comment.user.login }}
+          PR: ${{ context.issue.number }}
+        run: |
+          echo "Found it"
+          echo "Body: $COMMENT_BODY"
+          echo "PR: $PR"
+          echo $COMMENT_BODY > comment_body.file
+          python3 scripts/update-changelog.py -changelog-file changelog.md -changes-file comment_body.file
+      - name: Commit changelog
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          git add changelog.md
+          git commit -nm "Updated changelog.md"
+          git push

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## 1.5.6 (in development)
 
+<!--- Begin changes - Do not remove -->
+
 -   Fix: [#214] Check that lunch has beginning and end, if there is lunch
 -   Fix: [#377] Fixed the layout which was broken when width < 768px
 -   Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
@@ -13,7 +15,11 @@
 -   Enhancement: [#383] Adding system default theme that auto-detect if dark or light mode is set
 -   Enhancement: [#394] Adding option to control the behavior of the Minimize button
 
+<!--- End changes - Do not remove -->
+
 Who built 1.5.6:
+
+<!--- Begin users - Do not remove -->
 
 -   thamara
 -   parikhdhruv24791
@@ -25,6 +31,8 @@ Who built 1.5.6:
 -   06b
 -   skevprog
 -   michaelknowles
+
+<!--- End users - Do not remove -->
 
 ## 1.5.5
 

--- a/scripts/update-changelog.py
+++ b/scripts/update-changelog.py
@@ -1,0 +1,106 @@
+import argparse
+import sys
+import re
+
+# Parses a comment that must follow the strict rule of being:
+# <trigger expression>
+# Message: <some one line message here>
+# User: <some user name here>
+# And updates the the changelog file to include the new information
+
+# Global settings
+g_prefix_line = '-   '
+g_begin_changes = '<!--- Begin changes - Do not remove -->'
+g_end_changes = '<!--- End changes - Do not remove -->'
+g_begin_users = '<!--- Begin users - Do not remove -->'
+g_end_users = '<!--- End users - Do not remove -->'
+
+def remove_prefix(text: str, prefix: str) -> str:
+    """Remove the prefix from the string"""
+    return re.sub(r'^{0}'.format(re.escape(prefix)), '', text)
+
+def get_sorted_unique_entries(entries) -> list:
+    """Return a sorted list of unique entries"""
+    entries = list(set(entries))
+    entries.sort()
+    return [('{}{}'.format(g_prefix_line, entry) if entry else '') for entry in entries]
+
+def get_updated_file_content(current_changelog_lines: str, new_change: any, new_user: any) -> list:
+    """Returns the list of content for the updated changelog"""
+    new_file_content = []
+    is_sourcing_changes = False
+    is_sourcing_users = False
+    changes = [new_change] if new_change else []
+    users = [new_user] if new_user else []
+
+    for line in current_changelog_lines:
+        line = remove_prefix(line.strip(), g_prefix_line)
+        if line == g_end_changes:
+            is_sourcing_changes = False
+            new_file_content.extend(get_sorted_unique_entries(changes))
+            # adds an extra item to avoid issues with the linter
+            new_file_content.append('')
+
+        if line == g_end_users:
+            is_sourcing_users = False
+            new_file_content.extend(get_sorted_unique_entries(users))
+            # adds an extra item to avoid issues with the linter
+            new_file_content.append('')
+
+        if not is_sourcing_changes and not is_sourcing_users:
+            new_file_content.append(line)
+
+        if is_sourcing_changes:
+            changes.append(line)
+
+        if is_sourcing_users:
+            users.append(line)
+
+        if line == g_begin_changes:
+            is_sourcing_changes = True
+
+        if line == g_begin_users:
+            is_sourcing_users = True
+
+    return new_file_content
+
+def update_changelog(changelog_filename: str, new_change: any, new_user: any):
+    """Updates the changelog file to include the new changes"""
+    new_file_content = []
+    with open(changelog_filename) as file_handler:
+        lines = file_handler.readlines()
+        new_file_content = get_updated_file_content(lines, new_change, new_user)
+
+    with open(changelog_filename, "w") as file_handler:
+        file_handler.write('\n'.join(new_file_content))
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-changelog-file", help="Changelog file")
+    parser.add_argument("-changes-file", help="Changes file, containing 'Message' and 'User'")
+    return parser.parse_args()
+
+def get_change_and_user(changes_file: str) -> list:
+    """Parses changes file retrieving Message and User"""
+    message = None
+    user = None
+    with open(changes_file) as file_handler:
+        for line in file_handler.readlines():
+            match = re.match("Message: (.*)", line.strip())
+            if match:
+                message = match.group(1)
+
+            match = re.match("User: (.*)", line.strip())
+            if match:
+                user = match.group(1)
+
+    return [message, user]
+
+def main():
+    args = get_arguments()
+    [message, user] = get_change_and_user(args.changes_file)
+    if message or user:
+        update_changelog(args.changelog_file, message, user)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a workflow that is capable of automatically update the `changelog.md` from a comment on the PR.

Here's an example of that in action:

1. The comment:

![image](https://user-images.githubusercontent.com/846063/94987731-dc799980-053e-11eb-9296-35772b726761.png)

2. The commit:

![image](https://user-images.githubusercontent.com/846063/94987746-0206a300-053f-11eb-8c62-eaf93a88e328.png)



Some important points:
- For now, I'm the only user for which this will run. I want to extend this list to the maintainers of the repository, but still needs to study the best way of doing so
- The python script use is fairly simple, but still complex. I want to work more on this, but it already works pretty well
- I see a lot of improvements here and there, but as I said, it's already working well, so I would like to have it running ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thamara/time-to-leave/400)
<!-- Reviewable:end -->
