### PR TITLE
When counting today is enabled, move the balance row after current day

### DIFF
--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -104,7 +104,8 @@ class BaseCalendar
         }
 
         let balanceRowPosition = 0;
-        for (let day = 1; day < this._getTodayDate(); ++day)
+        const lastDay = this._getCountToday() ? this._getTodayDate() + 1 : this._getTodayDate();
+        for (let day = 1; day < lastDay; ++day)
         {
             if (this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day))
             {

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -513,6 +513,11 @@ class FlexibleMonthCalendar extends BaseCalendar
         let monthTotal = '00:00';
         let workingDays = 0;
         let stopCountingMonthStats = false;
+        let lastDateToCount = new Date(this._getCalendarYear(), this._getCalendarMonth(), this._getCalendarDate());
+        if (this._getCountToday())
+        {
+            lastDateToCount.setDate(lastDateToCount.getDate() + 1);
+        }
         for (let day = 1; day <= monthLength; ++day)
         {
             if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day))
@@ -536,7 +541,7 @@ class FlexibleMonthCalendar extends BaseCalendar
                 this._colorErrorLine(dateKey);
             }
 
-            stopCountingMonthStats |= (this._getTodayDate() === day && this._getTodayMonth() === this._getCalendarMonth() && this._getTodayYear() === this._getCalendarYear());
+            stopCountingMonthStats |= (lastDateToCount.getDate() === day && lastDateToCount.getMonth() === this._getCalendarMonth() && lastDateToCount.getFullYear() === this._getCalendarYear());
             if (stopCountingMonthStats)
             {
                 continue;


### PR DESCRIPTION
Closes #574

When the setting "Count today in totals" is enabled, we should move the balance to below the current day, as now today is included in the balance.

With count today:
![image](https://user-images.githubusercontent.com/846063/98496440-67c20b00-2220-11eb-9881-8801a8ca157b.png)

Without count today:
![image](https://user-images.githubusercontent.com/846063/98496462-73153680-2220-11eb-9e52-8f8a7ade76e7.png)

