### PR TITLE
Change link color of non active navbar follow the theme's text color

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -678,6 +678,10 @@ input:disabled + .slider {
   width: 100%;
 }
 
+#workday-waiver-window a.nav-link:not(.active) {
+  color: var(--page-color);
+}
+
 /** Day view related styles **/
 
 html[data-view='day'] .container {


### PR DESCRIPTION
#### Related issue
Closes #443

#### Context / Background
Links in Workday Waiver Manager doesn't match any of the app's theme

#### What change is being introduced by this PR?
- Change the color of non active navar link using  `var(--page-color)
`
#### How will this be tested?

![image](https://user-images.githubusercontent.com/18456011/95719390-ef584080-0c99-11eb-9138-ec3caf941a83.png)

![image](https://user-images.githubusercontent.com/18456011/95719439-ff702000-0c99-11eb-92a7-26762872cf61.png)

![image](https://user-images.githubusercontent.com/18456011/95719478-0eef6900-0c9a-11eb-9e51-d6abd458c86d.png)

