### PR TITLE
Allow punch time on flexible calendar when times are full

### DIFF
--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -275,7 +275,7 @@ class FlexibleDayCalendar extends FlexibleMonthCalendar
 
         if (!this._isCalendarOnDate(new Date()))
         {
-            $('#punch-button').prop('disabled', false);
+            $('#punch-button').prop('disabled', true);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         }
     }

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -275,7 +275,7 @@ class FlexibleDayCalendar extends FlexibleMonthCalendar
 
         if (!this._isCalendarOnDate(new Date()))
         {
-            $('#punch-button').prop('disabled', true);
+            $('#punch-button').prop('disabled', false);
             ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', false);
         }
     }

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -243,6 +243,7 @@ class FlexibleMonthCalendar extends Calendar
 
     _addEntries(element)
     {
+        const calendar = this;
         const dateKey = $(element).attr('id');
         let moreThree =
             this.constructor._getRowCode(dateKey, true /*isInterval*/) +
@@ -252,7 +253,7 @@ class FlexibleMonthCalendar extends Calendar
         element.scrollLeft = element.scrollWidth - element.clientWidth;
         $(element).find('input[type=\'time\']').off('input propertychange').on('input propertychange', function()
         {
-            this._updateTimeDayCallback($(this).attr('data-date'));
+            calendar._updateTimeDayCallback($(this).attr('data-date'));
         });
     }
 
@@ -592,7 +593,7 @@ class FlexibleMonthCalendar extends Calendar
         return leaveBy;
     }
 
-        /*
+    /*
      * Will check if the inputs for today are all filled and then enable the button, if not.
      */
     _checkTodayPunchButton()

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -412,11 +412,12 @@ class FlexibleMonthCalendar extends Calendar
             const element = $(inputs[0]).parents('.time-cells')[0];
             this._addEntries(element);
             this._toggleArrowColor(element);
-            
+
             const input = $(inputsSelector)
                 .toArray()
-                .find(input => input.value === "");
-            if (input) {
+                .find(input => input.value === '');
+            if (input)
+            {
                 $(input).val(value);
                 this._updateTimeDayCallback(key);
             }

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -393,18 +393,18 @@ class FlexibleMonthCalendar extends Calendar
 
         const value = hourMinToHourFormatted(hour, min);
         const key = generateKey(year, month, day);
-        const inputs = $('#' + key + ' input[type="time"]');
+        const inputsSelector = '#' + key + ' input[type="time"]';
+        const inputs = $(inputsSelector);
         let allFull = true;
         for (const element of inputs)
         {
             if ($(element).val().length === 0)
             {
-                allFull= false;
+                allFull = false;
                 $(element).val(value);
                 this._updateTimeDayCallback(key);
                 break;
             }
-
         }
 
         if (allFull)
@@ -412,6 +412,14 @@ class FlexibleMonthCalendar extends Calendar
             const element = $(inputs[0]).parents('.time-cells')[0];
             this._addEntries(element);
             this._toggleArrowColor(element);
+            
+            const input = $(inputsSelector)
+                .toArray()
+                .find(input => input.value === "");
+            if (input) {
+                $(input).val(value);
+                this._updateTimeDayCallback(key);
+            }
         }
     }
 


### PR DESCRIPTION
#### Related issue
Closes #506 

#### Context / Background
Allow punch button to add pair entries even when slots are full in flexible mode

#### What change is being introduced by this PR?
- Enable punch button
- Remove unnecessary  `_checkTodayPunchButton` calls, since the button will always be enabled
- Move `_addEntries` and `_toggleArrowColor` from `_drawArrowsAndButtons`  to FlexibleMonthCalendar class to be called from `punchDate`
- When `punchDate` is called, check if inputs are all full, if yes, add new entries
#### How will this be tested?
In flexible mode, try to punch time when slots are full.
