### PR TITLE
Remove deprecated jQuery click apis and replaced with on - click apis

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -107,8 +107,8 @@ html[data-theme="cadent-star"] {
 /* There are some libraries that impose their own colors. These may need to be overriden for specific themes */
 
 ::-webkit-scrollbar {
-  width: 5px;
-  height: 5px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -385,7 +385,7 @@ body {
 
 .punch-button {
   opacity: 0.9;
-  width: calc(100vw - 40px);
+  width: calc(100vw - 60px);
   height: 100%;
   border: none;
   color: var(--punch-color);

--- a/css/styles.css
+++ b/css/styles.css
@@ -107,8 +107,8 @@ html[data-theme="cadent-star"] {
 /* There are some libraries that impose their own colors. These may need to be overriden for specific themes */
 
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 5px;
+  height: 5px;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -385,7 +385,7 @@ body {
 
 .punch-button {
   opacity: 0.9;
-  width: calc(100vw - 60px);
+  width: calc(100vw - 40px);
   height: 100%;
   border: none;
   color: var(--punch-color);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -105,7 +105,7 @@ $(() =>
             setInterval(notifyTimeToLeave, 60000);
             applyTheme(preferences.theme);
 
-            $('#punch-button').click(() => { calendar.punchDate(); });
+            $('#punch-button').on('click', () => { calendar.punchDate(); });
         })
         .catch(err =>
         {

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -47,11 +47,11 @@ class Calendar
     _initCalendar()
     {
         this._generateTemplate();
-
-        $('#next-month').click(() => { this._nextMonth(); });
-        $('#prev-month').click(() => { this._prevMonth(); });
-        $('#current-month').click(() => { this._goToCurrentDate(); });
-        $('#switch-view').click(() => { this._switchView(); });
+        // .click() is deprecated in jQuery 3. Changed to 'on' syntax.
+        $('#next-month').on('click', () => { this._nextMonth(); });
+        $('#prev-month').on('click', () => { this._prevMonth(); });
+        $('#current-month').on('click', () => { this._goToCurrentDate(); });
+        $('#switch-view').on('click', () => { this._switchView(); });
 
         this._draw();
     }
@@ -91,8 +91,8 @@ class Calendar
                 if (balanceElement)
                 {
                     balanceElement.val(balance);
-                    balanceElement.html(balance);
                     balanceElement.removeClass('text-success text-danger');
+                    balanceElement.html(balance);
                     balanceElement.addClass(isNegative(balance) ? 'text-danger' : 'text-success');
                 }
             })

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -47,7 +47,6 @@ class Calendar
     _initCalendar()
     {
         this._generateTemplate();
-        // .click() is deprecated in jQuery 3. Changed to 'on' syntax.
         $('#next-month').on('click', () => { this._nextMonth(); });
         $('#prev-month').on('click', () => { this._prevMonth(); });
         $('#current-month').on('click', () => { this._goToCurrentDate(); });
@@ -90,10 +89,8 @@ class Calendar
                 let balanceElement = $('#overall-balance');
                 if (balanceElement)
                 {
-                    balanceElement.val(balance);
-                    balanceElement.removeClass('text-success text-danger');
-                    balanceElement.html(balance);
-                    balanceElement.addClass(isNegative(balance) ? 'text-danger' : 'text-success');
+                    balanceElement.val(balance).removeClass('text-success text-danger')
+                        .html(balance).addClass(isNegative(balance) ? 'text-danger' : 'text-success');
                 }
             })
             .catch(err =>

--- a/js/classes/FixedDayCalendar.js
+++ b/js/classes/FixedDayCalendar.js
@@ -28,11 +28,11 @@ class FixedDayCalendar extends Calendar
     {
         this._generateTemplate();
 
-        $('#next-day').click(() => { this._nextDay(); });
-        $('#prev-day').click(() => { this._prevDay(); });
-        $('#switch-view').click(() => { this._switchView(); });
-        $('#current-day').click(() => { this._goToCurrentDate(); });
-        $('#input-calendar-date').change((event) =>
+        $('#next-day').on('click', () => { this._nextDay(); });
+        $('#prev-day').on('click', () => { this._prevDay(); });
+        $('#switch-view').on('click', () => { this._switchView(); });
+        $('#current-day').on('click', () => { this._goToCurrentDate(); });
+        $('#input-calendar-date').on('change', (event) =>
         {
             let [year, month, day] = $(event.target).val().split('-');
             this._goToDate(new Date(year, month-1, day));

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -31,11 +31,11 @@ class FlexibleDayCalendar extends FlexibleMonthCalendar
     {
         this._generateTemplate();
 
-        $('#next-day').click(() => { this._nextDay(); });
-        $('#prev-day').click(() => { this._prevDay(); });
-        $('#switch-view').click(() => { this._switchView(); });
-        $('#current-day').click(() => { this._goToCurrentDate(); });
-        $('#input-calendar-date').change((event) =>
+        $('#next-day').on('click', () => { this._nextDay(); });
+        $('#prev-day').on('click', () => { this._prevDay(); });
+        $('#switch-view').on('click', () => { this._switchView(); });
+        $('#current-day').on('click', () => { this._goToCurrentDate(); });
+        $('#input-calendar-date').on('change', (event) =>
         {
             let [year, month, day] = $(event.target).val().split('-');
             this._goToDate(new Date(year, month-1, day));


### PR DESCRIPTION
#### Related issue
Closes Not Applicable

#### Context / Background
jQuery 3 has deprecated `$.click()` way of attaching events.

#### What change is being introduced by this PR?

- Checked documentation
- Changed all `.click()` to `$.on('click', () => {});
- There should be No consequence of this change.


#### How will this be tested?
The application behaviour should not change at all.