### PR TITLE
add translations to download manager

### DIFF
--- a/js/update-manager.js
+++ b/js/update-manager.js
@@ -4,6 +4,7 @@ const { app, net, shell, dialog, BrowserWindow } = require('electron');
 const { getDateStr } = require('./date-aux.js');
 const isOnline = require('is-online');
 const Store = require('electron-store');
+const i18n = require('../src/configs/i18next.config');
 
 function shouldCheckForUpdates()
 {
@@ -37,10 +38,14 @@ async function checkForUpdates(showUpToDateDialog)
                 {
                     const options = {
                         type: 'question',
-                        buttons: ['Dismiss', 'Download latest version', 'Remind me later'],
+                        buttons: [
+                            i18n.t('$UpdateManager.dismissBtn'),
+                            i18n.t('$UpdateManager.downloadBtn'),
+                            i18n.t('$UpdateManager.remindBtn')
+                        ],
                         defaultId: 1,
-                        title: 'TTL Check for updates',
-                        message: 'You are using an old version of TTL and is missing out on a lot of new cool things!',
+                        title: i18n.t('$UpdateManager.title'),
+                        message: i18n.t('$UpdateManager.old-version-msg'),
                     };
                     let response = dialog.showMessageBoxSync(BrowserWindow.getFocusedWindow(), options);
                     if (response === 1)
@@ -61,9 +66,9 @@ async function checkForUpdates(showUpToDateDialog)
                 {
                     const options = {
                         type: 'info',
-                        buttons: ['OK'],
-                        title: 'TTL Check for updates',
-                        message: 'Your TTL is up to date.'
+                        buttons: [i18n.t('$Menu.ok')],
+                        title: i18n.t('$UpdateManager.title'),
+                        message: i18n.t('$UpdateManager.upto-date-msg')
                     };
                     dialog.showMessageBox(null, options);
                 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -170,14 +170,6 @@
         "time-to-leave": "Hey there! I think it's time to leave.",
         "punch-reminder": "Don't forget to punch in!"
     },
-    "$UpdateManager": {
-        "dismissBtn": "Dismiss",
-        "downloadBtn": "Download latest version",
-        "remindBtn": "Remind me later",
-        "title": "TTL Check for updates",
-        "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
-    },
     "$FixedDayCalendar": {
         "leave-by": "You should leave by:",
         "all-done": "All done for today. Balance of the day:",
@@ -260,5 +252,13 @@
         "october": "October",
         "november": "November",
         "december": "December"
+    },
+    "$UpdateManager": {
+        "dismissBtn": "Dismiss",
+        "downloadBtn": "Download latest version",
+        "remindBtn": "Remind me later",
+        "title": "TTL Check for updates",
+        "upto-date-msg": "Your TTL is up to date.",
+        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
     }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -170,6 +170,14 @@
         "time-to-leave": "Hey there! I think it's time to leave.",
         "punch-reminder": "Don't forget to punch in!"
     },
+    "$UpdateManager": {
+        "dismissBtn": "Dismiss",
+        "downloadBtn": "Download latest version",
+        "remindBtn": "Remind me later",
+        "title": "TTL Check for updates",
+        "upto-date-msg": "Your TTL is up to date.",
+        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+    },
     "$FixedDayCalendar": {
         "leave-by": "You should leave by:",
         "all-done": "All done for today. Balance of the day:",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -252,5 +252,13 @@
         "october": "Octubre",
         "november": "Noviembre",
         "december": "Diciembre"
+    },
+    "$UpdateManager": {
+        "dismissBtn": "Dismiss",
+        "downloadBtn": "Download latest version",
+        "remindBtn": "Remind me later",
+        "title": "TTL Check for updates",
+        "upto-date-msg": "Your TTL is up to date.",
+        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
     }
 }

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -252,5 +252,13 @@
         "october": "Ottobre",
         "november": "Novembre",
         "december": "Dicembre"
+    },
+    "$UpdateManager": {
+        "dismissBtn": "Dismiss",
+        "downloadBtn": "Download latest version",
+        "remindBtn": "Remind me later",
+        "title": "TTL Check for updates",
+        "upto-date-msg": "Your TTL is up to date.",
+        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
     }
 }

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -252,5 +252,13 @@
         "october": "Outubro",
         "november": "Novembro",
         "december": "Dezembro"
+    },
+    "$UpdateManager": {
+        "dismissBtn": "Dismiss",
+        "downloadBtn": "Download latest version",
+        "remindBtn": "Remind me later",
+        "title": "TTL Check for updates",
+        "upto-date-msg": "Your TTL is up to date.",
+        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
     }
 }


### PR DESCRIPTION
#### Related issue
Closes #488 

#### Context / Background
Download manager had missing translations

#### What change is being introduced by this PR?
Have extracted the hard coded strings to translation and used i18n to translate.

#### How will this be tested?
Under menu -> Help -> Click check for updates and see that the messages are in the respective language selected
