### PR TITLE
Fix 427: Updating mocha timeout for windows

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -18,7 +18,6 @@ jobs:
           npm ci
           npm run test:jest
       - name: '        Tests - Mocha'
-        if: matrix.os == 'macOS-latest'
         run: npm run test:mocha
       - name: '        Create COV_REPORT'
         run: |
@@ -27,7 +26,6 @@ jobs:
         run: |
           cp coverage_jest/coverage-final.json COV_REPORT/coverage-final-jest.json
       - name: '        Copy mocha results'
-        if: matrix.os == 'macOS-latest'
         run: |
           cp coverage/coverage-final.json COV_REPORT/coverage-final-mocha.json
       - name: '     Coverage'

--- a/tests/main-window.js
+++ b/tests/main-window.js
@@ -9,11 +9,10 @@ const weekDay = [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Frida
 
 describe('Application launch', function()
 {
-    this.timeout(10000);
-
     //  deepcode ignore UseArrowFunction: => will not work on here
     beforeEach(function()
     {
+        this.timeout(25000); // Estimated pessimistic time taken for the app to the brought up in CI
         this.app = new Application({
             path: electronPath,
             args: [path.join(__dirname, '..')]
@@ -23,6 +22,7 @@ describe('Application launch', function()
 
     afterEach(function()
     {
+        this.timeout(10000); // Estimated pessimistic time taken for the app to be stopped in CI
         if (this.app && this.app.isRunning())
         {
             return this.app.stop();


### PR DESCRIPTION
#### Related issue
Closes #427

#### Context / Background
Moving the timeout to the "beforeEach" hook allows it to be specific to how much time the app takes to be brought up. The other needs can increase their own timeouts if required.

#### How will this be tested?
CI!
