### PR TITLE
Improvements on code cov

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -19,7 +19,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v1.0.0
         with:
-          name: 'COVERAGE'
+          name: 'COVERAGE-${{ matrix.os }}'
           path: 'coverage/'
       - name: '      CodeCov'
         if: success()
@@ -27,4 +27,5 @@ jobs:
         with:
           file: 'COVERAGE*'
           token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-${{ matrix.os }}
           fail_ci_if_error: false

--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  precision: 2
+  round: down
+  range: "55...100"


### PR DESCRIPTION
Improvements on codecov to generate two different artifacts, one for each OS, and also use a baseline for the repository that is valid for our current status.