### PR TITLE
Fix Linux tray menu

### DIFF
--- a/js/main-window.js
+++ b/js/main-window.js
@@ -93,6 +93,7 @@ function createWindow()
         let contextMenuTemplate = getContextMenuTemplate(mainWindow);
         contextMenuTemplate[0].enabled = arg;
         contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
+        tray.setContextMenu(contextMenu);
     });
 
     ipcMain.on('RESIZE_MAIN_WINDOW', (event, width, height) =>


### PR DESCRIPTION
#### Related issue
Closes #568

#### Context / Background
As per the title: the tray context menu on Linux (specifically Ubuntu GNOME3) doesn't work as it does on Windows with the three actions, "Punch Time," "Show App," and "Quit," and instead just has the default tray context menu. 

#### What change is being introduced by this PR?
On Linux, app trays in Electron have to have their context menus set explicitly rather than dynamically through the `click` event, as per the [`Tray` documentation](https://www.electronjs.org/docs/api/tray).
> - When app indicator is used on Linux, the click event is ignored.

> If you want to keep exact same behaviors on all platforms, you should not rely on the click event and always attach a context menu to the tray icon.

To do this, I called `tray.setContextMenu(contextMenu)` directly after `contextMenu` is built on app startup. This may actually be a bad practice — I'm quite unfamiliar with this codebase — and I'd be glad to receive any feedback, positive or negative.

Original behavior:

![image](https://user-images.githubusercontent.com/37482938/108412281-4abdb080-71ef-11eb-8f40-5ccf8d80a22a.png)

Patched behavior:

![image](https://user-images.githubusercontent.com/37482938/108412293-4f826480-71ef-11eb-8d82-55f9405af533.png)

#### How will this be tested?
All Jest tests passed without issue, and building succeeded on both Windows and Linux; both distributions work as expected.

(Sorry about the lack of a feature branch; it slipped my mind when I made the commit.)