### PR TITLE
Fixing waiver window open from Calendar

### DIFF
--- a/__tests__/__renderer__/workday-waiver-aux.js
+++ b/__tests__/__renderer__/workday-waiver-aux.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const { formatDayId, sendWaiverDay } = require('../../js/workday-waiver-aux');
+const { formatDayId, displayWaiverWindow } = require('../../js/workday-waiver-aux');
 
 describe('Workday Waiver Aux', function()
 {
@@ -27,16 +27,16 @@ describe('Workday Waiver Aux', function()
         });
     });
 
-    describe('sendWaiverDay(dayId)', function()
+    describe('displayWaiverWindow(dayId)', function()
     {
         test('should do seamless call', async() =>
         {
-            await sendWaiverDay(validJSDay);
-            await sendWaiverDay(validJSDay2);
-            await sendWaiverDay(garbageString);
-            await sendWaiverDay(incompleteDate);
+            await displayWaiverWindow(validJSDay);
+            await displayWaiverWindow(validJSDay2);
+            await displayWaiverWindow(garbageString);
+            await displayWaiverWindow(incompleteDate);
         });
     });
 
-    // TODO: Come up with a way to test displayWaiverWindow
+    // TODO: Come up with a way to test displayWaiverWindow's opening of a window
 });

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -11,7 +11,6 @@ const {
 } = require('../time-math.js');
 const {
     formatDayId,
-    sendWaiverDay,
     displayWaiverWindow
 } = require('../workday-waiver-aux.js');
 const { showDay, switchCalendarView } = require('../user-preferences.js');
@@ -169,8 +168,7 @@ class BaseCalendar
             //  deepcode ignore no-invalid-this: jQuery use
             const dayId = $(this).closest('tr').attr('id').substr(3);
             const waiverDay = formatDayId(dayId);
-            sendWaiverDay(waiverDay);
-            displayWaiverWindow();
+            displayWaiverWindow(waiverDay);
         });
 
         this._updateAllTimeBalance();

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -11,7 +11,6 @@ const { getMonthLength } = require('../date-aux.js');
 const { generateKey } = require('../date-db-formatter.js');
 const {
     formatDayId,
-    sendWaiverDay,
     displayWaiverWindow
 } = require('../workday-waiver-aux.js');
 const { showDialog } = require('../window-aux.js');
@@ -271,8 +270,7 @@ class FlexibleMonthCalendar extends BaseCalendar
         {
             const dayId = $(this).siblings().closest('.time-cells').attr('id');
             const waiverDay = formatDayId(dayId);
-            sendWaiverDay(waiverDay);
-            displayWaiverWindow();
+            displayWaiverWindow(waiverDay);
         });
     }
 

--- a/js/menus.js
+++ b/js/menus.js
@@ -3,7 +3,6 @@
 const { app, BrowserWindow, clipboard, dialog, shell } = require('electron');
 const { appConfig, getDetails } = require('./app-config.js');
 const { checkForUpdates } = require('./update-manager');
-const { getDateStr } = require('./date-aux.js');
 const {
     getSavedPreferences,
 } = require('./saved-preferences.js');
@@ -13,7 +12,7 @@ const { savePreferences } = require('./user-preferences.js');
 const path = require('path');
 const Store = require('electron-store');
 const i18n = require('../src/configs/i18next.config');
-let { waiverWindow, prefWindow } = require('./windows');
+let { openWaiverManagerWindow, prefWindow } = require('./windows');
 
 function getMainMenuTemplate(mainWindow)
 {
@@ -23,35 +22,7 @@ function getMainMenuTemplate(mainWindow)
             id: 'workday-waiver-manager',
             click(item, window, event)
             {
-                if (waiverWindow !== null)
-                {
-                    waiverWindow.show();
-                    return;
-                }
-
-                if (event)
-                {
-                    const today = new Date();
-                    global.waiverDay = getDateStr(today);
-                }
-                const htmlPath = path.join('file://', __dirname, '../src/workday-waiver.html');
-                waiverWindow = new BrowserWindow({ width: 600,
-                    height: 500,
-                    parent: mainWindow,
-                    resizable: true,
-                    icon: appConfig.iconpath,
-                    webPreferences: {
-                        enableRemoteModule: true,
-                        nodeIntegration: true
-                    } });
-                waiverWindow.setMenu(null);
-                waiverWindow.loadURL(htmlPath);
-                waiverWindow.show();
-                waiverWindow.on('close', function()
-                {
-                    waiverWindow = null;
-                    mainWindow.webContents.send('WAIVER_SAVED');
-                });
+                openWaiverManagerWindow(mainWindow, event);
             },
         },
         {type: 'separator'},

