### PR TITLE
Add squirrel module so app shows up on Windows searchbar

### DIFF
--- a/js/squirrel.js
+++ b/js/squirrel.js
@@ -1,6 +1,7 @@
-/* eslint-disable */
-function handleSquirrelEvent(application) {
-    if (process.argv.length === 1) {
+function handleSquirrelEvent(application)
+{
+    if (process.argv.length === 1)
+    {
         return false;
     }
 
@@ -12,57 +13,60 @@ function handleSquirrelEvent(application) {
     const updateDotExe = path.resolve(path.join(rootAtomFolder, 'Update.exe'));
     const exeName = path.basename(process.execPath);
 
-    const spawn = function(command, args) {
-        let spawnedProcess, error;
+    const spawn = function(command, args)
+    {
+        let spawnedProcess;
 
-        try {
+        try
+        {
             spawnedProcess = ChildProcess.spawn(command, args, {
                 detached: true
             });
-        } catch (error) {}
+        }
+        catch (error)
+        {
+            // eslint-disable-next-line no-empty
+            // We don't need to do anything in this block.
+        }
 
         return spawnedProcess;
     };
 
-    const spawnUpdate = function(args) {
+    const spawnUpdate = function(args)
+    {
         return spawn(updateDotExe, args);
     };
 
     const squirrelEvent = process.argv[1];
-    switch (squirrelEvent) {
-        case '--squirrel-install':
-        case '--squirrel-updated':
-            // Optionally do things such as:
-            // - Add your .exe to the PATH
-            // - Write to the registry for things like file associations and
-            //   explorer context menus
+    switch (squirrelEvent)
+    {
+    case '--squirrel-install':
+    case '--squirrel-updated':
 
-            // Install start menu shortcuts
-            spawnUpdate(['--createShortcut', exeName]);
+        // Install start menu shortcuts
+        spawnUpdate(['--createShortcut', exeName]);
 
-            setTimeout(application.quit, 1000);
-            return true;
+        setTimeout(application.quit, 1000);
+        return true;
 
-        case '--squirrel-uninstall':
-            // Undo anything you did in the --squirrel-install and
-            // --squirrel-updated handlers
+    case '--squirrel-uninstall':
+        // Undo anything you did in the --squirrel-install and --squirrel-updated handlers
 
-            // Remove start menu shortcuts
-            spawnUpdate(['--removeShortcut', exeName]);
+        // Remove start menu shortcuts
+        spawnUpdate(['--removeShortcut', exeName]);
 
-            setTimeout(application.quit, 1000);
-            return true;
+        setTimeout(application.quit, 1000);
+        return true;
 
-        case '--squirrel-obsolete':
-            // This is called on the outgoing version of your app before
-            // we update to the new version - it's the opposite of
-            // --squirrel-updated
+    case '--squirrel-obsolete':
+        // This is called on the outgoing version of your app before
+        // we update to the new version - it's the opposite of
+        // --squirrel-updated
 
-            application.quit();
-            return true;
+        application.quit();
+        return true;
     }
-};
-/* eslint-enable */
+}
 
 module.exports = {
     handleSquirrelEvent

--- a/js/squirrel.js
+++ b/js/squirrel.js
@@ -1,0 +1,69 @@
+/* eslint-disable */
+function handleSquirrelEvent(application) {
+    if (process.argv.length === 1) {
+        return false;
+    }
+
+    const ChildProcess = require('child_process');
+    const path = require('path');
+
+    const appFolder = path.resolve(process.execPath, '..');
+    const rootAtomFolder = path.resolve(appFolder, '..');
+    const updateDotExe = path.resolve(path.join(rootAtomFolder, 'Update.exe'));
+    const exeName = path.basename(process.execPath);
+
+    const spawn = function(command, args) {
+        let spawnedProcess, error;
+
+        try {
+            spawnedProcess = ChildProcess.spawn(command, args, {
+                detached: true
+            });
+        } catch (error) {}
+
+        return spawnedProcess;
+    };
+
+    const spawnUpdate = function(args) {
+        return spawn(updateDotExe, args);
+    };
+
+    const squirrelEvent = process.argv[1];
+    switch (squirrelEvent) {
+        case '--squirrel-install':
+        case '--squirrel-updated':
+            // Optionally do things such as:
+            // - Add your .exe to the PATH
+            // - Write to the registry for things like file associations and
+            //   explorer context menus
+
+            // Install start menu shortcuts
+            spawnUpdate(['--createShortcut', exeName]);
+
+            setTimeout(application.quit, 1000);
+            return true;
+
+        case '--squirrel-uninstall':
+            // Undo anything you did in the --squirrel-install and
+            // --squirrel-updated handlers
+
+            // Remove start menu shortcuts
+            spawnUpdate(['--removeShortcut', exeName]);
+
+            setTimeout(application.quit, 1000);
+            return true;
+
+        case '--squirrel-obsolete':
+            // This is called on the outgoing version of your app before
+            // we update to the new version - it's the opposite of
+            // --squirrel-updated
+
+            application.quit();
+            return true;
+    }
+};
+/* eslint-enable */
+
+module.exports = {
+    handleSquirrelEvent
+};

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const { createWindow, createMenu, getMainWindow, triggerStartupDialogs } = requi
 const { notify } = require('./js/notification');
 const { getUserPreferences } = require('./js/user-preferences.js');
 const i18n = require('./src/configs/i18next.config');
+const { handleSquirrelEvent } = require('./js/squirrel.js');
 
 /* eslint-disable */
 if (handleSquirrelEvent(app)) {
@@ -170,69 +171,3 @@ catch (_)
     // eslint-disable-next-line no-empty
     // We don't need to do anything in this block.
 }
-
-/* eslint-disable */
-function handleSquirrelEvent(application) {
-    if (process.argv.length === 1) {
-        return false;
-    }
-
-    const ChildProcess = require('child_process');
-    const path = require('path');
-
-    const appFolder = path.resolve(process.execPath, '..');
-    const rootAtomFolder = path.resolve(appFolder, '..');
-    const updateDotExe = path.resolve(path.join(rootAtomFolder, 'Update.exe'));
-    const exeName = path.basename(process.execPath);
-
-    const spawn = function(command, args) {
-        let spawnedProcess, error;
-
-        try {
-            spawnedProcess = ChildProcess.spawn(command, args, {
-                detached: true
-            });
-        } catch (error) {}
-
-        return spawnedProcess;
-    };
-
-    const spawnUpdate = function(args) {
-        return spawn(updateDotExe, args);
-    };
-
-    const squirrelEvent = process.argv[1];
-    switch (squirrelEvent) {
-        case '--squirrel-install':
-        case '--squirrel-updated':
-            // Optionally do things such as:
-            // - Add your .exe to the PATH
-            // - Write to the registry for things like file associations and
-            //   explorer context menus
-
-            // Install start menu shortcuts
-            spawnUpdate(['--createShortcut', exeName]);
-
-            setTimeout(application.quit, 1000);
-            return true;
-
-        case '--squirrel-uninstall':
-            // Undo anything you did in the --squirrel-install and
-            // --squirrel-updated handlers
-
-            // Remove start menu shortcuts
-            spawnUpdate(['--removeShortcut', exeName]);
-
-            setTimeout(application.quit, 1000);
-            return true;
-
-        case '--squirrel-obsolete':
-            // This is called on the outgoing version of your app before
-            // we update to the new version - it's the opposite of
-            // --squirrel-updated
-
-            application.quit();
-            return true;
-    }
-};
-/* eslint-enable */

--- a/main.js
+++ b/main.js
@@ -7,6 +7,13 @@ const { notify } = require('./js/notification');
 const { getUserPreferences } = require('./js/user-preferences.js');
 const i18n = require('./src/configs/i18next.config');
 
+/* eslint-disable */
+if (handleSquirrelEvent(app)) {
+    // squirrel event handled and app will exit in 1000ms, so don't do anything else
+    return;
+  }
+/* eslint-enable */
+
 i18n.on('loaded', () =>
 {
     const userPreferences = getUserPreferences();
@@ -163,3 +170,69 @@ catch (_)
     // eslint-disable-next-line no-empty
     // We don't need to do anything in this block.
 }
+
+/* eslint-disable */
+function handleSquirrelEvent(application) {
+    if (process.argv.length === 1) {
+        return false;
+    }
+
+    const ChildProcess = require('child_process');
+    const path = require('path');
+
+    const appFolder = path.resolve(process.execPath, '..');
+    const rootAtomFolder = path.resolve(appFolder, '..');
+    const updateDotExe = path.resolve(path.join(rootAtomFolder, 'Update.exe'));
+    const exeName = path.basename(process.execPath);
+
+    const spawn = function(command, args) {
+        let spawnedProcess, error;
+
+        try {
+            spawnedProcess = ChildProcess.spawn(command, args, {
+                detached: true
+            });
+        } catch (error) {}
+
+        return spawnedProcess;
+    };
+
+    const spawnUpdate = function(args) {
+        return spawn(updateDotExe, args);
+    };
+
+    const squirrelEvent = process.argv[1];
+    switch (squirrelEvent) {
+        case '--squirrel-install':
+        case '--squirrel-updated':
+            // Optionally do things such as:
+            // - Add your .exe to the PATH
+            // - Write to the registry for things like file associations and
+            //   explorer context menus
+
+            // Install start menu shortcuts
+            spawnUpdate(['--createShortcut', exeName]);
+
+            setTimeout(application.quit, 1000);
+            return true;
+
+        case '--squirrel-uninstall':
+            // Undo anything you did in the --squirrel-install and
+            // --squirrel-updated handlers
+
+            // Remove start menu shortcuts
+            spawnUpdate(['--removeShortcut', exeName]);
+
+            setTimeout(application.quit, 1000);
+            return true;
+
+        case '--squirrel-obsolete':
+            // This is called on the outgoing version of your app before
+            // we update to the new version - it's the opposite of
+            // --squirrel-updated
+
+            application.quit();
+            return true;
+    }
+};
+/* eslint-enable */

--- a/main.js
+++ b/main.js
@@ -7,13 +7,16 @@ const { notify } = require('./js/notification');
 const { getUserPreferences } = require('./js/user-preferences.js');
 const i18n = require('./src/configs/i18next.config');
 const { handleSquirrelEvent } = require('./js/squirrel.js');
+const { appConfig } = require('./js/app-config');
 
-/* eslint-disable */
-if (handleSquirrelEvent(app)) {
-    // squirrel event handled and app will exit in 1000ms, so don't do anything else
-    return;
-  }
-/* eslint-enable */
+if (appConfig.win32)
+{
+    if (handleSquirrelEvent(app))
+    {
+        // squirrel event handled and app will exit in 1000ms, so don't do anything else
+        return;
+    }
+}
 
 i18n.on('loaded', () =>
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4924,13 +4924,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "fsevents": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-          "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
-          "dev": true,
-          "optional": true
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5536,7 +5529,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -6466,6 +6458,14 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "electron-squirrel-startup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz",
+      "integrity": "sha1-GbTlWTP6Dvj1VnhLnGYPdyVGoLg=",
+      "requires": {
+        "debug": "^2.2.0"
       }
     },
     "electron-store": {
@@ -8014,6 +8014,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -14073,15 +14080,6 @@
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
             "readdirp": "~3.5.0"
-          },
-          "dependencies": {
-            "fsevents": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-              "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "cliui": {
@@ -14134,6 +14132,13 @@
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
@@ -14357,8 +14362,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@fortawesome/fontawesome-free": "^5.15.1",
     "bootstrap": "^4.5.3",
     "date-holidays": "^1.8.1",
+    "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^6.0.1",
     "i18next": "^19.8.2",
     "i18next-node-fs-backend": "^2.1.3",


### PR DESCRIPTION
#### Related issue
Closes #226

#### Context / Background
In Windows, when you search for the app in the Windows Searchbar, you cannot find it. With this PR, it can now be found. 

#### What change is being introduced by this PR?
Mainly there's some changes in the `main.js` file, where I added the Squirrel events as suggested in the issue: https://stackoverflow.com/questions/38000403/electron-app-installed-but-doesnt-appear-in-start-menu. In this file I 
had to disable eslint in these new changes, since when I fixed the eslint errors, the app disappeared from the searchbar again. 

There's also some changes on the packages for the app. I installed the module `electron-squirrel-startup`, which manages these Squirrel events.

#### How will this be tested?
With other computers that uses Windows. 

#### Screenshots
![p1](https://user-images.githubusercontent.com/72418396/103183674-2d183e80-4871-11eb-93da-ed548454d28e.png)

![p2](https://user-images.githubusercontent.com/72418396/103183679-32758900-4871-11eb-926b-49a2177277f5.png)
