### PR TITLE
Fixing focus outline for items in preferences

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -123,6 +123,7 @@ html[data-theme="cadent-star"] {
 
 *:focus {
   outline: var(--outline);
+  z-index: 1;
 }
 
 html[data-theme="cadent-star"] ::-webkit-scrollbar-thumb {
@@ -488,6 +489,7 @@ body {
   background-color: var(--slider-background-color);
   -webkit-transition: 0.4s;
   transition: 0.4s;
+  transition: outline-color 0s;
 }
 
 .slider::before {
@@ -506,6 +508,7 @@ input:checked + .slider {
 
 input:focus + .slider {
   box-shadow: 0 0 1px var(--slider-checked-color);
+  outline: var(--outline);
 }
 
 input:checked + .slider::before {
@@ -590,6 +593,7 @@ input:disabled + .slider {
   font-variant-caps: all-petite-caps;
   border: none;
   height: inherit;
+  line-height: normal;
 }
 
 #preferences-window .weekdays-selector input {


### PR DESCRIPTION
Closes #581
In this PR I'm adjusting the height of the focus box on the date input on preferences, as well as adding a focus outline to the checkbox inputs.

![Apd5TfrtSP](https://user-images.githubusercontent.com/846063/98488111-0ee57900-2206-11eb-8600-786d4a0e5cac.gif)
