### PR TITLE
refactor : Reinforce param order in Calendar.js

### DIFF
--- a/__tests__/__renderer__/classes/Calendar.js
+++ b/__tests__/__renderer__/classes/Calendar.js
@@ -57,23 +57,23 @@ describe('Calendar class Tests', () =>
     test('Calendar internal storage correct loading', () =>
     {
         expect(calendar._internalStore['2020-3-1-day-begin']).toBe('08:00');
-        expect(calendar._getStore(1, 3, 2020, 'day-begin')).toBe('08:00');
+        expect(calendar._getStore(2020, 3, 1, 'day-begin')).toBe('08:00');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
-        expect(calendar._getStore(1, 3, 2010, 'day-begin')).toBe(undefined);
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe(undefined);
 
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(9);
         expect(store.size).toStrictEqual(9);
 
-        calendar._setStore(1, 3, 2010, 'day-begin', '05:00');
+        calendar._setStore(2010, 3, 1, 'day-begin', '05:00');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe('05:00');
-        expect(calendar._getStore(1, 3, 2010, 'day-begin')).toBe('05:00');
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe('05:00');
 
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(10);
         expect(store.size).toStrictEqual(10);
 
-        calendar._removeStore(1, 3, 2010, 'day-begin');
+        calendar._removeStore(2010, 3, 1, 'day-begin');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
-        expect(calendar._getStore(1, 3, 2010, 'day-begin')).toBe(undefined);
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe(undefined);
 
         // remove just sets the value as undefined in internal store, if it existed
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(10);
@@ -84,9 +84,9 @@ describe('Calendar class Tests', () =>
     {
         // Waiver Store internally saves the human month index, but the calendar methods use JS month index
         expect(calendar._internalWaiverStore['2019-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2019)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2019, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         expect(waivedWorkdays.size).toStrictEqual(3);
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(3);
@@ -97,14 +97,14 @@ describe('Calendar class Tests', () =>
         waivedWorkdays.set(newWaivedEntry);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         calendar.loadInternalWaiveStore();
 
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(4);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
     });
 
     test('Calendar Month Changes', () =>

--- a/__tests__/__renderer__/classes/FixedDayCalendar.js
+++ b/__tests__/__renderer__/classes/FixedDayCalendar.js
@@ -52,23 +52,23 @@ describe('FixedDayCalendar class Tests', () =>
     test('FixedDayCalendar internal storage correct loading', () =>
     {
         expect(calendar._internalStore['2020-3-1-day-begin']).toBe('08:00');
-        expect(calendar._getStore(1, 3, 2020, 'day-begin')).toBe('08:00');
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe('08:00');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
-        expect(calendar._getStore(1, 3, 2010, 'day-begin')).toBe(undefined);
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe(undefined);
 
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(9);
         expect(store.size).toStrictEqual(9);
 
-        calendar._setStore(1, 3, 2010, 'day-begin', '05:00');
+        calendar._setStore(2010, 3, 1, 'day-begin', '05:00');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe('05:00');
-        expect(calendar._getStore(1, 3, 2010, 'day-begin')).toBe('05:00');
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe('05:00');
 
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(10);
         expect(store.size).toStrictEqual(10);
 
-        calendar._removeStore(1, 3, 2010, 'day-begin');
+        calendar._removeStore(2010, 3, 1, 'day-begin');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
-        expect(calendar._getStore(1, 3, 2010, 'day-begin')).toBe(undefined);
+        expect(calendar._getStore(2020, 3, 1, 'day-begin')).toBe(undefined);
 
         // remove just sets the value as undefined in internal store, if it existed
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(10);
@@ -79,9 +79,9 @@ describe('FixedDayCalendar class Tests', () =>
     {
         // Waiver Store internally saves the human month index, but the calendar methods use JS month index
         expect(calendar._internalWaiverStore['2019-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2019)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2019, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         expect(waivedWorkdays.size).toStrictEqual(3);
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(3);
@@ -92,14 +92,14 @@ describe('FixedDayCalendar class Tests', () =>
         waivedWorkdays.set(newWaivedEntry);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         calendar.loadInternalWaiveStore();
 
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(4);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
     });
 
     test('FixedDayCalendar Day Changes', () =>

--- a/__tests__/__renderer__/classes/FixedDayCalendar.js
+++ b/__tests__/__renderer__/classes/FixedDayCalendar.js
@@ -51,8 +51,8 @@ describe('FixedDayCalendar class Tests', () =>
 
     test('FixedDayCalendar internal storage correct loading', () =>
     {
-        expect(calendar._internalStore['2010-3-1-day-begin']).toBe('08:00');
-        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe('08:00');
+        expect(calendar._internalStore['2020-3-1-day-begin']).toBe('08:00');
+        expect(calendar._getStore(2020, 3, 1, 'day-begin')).toBe('08:00');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
         expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe(undefined);
 
@@ -68,7 +68,7 @@ describe('FixedDayCalendar class Tests', () =>
 
         calendar._removeStore(2010, 3, 1, 'day-begin');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
-        expect(calendar._getStore(2020, 3, 1, 'day-begin')).toBe(undefined);
+        expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe(undefined);
 
         // remove just sets the value as undefined in internal store, if it existed
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(10);

--- a/__tests__/__renderer__/classes/FixedDayCalendar.js
+++ b/__tests__/__renderer__/classes/FixedDayCalendar.js
@@ -51,7 +51,7 @@ describe('FixedDayCalendar class Tests', () =>
 
     test('FixedDayCalendar internal storage correct loading', () =>
     {
-        expect(calendar._internalStore['2020-3-1-day-begin']).toBe('08:00');
+        expect(calendar._internalStore['2010-3-1-day-begin']).toBe('08:00');
         expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe('08:00');
         expect(calendar._internalStore['2010-3-1-day-begin']).toBe(undefined);
         expect(calendar._getStore(2010, 3, 1, 'day-begin')).toBe(undefined);

--- a/__tests__/__renderer__/classes/FlexibleDayCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleDayCalendar.js
@@ -91,9 +91,9 @@ describe('FlexibleDayCalendar class Tests', () =>
     {
         // Waiver Store internally saves the human month index, but the calendar methods use JS month index
         expect(calendar._internalWaiverStore['2019-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2019)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2019, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         expect(waivedWorkdays.size).toStrictEqual(3);
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(3);
@@ -104,14 +104,14 @@ describe('FlexibleDayCalendar class Tests', () =>
         waivedWorkdays.set(newWaivedEntry);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         calendar.loadInternalWaiveStore();
 
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(4);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
     });
 
     test('FlexibleDayCalendar Day Changes', () =>

--- a/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
@@ -91,9 +91,9 @@ describe('FlexibleMonthCalendar class Tests', () =>
     {
         // Waiver Store internally saves the human month index, but the calendar methods use JS month index
         expect(calendar._internalWaiverStore['2019-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2019)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2019, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         expect(waivedWorkdays.size).toStrictEqual(3);
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(3);
@@ -104,14 +104,14 @@ describe('FlexibleMonthCalendar class Tests', () =>
         waivedWorkdays.set(newWaivedEntry);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual(undefined);
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual(undefined);
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual(undefined);
 
         calendar.loadInternalWaiveStore();
 
         expect(Object.keys(calendar._internalWaiverStore).length).toStrictEqual(4);
 
         expect(calendar._internalWaiverStore['2010-12-31']).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
-        expect(calendar._getWaiverStore(31, 11, 2010)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
+        expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
     });
 
     test('FlexibleMonthCalendar Month Changes', () =>

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -156,9 +156,9 @@ class Calendar
 
     /**
      * Gets value from internal store.
-     * @param {number} day
-     * @param {number} month
      * @param {number} year
+     * @param {number} month
+     * @param {number} day
      * @param {string} key
      * @return {string|undefined} A time string
      */
@@ -170,9 +170,9 @@ class Calendar
 
     /**
      * Saves value on store and updates internal store.
-     * @param {number} day
-     * @param {number} month
      * @param {number} year
+     * @param {number} month
+     * @param {number} day
      * @param {string} key
      * @param {string} newValue valid time value
      */
@@ -186,9 +186,9 @@ class Calendar
 
     /**
      * Removes value from store and from internal store.
-     * @param {number} day
-     * @param {number} month
      * @param {number} year
+     * @param {number} month
+     * @param {number} day
      * @param {string} key
      */
     _removeStore(year, month, day, key)
@@ -201,9 +201,9 @@ class Calendar
 
     /**
      * Gets value from internal waiver store.
-     * @param {number} day
-     * @param {number} month
      * @param {number} year
+     * @param {number} month
+     * @param {number} day
      * @return {string} A time string
      */
     _getWaiverStore(year, month, day)
@@ -610,9 +610,9 @@ class Calendar
 
     /**
      * Gets the total for a specific day by looking into both stores.
-     * @param {number} day
-     * @param {number} month
      * @param {number} year
+     * @param {number} month
+     * @param {number} day
      * @return {string|undefined}
      */
     _getDayTotal(year, month, day)

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -111,7 +111,7 @@ class Calendar
         this._updateTableBody();
         this._updateBasedOnDB();
 
-        let waivedInfo = this._getWaiverStore(this._getTodayDate(), this._getTodayMonth(), this._getTodayYear());
+        let waivedInfo = this._getWaiverStore(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
         let showCurrentDay = this._showDay(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
         this._togglePunchButton(showCurrentDay && waivedInfo === undefined);
 
@@ -145,7 +145,7 @@ class Calendar
     {
         let idTag = this._getCalendarYear() + '-' + month + '-' + day + '-' + key;
 
-        let value = this._getStore(day, month, this._getCalendarYear(), key);
+        let value = this._getStore(this._getCalendarYear(), month, day, key);
         if (value === undefined)
         {
             value = '';
@@ -162,7 +162,7 @@ class Calendar
      * @param {string} key
      * @return {string|undefined} A time string
      */
-    _getStore(day, month, year, key)
+    _getStore(year, month, day, key)
     {
         let idTag = generateKey(year, month, day, key);
         return this._internalStore[idTag];
@@ -176,7 +176,7 @@ class Calendar
      * @param {string} key
      * @param {string} newValue valid time value
      */
-    _setStore(day, month, year, key, newValue)
+    _setStore(year, month, day, key, newValue)
     {
         let idTag = generateKey(year, month, day, key);
 
@@ -191,7 +191,7 @@ class Calendar
      * @param {number} year
      * @param {string} key
      */
-    _removeStore(day, month, year, key)
+    _removeStore(year, month, day, key)
     {
         let idTag = generateKey(year, month, day, key);
 
@@ -206,7 +206,7 @@ class Calendar
      * @param {number} year
      * @return {string} A time string
      */
-    _getWaiverStore(day, month, year)
+    _getWaiverStore(year, month, day)
     {
         let dayKey = getDateStr(new Date(year, month, day));
 
@@ -330,7 +330,7 @@ class Calendar
             }
         }
 
-        let waivedInfo = this._getWaiverStore(day, month, year);
+        let waivedInfo = this._getWaiverStore(year, month, day);
         if (waivedInfo !== undefined)
         {
             let summaryStr = '<b>Waived day: </b>' + waivedInfo['reason'];
@@ -615,14 +615,14 @@ class Calendar
      * @param {number} year
      * @return {string|undefined}
      */
-    _getDayTotal(day, month, year)
+    _getDayTotal(year, month, day)
     {
-        let storeTotal = this._getStore(day, month, year, 'day-total');
+        let storeTotal = this._getStore(year, month, day, 'day-total');
         if (storeTotal !== undefined)
         {
             return storeTotal;
         }
-        let waiverTotal = this._getWaiverStore(day, month, year);
+        let waiverTotal = this._getWaiverStore(year, month, day);
         if (waiverTotal !== undefined)
         {
             return waiverTotal['hours'];
@@ -831,7 +831,7 @@ class Calendar
             let dayTotal = null;
             let dayStr = this._getCalendarYear() + '-' + this._getCalendarMonth() + '-' + day + '-';
 
-            let waivedInfo = this._getWaiverStore(day, this._getCalendarMonth(), this._getCalendarYear());
+            let waivedInfo = this._getWaiverStore(this._getCalendarYear(), this._getCalendarMonth(), day);
             if (waivedInfo !== undefined)
             {
                 let waivedDayTotal = waivedInfo['hours'];
@@ -965,11 +965,11 @@ class Calendar
     {
         if (validateTime(newValue))
         {
-            this._setStore(day, month, year, key, newValue);
+            this._setStore(year, month, day, key, newValue);
         }
         else
         {
-            this._removeStore(day, month, year, key);
+            this._removeStore(year, month, day, key);
         }
     }
 
@@ -1054,10 +1054,10 @@ class Calendar
      */
     _getDaysEntries(month, day)
     {
-        return [this._getStore(day, month, this._getCalendarYear(), 'day-begin'),
-            this._getStore(day, month, this._getCalendarYear(), 'lunch-begin'),
-            this._getStore(day, month, this._getCalendarYear(), 'lunch-end'),
-            this._getStore(day, month, this._getCalendarYear(), 'day-end')];
+        return [this._getStore(this._getCalendarYear(), month, day, 'day-begin'),
+            this._getStore(this._getCalendarYear(), month, day, 'lunch-begin'),
+            this._getStore(this._getCalendarYear(), month, day, 'lunch-end'),
+            this._getStore(this._getCalendarYear(), month, day, 'day-end')];
     }
 
     /**

--- a/js/classes/FixedDayCalendar.js
+++ b/js/classes/FixedDayCalendar.js
@@ -149,7 +149,7 @@ class FixedDayCalendar extends Calendar
                     '</div>\n';
         }
 
-        let waivedInfo = this._getWaiverStore(day, month, year);
+        let waivedInfo = this._getWaiverStore(year, month, day);
         if (waivedInfo !== undefined)
         {
             let summaryStr = `<b>${i18n.t('$FixedDayCalendar.waived-day')}: </b>` + waivedInfo['reason'];
@@ -305,7 +305,7 @@ class FixedDayCalendar extends Calendar
                 continue;
             }
 
-            let dayTotal = this._getDayTotal(day, this._getCalendarMonth(), this._getCalendarYear());
+            let dayTotal = this._getDayTotal(this._getCalendarYear(), this._getCalendarMonth(), day);
             if (dayTotal !== undefined)
             {
                 countDays = true;
@@ -354,7 +354,7 @@ class FixedDayCalendar extends Calendar
 
             if (day === this._getCalendarDate())
             {
-                let waivedInfo = this._getWaiverStore(day, this._getCalendarMonth(), this._getCalendarYear());
+                let waivedInfo = this._getWaiverStore(this._getCalendarYear(), this._getCalendarMonth(), day);
                 if (waivedInfo !== undefined)
                 {
                     let waivedDayTotal = waivedInfo['hours'];

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -163,7 +163,7 @@ class FlexibleDayCalendar extends FlexibleMonthCalendar
                     '</div>\n';
         }
 
-        let waivedInfo = this._getWaiverStore(day, month, year);
+        let waivedInfo = this._getWaiverStore(year, month, day);
         if (waivedInfo !== undefined)
         {
             let summaryStr = '<b>Waived day: </b>' + waivedInfo['reason'];
@@ -408,7 +408,7 @@ class FlexibleDayCalendar extends FlexibleMonthCalendar
             return dayTotal;
         }
 
-        const waiverTotal = this._getWaiverStore(day, month, year);
+        const waiverTotal = this._getWaiverStore(year, month, day);
         if (waiverTotal !== undefined)
         {
             return waiverTotal['hours'];
@@ -518,7 +518,7 @@ class FlexibleDayCalendar extends FlexibleMonthCalendar
             const dateKey = generateKey(this._getCalendarYear(), this._getCalendarMonth(), day);
             if (day === this._getCalendarDate())
             {
-                let waivedInfo = this._getWaiverStore(day, this._getCalendarMonth(), this._getCalendarYear());
+                let waivedInfo = this._getWaiverStore(this._getCalendarYear(), this._getCalendarMonth(), day);
                 if (waivedInfo !== undefined)
                 {
                     let waivedDayTotal = waivedInfo['hours'];

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -157,7 +157,7 @@ class FlexibleMonthCalendar extends Calendar
                     '</div></div>\n';
         }
 
-        let waivedInfo = this._getWaiverStore(day, month, year);
+        let waivedInfo = this._getWaiverStore(year, month, day);
         if (waivedInfo !== undefined)
         {
             let summaryStr = '<b>Waived day: </b>' + waivedInfo['reason'];
@@ -214,7 +214,7 @@ class FlexibleMonthCalendar extends Calendar
         this._updateTableBody();
         this._updateBasedOnDB();
 
-        let waivedInfo = this._getWaiverStore(this._getTodayDate(), this._getTodayMonth(), this._getTodayYear());
+        let waivedInfo = this._getWaiverStore(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
         let showCurrentDay = this._showDay(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
         this._togglePunchButton(showCurrentDay && waivedInfo === undefined);
 
@@ -480,7 +480,7 @@ class FlexibleMonthCalendar extends Calendar
             let dayTotal = null;
             const dateKey = generateKey(this._getCalendarYear(), this._getCalendarMonth(), day);
 
-            let waivedInfo = this._getWaiverStore(day, this._getCalendarMonth(), this._getCalendarYear());
+            let waivedInfo = this._getWaiverStore(this._getCalendarYear(), this._getCalendarMonth(), day);
             if (waivedInfo !== undefined)
             {
                 let waivedDayTotal = waivedInfo['hours'];


### PR DESCRIPTION
#### Related issue
#385 

#### Context / Background
<!--
- Convert order of day, month, year  to yaer, month, day
-->

