### PR TITLE
Issue #51 -- Refactored Global Preferences Variable

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -7,12 +7,16 @@ const {
     hourToMinutes
 } = require('./js/time-math.js');
 const { notify } = require('./js/notification.js');
-const { getUserPreferences } = require('./js/user-preferences.js');
+const {
+    getUserPreferences,
+    notificationIsEnabled
+} = require('./js/user-preferences.js');
 const { applyTheme } = require('./js/themes.js');
 const { CalendarFactory } = require('./js/classes/CalendarFactory.js');
 const i18n = require('./src/configs/i18next.config.js');
 
 // Global values for calendar
+// Ideally, remove this prefs \/\/\/\/\/\/
 let preferences = getUserPreferences();
 let calendar = null;
 
@@ -35,31 +39,24 @@ ipcRenderer.on('LANGUAGE_CHANGED', (event, message) =>
 
 
 /*
- * Get nofified when preferences has been updated.
+ * Get notified when preferences has been updated.
  */
 ipcRenderer.on('PREFERENCE_SAVED', function(event, prefs)
 {
     preferences = prefs;
     calendar = CalendarFactory.getInstance(prefs, calendar);
     applyTheme(prefs.theme);
-});
+}
+);
 
 /*
- * Get nofified when waivers get updated.
+ * Get notified when waivers get updated.
  */
 ipcRenderer.on('WAIVER_SAVED', function()
 {
     calendar.loadInternalWaiveStore();
     calendar.redraw();
 });
-
-/*
- * Returns true if the notification is enabled in preferences.
- */
-function notificationIsEnabled()
-{
-    return preferences['notification'];
-}
 
 /*
  * Notify user if it's time to leave

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -253,18 +253,28 @@ function getDefaultWidthHeight()
     }
 }
 
+
+/*
+ * Returns the value of language in preferences.
+ */
 function getUserLanguage()
 {
     let preferences = getLoadedOrDerivedUserPreferences();
     return preferences['language'];
 }
 
+/*
+ * Returns the value of notification-interval in preferences.
+ */
 function getNotificationsInterval()
 {
     let preferences = getLoadedOrDerivedUserPreferences();
     return preferences['notifications-interval'];
 }
 
+/*
+ * Returns true if repetition is enabled in preferences.
+ */
 function repetitionIsEnabled()
 {
     let preferences = getLoadedOrDerivedUserPreferences();

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -253,15 +253,36 @@ function getDefaultWidthHeight()
     }
 }
 
+function getUserLanguage()
+{
+    let preferences = getLoadedOrDerivedUserPreferences();
+    return preferences['language'];
+}
+
+function getNotificationsInterval()
+{
+    let preferences = getLoadedOrDerivedUserPreferences();
+    return preferences['notifications-interval'];
+}
+
+function repetitionIsEnabled()
+{
+    let preferences = getLoadedOrDerivedUserPreferences();
+    return preferences['repetition'];
+}
+
 module.exports = {
     defaultPreferences,
     getDefaultWidthHeight,
     getUserPreferences: getLoadedOrDerivedUserPreferences,
+    getUserLanguage,
+    getNotificationsInterval,
     getPreferencesFilePath,
     savePreferences,
     showDay,
     switchCalendarView,
     isNotBoolean,
     isValidPreferenceTime,
-    notificationIsEnabled
+    notificationIsEnabled,
+    repetitionIsEnabled
 };

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -185,6 +185,15 @@ function getLoadedOrDerivedUserPreferences()
 }
 
 /*
+ * Returns true if the notification is enabled in preferences.
+ */
+function notificationIsEnabled()
+{
+    let preferences = getLoadedOrDerivedUserPreferences();
+    return preferences['notification'];
+}
+
+/*
  * Returns true if we should display week day.
  */
 function showWeekDay(weekDay, preferences = undefined)
@@ -253,5 +262,6 @@ module.exports = {
     showDay,
     switchCalendarView,
     isNotBoolean,
-    isValidPreferenceTime
+    isValidPreferenceTime,
+    notificationIsEnabled
 };


### PR DESCRIPTION
#### Related issue
Addresses  #51 

#### Context / Background

- I was able to refactor and add some getter functions that removed the need for the global preferences variable in calendar.js
- I'm sorry, I'm very new to this (this was my first pull request), and I wasn't able to address ipcRenderer or calendar.redraw(). I'm going to continue researching and tinkering. If I find a solution, I will submit another PR.


#### What change is being introduced by this PR?

- Any place where preferences['a particular preference'] was being invoked, I wrote a function in user-preferences.js to expose only that segment of preferences and imported that function into calendar.js
- Those functions are: repetitionIsEnabled, getUserLanguage, getNotificationsInterval
- I also moved notificationIsEnabled from calendar.js to user-preferences.js

#### How will this be tested?

- I ran the linter and everything seems to be in working order. 


Thank you for your consideration!