--- a/js/windows.js
+++ b/js/windows.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const { BrowserWindow } = require('electron');
+const { appConfig } = require('./app-config.js');
+const path = require('path');
+const { getDateStr } = require('./date-aux.js');
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let waiverWindow = null;
@@ -7,9 +12,43 @@ let prefWindow = null;
 let tray = null;
 let contextMenu = null;
 
+function openWaiverManagerWindow(mainWindow, event)
+{
+    if (waiverWindow !== null)
+    {
+        waiverWindow.show();
+        return;
+    }
+
+    if (event)
+    {
+        const today = new Date();
+        global.waiverDay = getDateStr(today);
+    }
+    const htmlPath = path.join('file://', __dirname, '../src/workday-waiver.html');
+    waiverWindow = new BrowserWindow({ width: 600,
+        height: 500,
+        parent: mainWindow,
+        resizable: true,
+        icon: appConfig.iconpath,
+        webPreferences: {
+            enableRemoteModule: true,
+            nodeIntegration: true
+        } });
+    waiverWindow.setMenu(null);
+    waiverWindow.loadURL(htmlPath);
+    waiverWindow.show();
+    waiverWindow.on('close', function()
+    {
+        waiverWindow = null;
+        mainWindow.webContents.send('WAIVER_SAVED');
+    });
+}
+
 module.exports = {
     waiverWindow,
     prefWindow,
     tray,
-    contextMenu
+    contextMenu,
+    openWaiverManagerWindow
 };

--- a/js/workday-waiver-aux.js
+++ b/js/workday-waiver-aux.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { ipcRenderer } = require('electron');
-const { Menu } = require('electron').remote;
 
 /**
  * @param {string} dayId - day in '<year>-<month - 1>-<day>' format
@@ -16,26 +15,16 @@ function formatDayId(dayId)
 }
 
 /**
- * Sends waiverDay value through SET_WAIVER_DAY event.
+ * Sends waiverDay value through SET_WAIVER_DAY event, which triggers open window event on main process.
  *
  * @param {string} waiverDay - day in 'YYYY-MM-DD' format
  */
-function sendWaiverDay(waiverDay)
+function displayWaiverWindow(waiverDay)
 {
     ipcRenderer.send('SET_WAIVER_DAY', waiverDay);
 }
 
-/**
- * Displays workday waiver manager window.
- */
-function displayWaiverWindow()
-{
-    const waiverMenu = Menu.getApplicationMenu().getMenuItemById('workday-waiver-manager');
-    waiverMenu.click();
-}
-
 module.exports = {
     formatDayId,
-    sendWaiverDay,
     displayWaiverWindow
 };

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const { createWindow, createMenu, getMainWindow, triggerStartupDialogs } = requi
 const { notify } = require('./js/notification');
 const { getUserPreferences } = require('./js/user-preferences.js');
 const i18n = require('./src/configs/i18next.config');
+const { openWaiverManagerWindow } = require('./js/windows.js');
 
 i18n.on('loaded', () =>
 {
@@ -42,6 +43,8 @@ ipcMain.on('GET_INITIAL_TRANSLATIONS', (event, language) =>
 ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) =>
 {
     global.waiverDay = waiverDay;
+    const mainWindow = getMainWindow();
+    openWaiverManagerWindow(mainWindow);
 });
 
 let launchDate = new Date();


### PR DESCRIPTION
After we stopped setting the ApplicationMenu in createMenu() because of i18n, the function displayWaiverWindow() stopped working on the calendar when clicking on a day, because it was trying to get the menu out of the Application Menu. This probably worked on MacOS, but not on Windows.

I changed it so that, when clicking on a day, the SET_WAIVER_DAY ipc event also triggers the window opening, this time directly on the main process. The function to open the Waiver Manager was extracted from menus.js into the windows.js file.