### PR TITLE
Fix #619: Minimum number of entries should be two

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -779,8 +779,6 @@ html[data-view='flexible'] .calendar-table-header .header-day-total {
 }
 
 html[data-view='flexible'] .row-time {
-  display: table-cell;
-  width: 50px;
   margin: auto;
 }
 
@@ -838,6 +836,7 @@ html[data-view='flexible'] .time-cells {
   width: 69%;
   overflow-x: scroll;
   height: 30px;
+  display: flex;
 }
 
 @media (min-width: 1200px) {

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -496,7 +496,7 @@ class BaseCalendar
      */
     _updateDbEntry(dateKey, newValues)
     {
-        let validatedTimes = this._validateTimes(newValues);
+        let validatedTimes = this._validateTimes(newValues, true /*removeEndingInvalids*/);
         if (validatedTimes.length > 0)
         {
             this._setStore(dateKey, validatedTimes);

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -521,7 +521,7 @@ class BaseCalendar
         const validatedTimes = this._validateTimes(values);
 
         const storeHasExpectedSize = values.length === inputs.length;
-        const inputsHaveExpectedSize = values.length >= 4 && values.length % 2 === 0;
+        const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
         const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
         const hasDayEnded = storeHasExpectedSize && inputsHaveExpectedSize && validatedTimesOk;
 
@@ -529,7 +529,7 @@ class BaseCalendar
         {
             let dayTotal = '00:00';
             let timesAreProgressing = true;
-            if (validatedTimes.length >= 4 && validatedTimes.length % 2 === 0)
+            if (validatedTimes.length >= 2 && validatedTimes.length % 2 === 0)
             {
                 for (let i = 0; i < validatedTimes.length; i += 2)
                 {

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -673,8 +673,8 @@ class FlexibleDayCalendar extends BaseCalendar
      */
     _addNecessaryEntries(dateKey, entrySize)
     {
-        // 2 pairs is the default minimum size of the table
-        const numberOfPairs = Math.ceil(entrySize/2) >= 2 ? Math.ceil(entrySize/2) : 2;
+        // 2 pairs is the default minimum size of the table, when no entries are there
+        const numberOfPairs = Math.ceil(entrySize/2) >= 1 ? Math.ceil(entrySize/2) : 2;
 
         function entryPairHTMLCode(entryIndex, isLastRow)
         {

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -291,7 +291,7 @@ class FlexibleDayCalendar extends BaseCalendar
         function removeEntries()
         {
             const existingEntryPairs = $('.row-entry-pair').length;
-            if (existingEntryPairs > 2)
+            if (existingEntryPairs > 1)
             {
                 const dateKey = $('.rows-time').attr('id');
                 const removeEntriesDialogOptions = {
@@ -310,7 +310,7 @@ class FlexibleDayCalendar extends BaseCalendar
                     $('.rows-time > div:last-of-type').remove();
                     $('.rows-time > div:last-of-type').remove();
 
-                    if (existingEntryPairs - 1 > 2)
+                    if (existingEntryPairs - 1 > 1)
                     {
                         const minusSignCode =
                             '<div class="sign-cell">' +
@@ -380,7 +380,7 @@ class FlexibleDayCalendar extends BaseCalendar
         if (values !== undefined)
         {
             const validatedTimes = this._validateTimes(values);
-            const inputsHaveExpectedSize = values.length >= 4 && values.length % 2 === 0;
+            const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
             const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
             const hasDayEnded = inputsHaveExpectedSize && validatedTimesOk;
 
@@ -389,7 +389,7 @@ class FlexibleDayCalendar extends BaseCalendar
             {
                 dayTotal = '00:00';
                 let timesAreProgressing = true;
-                if (validatedTimes.length >= 4 && validatedTimes.length % 2 === 0)
+                if (validatedTimes.length >= 2 && validatedTimes.length % 2 === 0)
                 {
                     for (let i = 0; i < validatedTimes.length; i += 2)
                     {
@@ -685,7 +685,7 @@ class FlexibleDayCalendar extends BaseCalendar
                         '<div class="sign-container"><span class="minus-sign">-</span></div>' +
                     '</div>' +
                 '</div>';
-            const shouldPrintMinusSign = numberOfPairs > 2 && isLastRow;
+            const shouldPrintMinusSign = numberOfPairs > 1 && isLastRow;
 
             return '<div class="row-entry-pair">' +
                 `<div class="th th-label first-group">${i18n.t('$FlexibleDayCalendar.entry')} #` + entryIndex + '</div>' +

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -325,7 +325,14 @@ class FlexibleMonthCalendar extends BaseCalendar
             const element = $(target);
             const hasHorizontalScrollbar = target.scrollWidth > target.clientWidth;
             element.parent().find('.arrow').toggleClass('disabled', !hasHorizontalScrollbar);
-            element.parent().find('.sign-cell.minus-sign').toggleClass('disabled', !hasHorizontalScrollbar);
+        }
+
+        function toggleMinusSign(target)
+        {
+            const element = $(target);
+            const numberEntries = $(element).find('.row-time').length;
+            const hasMoreThanTwoEntries = numberEntries > 2;
+            element.parent().find('.sign-cell.minus-sign').toggleClass('disabled', !hasMoreThanTwoEntries);
         }
 
         const resizeObserver = new ResizeObserver(entries =>
@@ -340,6 +347,7 @@ class FlexibleMonthCalendar extends BaseCalendar
         {
             resizeObserver.observe(element);
             toggleArrowColor(element);
+            toggleMinusSign(element);
         });
 
         function addEntries(element)
@@ -366,12 +374,13 @@ class FlexibleMonthCalendar extends BaseCalendar
             const element = $(this).parent().parent().find('.time-cells')[0];
             addEntries(element);
             toggleArrowColor(element);
+            toggleMinusSign(element);
         });
 
         function removeEntries(element)
         {
             const row = $(element).find('.row-time');
-            if (row.length > 5)
+            if (row.length > 3)
             {
                 const dateKey = $(element).attr('id');
                 const removeEntriesDialogOptions = {
@@ -391,6 +400,7 @@ class FlexibleMonthCalendar extends BaseCalendar
                     row.slice(sliceNum).remove();
                     calendar._updateTimeDay($(element).attr('id'));
                     toggleArrowColor(element);
+                    toggleMinusSign(element);
                     setTimeout(() =>
                     {
                         calendar._checkTodayPunchButton();
@@ -697,12 +707,12 @@ class FlexibleMonthCalendar extends BaseCalendar
             return index % 3 !== 2;
         }
 
-        function lessThanFourEntries(index)
+        function lessThanTwoEntries(index)
         {
-            return index < 5;
+            return index < 3;
         }
 
-        while (lessThanFourEntries(i) || inputGroupFullyPrinted(i))
+        while (lessThanTwoEntries(i) || inputGroupFullyPrinted(i))
         {
             ++i;
             if (indexIsInterval(i))

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -709,7 +709,7 @@ class FlexibleMonthCalendar extends BaseCalendar
 
         function lessThanTwoEntries(index)
         {
-            return index < 3;
+            return index < 2;
         }
 
         while (lessThanTwoEntries(i) || inputGroupFullyPrinted(i))


### PR DESCRIPTION
Note this still has one problem, which is always having two entries on day view or 4 on month view. We need to think of a way of saving whether the user had gone past the normal minimum to not keep readding

#### Related issue
Closes #619

#### Context / Background
Previously you could fill two slots on a day only, now you can't

#### What change is being introduced by this PR?
- Now it is possible to have only two times on the month view or one entry in the day view.
- Default is still 4 slots on month and 2 entries on day view

#### How will this be tested?
Manual Tests
GIF: https://imgur.com/a/H5fb9RE


