### PR TITLE
Fix error in Flexible calendar when adding a waiver

### DIFF
--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -230,7 +230,7 @@ class FlexibleMonthCalendar extends Calendar
 
         $('.waiver-trigger').off('click').on('click', function()
         {
-            const dayId = $(this).closest('tr').attr('id').substr(3);
+            const dayId = $(this)[0].nextSibling.nextSibling.nextSibling.nextSibling.id;
             const waiverDay = formatDayId(dayId);
             sendWaiverDay(waiverDay);
             displayWaiverWindow();

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -230,7 +230,7 @@ class FlexibleMonthCalendar extends Calendar
 
         $('.waiver-trigger').off('click').on('click', function()
         {
-            const dayId = $(this)[0].nextSibling.nextSibling.nextSibling.nextSibling.id;
+            const dayId = $(this).siblings().closest('.time-cells').attr('id');
             const waiverDay = formatDayId(dayId);
             sendWaiverDay(waiverDay);
             displayWaiverWindow();


### PR DESCRIPTION
#### Related issue
Closes #569 

#### Context / Background

Fixes the `undefined` error when adding a waiver in a Flexible calendar.

#### What change is being introduced by this PR?

 - Change the node reference in the `waiver-trigger` click event.

#### How will this be tested?

 - On Preferences, change the **Number of entries** to **Flexible**
 - Then in the Calendar click to add a waiver, the popup should show up

![Screen Recording 2020-10-28 at 10 11 18 PM](https://user-images.githubusercontent.com/8043309/97517680-0a020900-196c-11eb-9a92-ca9d3d917a33.gif)
