### PR TITLE
Added option to prefill lunch / break time

### DIFF
--- a/__tests__/__main__/time-math.js
+++ b/__tests__/__main__/time-math.js
@@ -162,8 +162,8 @@ describe('Time Math Functions', () =>
         expect(validateTime('00:11')).toBeTruthy();
         expect(validateTime('01:11')).toBeTruthy();
         expect(validateTime('11:11')).toBeTruthy();
-        expect(validateTime('24:00')).toBeTruthy();
         expect(validateTime('-04:00')).toBeTruthy();
+        expect(validateTime('24:00')).not.toBeTruthy();
         expect(validateTime('34:00')).not.toBeTruthy();
         expect(validateTime('4:00')).not.toBeTruthy();
         expect(validateTime('00:1')).not.toBeTruthy();

--- a/__tests__/__renderer__/user-preferences.js
+++ b/__tests__/__renderer__/user-preferences.js
@@ -7,7 +7,7 @@ const {
     getUserPreferences,
     savePreferences,
     isNotBoolean,
-    isValidPreferenceTime,
+    isNotificationInterval,
 } = require('../../js/user-preferences');
 const fs = require('fs');
 
@@ -23,19 +23,31 @@ describe('Should return false if the value is not boolean type', () =>
     });
 });
 
-describe('Should return true if the value is a valid time', () =>
+describe('Should return true if the value is a valid notification interval', () =>
 {
-    test('Value as time format (hh:mm)', () =>
+    test('Value as number (val >= 1 || val <= 30)', () =>
     {
-        expect(isValidPreferenceTime('00:35')).toBe(true);
+        expect(isNotificationInterval(1)).toBe(true);
+        expect(isNotificationInterval(15)).toBe(true);
+        expect(isNotificationInterval(30)).toBe(true);
+        expect(isNotificationInterval(-5)).not.toBe(true);
+        expect(isNotificationInterval(0)).not.toBe(true);
+        expect(isNotificationInterval(31)).not.toBe(true);
+        expect(isNotificationInterval(60)).not.toBe(true);
     });
-    test('Value as number type (val < 1 || val > 30)', () =>
+    test('Value as string (val >= 1 || val <= 30)', () =>
     {
-        expect(isValidPreferenceTime(60)).toBe(true);
+        expect(isNotificationInterval('1')).toBe(true);
+        expect(isNotificationInterval('30')).toBe(true);
+        expect(isNotificationInterval('-5')).not.toBe(true);
+        expect(isNotificationInterval('31')).not.toBe(true);
+        expect(isNotificationInterval('A')).not.toBe(true);
+        expect(isNotificationInterval('abc')).not.toBe(true);
     });
     test('Value as boolean type', () =>
     {
-        expect(isValidPreferenceTime(true)).toBe(false);
+        expect(isNotificationInterval(true)).not.toBe(true);
+        expect(isNotificationInterval(false)).not.toBe(true);
     });
 });
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -650,7 +650,7 @@ input:disabled + .slider {
   left: 25px;
 }
 
-#preferences-window #hours-per-day {
+#preferences-window #hours-per-day, #lunch-time-interval {
   text-align: right;
 }
 

--- a/js/classes/Calendar.js
+++ b/js/classes/Calendar.js
@@ -651,6 +651,16 @@ class Calendar
         return this._preferences['hide-non-working-days'];
     }
 
+    _getEnablePrefillLunchTime()
+    {
+        return this._preferences['enable-prefill-lunch-time'];
+    }
+
+    _getLunchTimeInterval()
+    {
+        return this._preferences['lunch-time-interval'];
+    }
+
     /**
      * Returns if "count today" was set in preferences.
      * @return {Boolean}
@@ -717,6 +727,16 @@ class Calendar
         return showDay(year, month, day, this._preferences);
     }
 
+    _calculateLunchEnd(lunchBegin)
+    {
+        let lunchInterval = this._getLunchTimeInterval();
+        let lunchEnd = sumTime(lunchBegin, lunchInterval);
+
+        let re = new RegExp('^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$');
+        lunchEnd = re.test(lunchEnd) ? lunchEnd : '23:59';
+        return lunchEnd;
+    }
+
     /**
      * Adds the next missing entry on the actual day and updates calendar.
      */
@@ -761,6 +781,14 @@ class Calendar
         let value = hourMinToHourFormatted(hour, min);
         $('#' + dayStr + entry).val(value);
         this._updateTimeDayCallback(dayStr + entry, value);
+
+        if (entry === 'lunch-begin' &&
+        this._getEnablePrefillLunchTime())
+        {
+            value = this._calculateLunchEnd(value);
+            $('#' + dayStr + 'lunch-end').val(value);
+            this._updateTimeDayCallback(dayStr + 'lunch-end', value);
+        }
     }
 
     /**

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -401,14 +401,24 @@ class FlexibleMonthCalendar extends Calendar
         const value = hourMinToHourFormatted(hour, min);
         const key = generateKey(year, month, day);
         const inputs = $('#' + key + ' input[type="time"]');
+
+        let i = 0;
         for (const element of inputs)
         {
             if ($(element).val().length === 0)
             {
                 $(element).val(value);
+                if ( i !== inputs.length - 1 &&
+                    i % 2 === 1 &&
+                    this._getEnablePrefillLunchTime())
+                {
+                    const lunchEnd = this._calculateLunchEnd(value);
+                    $(inputs[i+1]).val(lunchEnd);
+                }
                 this._updateTimeDayCallback(key);
                 break;
             }
+            i++;
         }
     }
 

--- a/js/time-math.js
+++ b/js/time-math.js
@@ -90,7 +90,7 @@ function sumTime(t1, t2)
  */
 function validateTime(time)
 {
-    let re = new RegExp('[0-2][0-9]:[0-5][0-9]');
+    let re = new RegExp('^-?(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$');
     return re.test(time);
 }
 

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -18,6 +18,8 @@ const defaultPreferences = {
     'minimize-to-tray': true,
     'hide-non-working-days': false,
     'hours-per-day': '08:00',
+    'enable-prefill-lunch-time': false,
+    'lunch-time-interval': '00:30',
     'notification': true,
     'repetition': true,
     'notifications-interval': '5',
@@ -43,6 +45,7 @@ const booleanInputs = [
     'close-to-tray',
     'minimize-to-tray',
     'hide-non-working-days',
+    'enable-prefill-lunch-time',
     'notification',
     'repetition',
     'start-at-login',
@@ -58,9 +61,13 @@ const booleanInputs = [
 const timeInputs = [
     'notifications-interval',
     'hours-per-day',
+    'lunch-time-interval',
 ];
 
 const isNotBoolean = (val) => typeof val !== 'boolean';
+const isNotificationInterval = (val) => !Number.isNaN(Number(val)) && isNotBoolean(val) && val >= 1 && val <= 30;
+
+//Don't use this. Use isNotificationInterval() and validateTime()
 const isValidPreferenceTime = (val) => validateTime(val) || Number.isNaN(Number(val)) || val < 1 || val > 30;
 
 /*
@@ -152,10 +159,14 @@ function initPreferencesFileIfNotExistsOrInvalid()
             shouldSaveDerivedPrefs = true;
         }
 
-        if (timeInputs.includes(key) && isValidPreferenceTime(value))
+        if (timeInputs.includes(key))
         {
-            derivedPrefs[key] = defaultPreferences[key];
-            shouldSaveDerivedPrefs = true;
+            // Set default preference value if notification or time interval is not valid
+            if ((key === 'notifications-interval' && !isNotificationInterval(value)) || !validateTime(value))
+            {
+                derivedPrefs[key] = defaultPreferences[key];
+                shouldSaveDerivedPrefs = true;
+            }
         }
 
         const inputEnum = {
@@ -292,6 +303,7 @@ module.exports = {
     showDay,
     switchCalendarView,
     isNotBoolean,
+    isNotificationInterval,
     isValidPreferenceTime,
     notificationIsEnabled,
     repetitionIsEnabled

--- a/locales/ca-CA/translation.json
+++ b/locales/ca-CA/translation.json
@@ -12,6 +12,8 @@
         "sat": "Dis",
         "hideNonWorkingDay": "Ocultar els dies no laborables (Vista mensual)",
         "hoursPerDay": "Hores per dia",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Funcionament de l'aplicació",
         "notification": "Notificació",
         "allowRecurringNotifications": "Permetre notificacions recurrents",
@@ -33,7 +35,8 @@
         "fixed": "Fixe",
         "flexible": "Flexible",
         "language": "Llenguatge",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Sobre",

--- a/locales/de-DE/translation.json
+++ b/locales/de-DE/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sa",
         "hideNonWorkingDay": "Arbeitsfreie Tage ausblenden (Monatsansicht)",
         "hoursPerDay": "Stunden pro Tag",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "App Verhalten",
         "notification": "Benachrichtigungen",
         "allowRecurringNotifications": "Wiederkehrende Benachrichtigungen erlauben",
@@ -33,7 +35,8 @@
         "fixed": "Fixiert",
         "flexible": "Flexibel",
         "language": "Sprache",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Über Time-To-Leave",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sat",
         "hideNonWorkingDay": "Hide non-working days (Month View)",
         "hoursPerDay": "Hours per day",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "App Behavior",
         "notification": "Notification",
         "allowRecurringNotifications": "Allow recurring notifications",
@@ -33,7 +35,8 @@
         "fixed": "Fixed",
         "flexible": "Flexible",
         "language": "Language",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "About",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sáb",
         "hideNonWorkingDay": "Ocultar los días no laborables (Vista por mes)",
         "hoursPerDay": "Horas por día",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Comportamiento de la aplicación",
         "notification": "Notificación",
         "allowRecurringNotifications": "Permitir notificaciones recurrentes",
@@ -33,7 +35,8 @@
         "fixed": "Fijo",
         "flexible": "Flexible",
         "language": "Languaje",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Sobre",

--- a/locales/fr-FR/translation.json
+++ b/locales/fr-FR/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sam",
         "hideNonWorkingDay": "Masquer les jours non ouvrés (Vue Mois)",
         "hoursPerDay": "Heures par jour",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Comportement de l'application",
         "notification": "Notification",
         "allowRecurringNotifications": "Autoriser les notifications récurrentes",
@@ -33,7 +35,8 @@
         "fixed": "Fixée",
         "flexible": "Flexible",
         "language": "Langue",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "À propos",

--- a/locales/hi/translation.json
+++ b/locales/hi/translation.json
@@ -12,6 +12,8 @@
         "fri": "शुक्र",
         "hideNonWorkingDay": "गैर-कार्य दिवस (माह दृश्य) छुपाएं",
         "hoursPerDay": "प्रति दिन घंटे",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "hours-per-day": "HH:mm",
         "language": "भाषा: हिन्दी",
         "light": "रोशनी",
@@ -33,7 +35,8 @@
         "userPreferences": "उपयोगकर्ता वरीयताएं",
         "view": "राय",
         "wed": "बुध",
-        "workingDays": "कार्य दिवस"
+        "workingDays": "कार्य दिवस",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "के बारे में",

--- a/locales/id/translation.json
+++ b/locales/id/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sab",
         "hideNonWorkingDay": "Sembunyikan hari Bukan-kerja (Tampilan Bulan)",
         "hoursPerDay": "Jam per-hari",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Perilaku Aplikasi",
         "notification": "Notifikasi",
         "allowRecurringNotifications": "Izinkan pemberitahuan berulang",
@@ -33,7 +35,8 @@
         "fixed": "Tetap",
         "flexible": "Fleksibel",
         "language": "Bahasa",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Tentang",

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sab",
         "hideNonWorkingDay": "Nascondi giorni festivi (visuale Mese)",
         "hoursPerDay": "Ore al giorno",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Comportamento App",
         "notification": "Notifiche",
         "allowRecurringNotifications": "Permetti notifiche ricorrenti",
@@ -33,7 +35,8 @@
         "fixed": "Fisso",
         "flexible": "Flessibile",
         "language": "Linguaggio",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Informazioni",

--- a/locales/ko/translation.json
+++ b/locales/ko/translation.json
@@ -12,6 +12,8 @@
         "sat": "토",
         "hideNonWorkingDay": "휴일 숨기기 (월별 보기에 적용)",
         "hoursPerDay": "하루 작업 목표 시간",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "프로그램 동작",
         "notification": "알림 표시",
         "allowRecurringNotifications": "반복 알림 허용",
@@ -33,7 +35,8 @@
         "fixed": "고정",
         "flexible": "가변",
         "language": "언어",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "자세히",

--- a/locales/mr/translation.json
+++ b/locales/mr/translation.json
@@ -12,6 +12,8 @@
         "sat": "शनि",
         "hideNonWorkingDay": "नॉन-कामकाजाचे दिवस लपवा (महिना दृश्य)",
         "hoursPerDay": "दिवसाचे तास",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "अ‍ॅप वर्तन",
         "notification": "सूचना",
         "allowRecurringNotifications": "आवर्ती सूचनांना परवानगी द्या",
@@ -33,7 +35,8 @@
         "fixed": "निश्चित",
         "flexible": "परिवर्तनशील",
         "language": "भाषा",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "बद्दल",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -12,6 +12,8 @@
         "sat": "Za",
         "hideNonWorkingDay": "Niet-werkdagen verbergen (Maandoverzicht)",
         "hoursPerDay": "Aantal uur per dag",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "App-gedrag",
         "notification": "Melding",
         "allowRecurringNotifications": "Terugkerende meldingen toestaan",
@@ -33,7 +35,8 @@
         "fixed": "Vast",
         "flexible": "Flexibel",
         "language": "Taal",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Over",

--- a/locales/pl/translation.json
+++ b/locales/pl/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sob",
         "hideNonWorkingDay": "Ukryj dni wolne (Widok Miesiąca)",
         "hoursPerDay": "Ilość godzin pracy dzienie",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Zachowanie aplikacji",
         "notification": "Powiadomienia",
         "allowRecurringNotifications": "Przypominaj wielokrotnie",
@@ -33,7 +35,8 @@
         "fixed": "Stała",
         "flexible": "Dynamiczna",
         "language": "Język (Language)",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Informacje o programie",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -12,6 +12,8 @@
         "sat": "Sáb",
         "hideNonWorkingDay": "Ocultar dias não úteis (Visão de mês)",
         "hoursPerDay": "Horas por dia",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "Comportamento do App",
         "notification": "Notificação",
         "allowRecurringNotifications": "Permitir notificações recorrentes",
@@ -33,7 +35,8 @@
         "fixed": "Fixo",
         "flexible": "Flexível",
         "language": "Idioma",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "Sobre",

--- a/locales/th-TH/translation.json
+++ b/locales/th-TH/translation.json
@@ -12,6 +12,8 @@
         "sat": "เสาร์",
         "hideNonWorkingDay": "ซ่อนวันหยุด (มุมมองรายเดือน)",
         "hoursPerDay": "จำนวนชั่วโมงทำงานต่อวัน",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "พฤติกรรมแอปพลิเคชัน",
         "notification": "การแจ้งเตือน",
         "allowRecurringNotifications": "อนุญาตให้แจ้งเตือนซ้ำ",
@@ -33,7 +35,8 @@
         "fixed": "ล็อค",
         "flexible": "ยืดหยุ่น",
         "language": "ภาษา",
-        "hours-per-day": "ชช:นน"
+        "hours-per-day": "ชช:นน",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "เกี่ยวกับ",

--- a/locales/zh-TW/translation.json
+++ b/locales/zh-TW/translation.json
@@ -12,6 +12,8 @@
         "sat": "六",
         "hideNonWorkingDay": "隱藏非工作日（月份視角）",
         "hoursPerDay": "小時每日",
+        "enablePrefillLunchTime": "Enable prefilling of lunch time",
+        "lunchTimeInterval": "Lunch Time Interval",
         "appBehavior": "程式特性",
         "notification": "通知",
         "allowRecurringNotifications": "允許定期通知",
@@ -33,7 +35,8 @@
         "fixed": "固定",
         "flexible": "自由",
         "language": "語言",
-        "hours-per-day": "HH:mm"
+        "hours-per-day": "HH:mm",
+        "lunch-time-interval": "HH:mm"
     },
     "$Menu": {
         "about": "關於",

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -47,6 +47,14 @@
                 <p data-i18n="$Preferences.hoursPerDay">Hours per day</p>
                 <input data-i18n="[placeholder]$Preferences.hours-per-day" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="08:00" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
             </div>
+            <div class="flex-box">
+                <p><i class="fas fa-utensils"></i><span data-i18n="$Preferences.enablePrefillLunchTime">Enable prefilling of lunch time</span></p>
+                <label id='enable-prefill-lunch-time' class="switch"><input type="checkbox" name="enable-prefill-lunch-time"><span class="slider round"></span></label>
+            </div>
+            <div class="flex-box">
+                <p data-i18n="$Preferences.lunchTimeInterval">Lunch Time Interval</p>
+                <input data-i18n="[placeholder]$Preferences.lunch-time-interval" type="text" name="lunch-time-interval" id="lunch-time-interval" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="00:30" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '00:30'">
+            </div>
             
         </section>
 

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -125,7 +125,7 @@ function renderPreferencesWindow()
         changeValue(this.name, this.checked);
     });
 
-    $('#hours-per-day').on('change', function()
+    $('#hours-per-day, #lunch-time-interval').on('change', function()
     {
         /* istanbul ignore else */
         if (this.checkValidity() === true)


### PR DESCRIPTION
#### Related issue
Closes #355

#### Context / Background
Added option to automatically prefill lunch end (or break end in flexible) when punching on lunch/break start.
2 new input fields in preferences - Switch that enables this feature and text input for break time length.
Lunch end will be prefilled only when punching on lunch start. Manually typing in lunch start won't prefill the end time. 

#### What change is being introduced by this PR?
Modified `punchDate` function in `Calendar.js` to check if we are punching for lunch-begin. Then calculate lunch end time ( in new function `_calculateLunchEnd` ) based on user preference and update lunch end field with this value.

Similarly modified `punchDate` in `FlexibleMonthCalendar` but we check for break start by index of time input field.

This PR also fixes problem with time input type user preferences not saving/displaying correct value. Problem was with `initPreferencesFileIfNotExistsOrInvalid`, specifically when validating time inputs with `isValidPreferenceTime`. This function tries to validate both notification interval and HH:mm time input in one condition. It's confusing and doesn't do what it is supposed to, so I just wrote new function `isNotificationInterval` and used it properly together with `validateTime`. 
I also removed the function from tests and added tests for `isNotificationInterval`.

I edited regex in `validateTime`. Old one allowed up to 29 hours in input.

Added field in translations:

- enablePrefillLunchTime
- lunchTimeInterval
- lunch-time-interval

<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->

#### How will this be tested?
Tested only manually. Will add tests later.
<!--
- How will you verify whether your changes worked as expected once merged?
-->
