### PR TITLE
change align Overall Start Date input to right

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -628,6 +628,13 @@ input:disabled + .slider {
   direction: rtl;
 }
 
+/* Styles for Right Alignment of input type date */
+#preferences-window input[type="date"].date-right::-webkit-datetime-edit {
+  text-align: right;
+  position: relative;
+  left: 25px;
+}
+
 /* Waiver page styles */
 
 #workday-waiver-window .section-title {

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -72,7 +72,7 @@
             </div>
             <div class="flex-box mb-2">
                 <p data-i18n="$Preferences.overallBalanceStart">Overall Balance Start Date</p>
-                <label id='overall-balance-start-date'><input type="date" name="overall-balance-start-date"></label>
+                <label id='overall-balance-start-date'><input type="date" class="date-right" name="overall-balance-start-date"></label>
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.minimizeToTray">Minimize button should minimize to tray</p>


### PR DESCRIPTION
#### Related issue
Closes #439 

#### Context / Background
All contents of the preferences table is aligned right, but the Overall Balance Start Date seems to have the alignment a little bit off.

#### What change is being introduced by this PR?
- add class `.date-right` on css and change `-webkit-datetime-edit` pseudo-elements.

#### How will this be tested?
![image](https://user-images.githubusercontent.com/18456011/95940338-4714ba00-0e08-11eb-87a5-208c59294626.png)
