### PR TITLE
Removing typo from '.old-version-msg'

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -264,6 +264,6 @@
         "remindBtn": "Remind me later",
         "title": "TTL Check for updates",
         "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+        "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!"
     }
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -264,6 +264,6 @@
         "remindBtn": "Remind me later",
         "title": "TTL Check for updates",
         "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+        "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!"
     }
 }

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -264,6 +264,6 @@
         "remindBtn": "Remind me later",
         "title": "TTL Check for updates",
         "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+        "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!"
     }
 }

--- a/locales/mr/translation.json
+++ b/locales/mr/translation.json
@@ -263,6 +263,6 @@
         "remindBtn": "Remind me later",
         "title": "TTL Check for updates",
         "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+        "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!"
     }
 }

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -264,6 +264,6 @@
         "remindBtn": "Remind me later",
         "title": "TTL Check for updates",
         "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+        "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!"
     }
 }

--- a/locales/zh-TW/translation.json
+++ b/locales/zh-TW/translation.json
@@ -264,6 +264,6 @@
         "remindBtn": "Remind me later",
         "title": "TTL Check for updates",
         "upto-date-msg": "Your TTL is up to date.",
-        "old-version-msg": "You are using an old version of TTL and is missing out on a lot of new cool things!"
+        "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!"
     }
 }


### PR DESCRIPTION
Just a small typo fix. "you is"