### PR TITLE
Documentation error; fixes #601

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,13 +149,13 @@ If a release is what you want, you can use the following commands:
 
 ```bash
 # macOS
-npm run package-mac
+npm run package:mac
 
 # Windows
-npm run package-win
+npm run package:win
 
 # Debian
-npm run package-deb
+npm run package:deb
 ```
 
 These will create the respective file under `release-builds/` directory.


### PR DESCRIPTION
#### Related issue
Closes #601

#### Context / Background
https://github.com/thamara/time-to-leave/issues/601

#### What change is being introduced by this PR?
- This is a simple typo fix to use a colon with packaging commands.
