### PR TITLE
Fix #627: Commit hooks broken due to website files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ node_modules/
 **/*.svg
 **/*.html
 **/*.css
+website/**/*.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug:main": "electron --inspect=5858 .",
     "debug:render": "electron --remote-debugging-port=9222 .",
     "lint": "npm-run-all lint:*",
-    "lint:css": "stylelint **/*.css website/styles/*.css",
+    "lint:css": "stylelint css/*.css",
     "lint:eslint": "eslint . ",
     "lint:markdown": "prettier docs/*.md *.md -c",
     "lint:json": "prettier locales/*/*.json -c",


### PR DESCRIPTION
#### Related issue
Closes #627 

#### Context / Background
Css and js hooks don't apply to how the website css and js files are merged, and are breaking commits on the proper app.

#### What change is being introduced by this PR?
Ignoring css and js from website in lint hooks.

