### PR TITLE
Changed the translation text so it renders correctly in the portugese…

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,7 +1,7 @@
 {
     "$Language": {
         "en": "English",
-        "pt-BR": "Português (Brasil)"
+        "pt-BR": "Português - Brasil"
     },
     "$Preferences": {
         "title": "Time to Leave - Preferences",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -1,7 +1,7 @@
 {
     "$Language": {
         "en": "English",
-        "pt-BR": "Português (Brasil)"
+        "pt-BR": "(Português (Brasil"
     },
     "$Preferences": {
         "title": "Time to Leave - Preferências",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -1,7 +1,7 @@
 {
     "$Language": {
         "en": "English",
-        "pt-BR": "(Português (Brasil"
+        "pt-BR": "Português - Brasil"
     },
     "$Preferences": {
         "title": "Time to Leave - Preferências",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,6 +1900,15 @@
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "jest-jasmine2": {
@@ -2899,6 +2908,15 @@
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "jest-message-util": {
@@ -8013,13 +8031,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -10014,6 +10025,15 @@
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "jest-jasmine2": {
@@ -11968,6 +11988,15 @@
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "jest-matcher-utils": {


### PR DESCRIPTION
… translation file

#### Related issue
Closes Misplaced parenthesis when "Português (Brasil)" is the selected language #453

#### Context / Background
<!--
Updated the translation text so it renders correctly onto the screen. This is also my first ever open source contribution so please let me know if I did anything wrong in the pull request! :)
-->

#### What change is being introduced by this PR?
<!--
- I started by forking, cloning and installing the packages, then took a look at the screen that popped up after npm start. Went through the code structure to find the place where the issue was taking place.
- I tried a few different things, I first played with the preferences page a bit, but the same thing kept happening, then I replaced the translated text with something completely different and the parentheses rendered correctly. Also compared to other options in the preferences menu that have a similar structure (ending on a parenthesis) and they worked fine. Then I just figured, I'll try what happens when I put a parenthesis at the start, and it solved the issue.
- I don't foresee any direct or indirect consequences, besides it being rendered correctly. I suppose, if this is an Electron issue with "special characters", in the future if this is patched, it might display wrong again. However I am not sure where the issue came from.
-->

#### How will this be tested?
<!--
- You can just run the app and check if it works again.
-->
