### PR TITLE
Reducing the width of "Punch" button to leave room for the scrollbars

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -107,8 +107,8 @@ html[data-theme="cadent-star"] {
 /* There are some libraries that impose their own colors. These may need to be overriden for specific themes */
 
 ::-webkit-scrollbar {
-  width: 5px;
-  height: 5px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -385,7 +385,7 @@ body {
 
 .punch-button {
   opacity: 0.9;
-  width: calc(100vw - 40px);
+  width: calc(100vw - 60px);
   height: 100%;
   border: none;
   color: var(--punch-color);

--- a/css/styles.css
+++ b/css/styles.css
@@ -107,8 +107,8 @@ html[data-theme="cadent-star"] {
 /* There are some libraries that impose their own colors. These may need to be overriden for specific themes */
 
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 5px;
+  height: 5px;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -385,7 +385,7 @@ body {
 
 .punch-button {
   opacity: 0.9;
-  width: 100%;
+  width: calc(100vw - 40px);
   height: 100%;
   border: none;
   color: var(--punch-color);


### PR DESCRIPTION
#### Related issue
Closes #441 

#### Context / Background
The reason for the gap is that the Scrollbar is Actually appearing on the body and it automatically reserves 10px for the scrollbar. Ideally, the scrollbar should appear on the container holding the table.
Leaving some room on the left and the right of the button looks like a good solution until we get to redoing the layout.

#### What change is being introduced by this PR?
- Verified that the width was already maxed out .
- The button was already center aligned, so I left 20px ---- button ---- 20px on both sides such that the scrollbar is clear of the button. Also reduced the width of the scrollbar such that it does not look overly big.
- Direct consequence is that the look and feel of the punch button is definitely a bit different. Indirect consequence would be that we've identified some layout issues that we'll fix soon.


#### How will this be tested?
Will check if the button always reserves 20px from the left and from the right.