### PR TITLE
Adjust scrollbar styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -103,6 +103,27 @@ html[data-theme="cadent-star"] {
 
 /* There are some libraries that impose their own colors. These may need to be overriden for specific themes */
 
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--punch-bground);
+}
+
+::-webkit-scrollbar-track {
+  background-color: var(--page-bground);
+}
+
+html[data-theme="cadent-star"] ::-webkit-scrollbar-thumb {
+  background-color: #ff9aa2;
+}
+
+html[data-theme="cadent-star"] ::-webkit-scrollbar-track {
+  background-color: #c7ceea;
+}
+
 html[data-theme="dark"] .text-danger {
   color: rgb(226, 93, 90);
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -104,8 +104,8 @@ html[data-theme="cadent-star"] {
 /* There are some libraries that impose their own colors. These may need to be overriden for specific themes */
 
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Time to leave's interface feels a bit more modern than a typical time tracking application, it's minimal and one thing that bothered me is that on windows, the default chrome that's used on the scrollbar just stands out with TTL! _I want to acknowledge that this is my opinion and if you don't agree that's cool. 👍_


So this pull request adjusts time to leave to use the page & punch background color instead, while cadent-star uses a different color.

![TimeToLeave-Scrollbar](https://user-images.githubusercontent.com/1302542/95521982-e82eeb00-0998-11eb-8871-801de374aab8.gif)

Tested on Windows (Windows 10 Pro, Version 2004, OS build 19041.508).

