### PR TITLE
Fix #506: Let punch button even when day is done

### DIFF
--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -151,9 +151,10 @@ class BaseCalendar
         this._updateTableBody();
         this._updateBasedOnDB();
 
-        let waivedInfo = this._getWaiverStore(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
-        let showCurrentDay = this._showDay(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
-        this._togglePunchButton(showCurrentDay && waivedInfo === undefined);
+        const isCurrentMonth = this._getTodayMonth() === this._getCalendarMonth() && this._getTodayYear() === this._getCalendarYear();
+        const waivedInfo = this._getWaiverStore(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
+        const showCurrentDay = this._showDay(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
+        this._togglePunchButton(isCurrentMonth && showCurrentDay && waivedInfo === undefined);
 
         this._updateLeaveBy();
 
@@ -181,6 +182,14 @@ class BaseCalendar
     redraw()
     {
         this._draw();
+    }
+
+    /**
+     * Responsible for adding new entries to the calendar view.
+     */
+    _addTodayEntries()
+    {
+        throw Error('Please implement this.');
     }
 
     /**
@@ -383,26 +392,23 @@ class BaseCalendar
         return showDay(year, month, day, this._preferences);
     }
 
-    /*
-     * Will check if the inputs for today are all filled and then enable the button, if not.
+    /**
+     * Returns whether the inputs for the day are all filled.
+     * @param {number} year
+     * @param {number} month
+     * @param {number} day
+     * @return {Boolean}
      */
-    _checkTodayPunchButton()
+    _areAllInputsFilled(year, month, day)
     {
-        const today = new Date();
-        const isCurrentMonth = (today.getMonth() === this._calendarDate.getMonth() && today.getFullYear() === this._calendarDate.getFullYear());
-        let enableButton = false;
-        if (isCurrentMonth)
+        const dateKey = generateKey(year, month, day);
+        const inputs = $('#' + dateKey + ' input[type="time"]');
+        let allInputsFilled = true;
+        for (let input of inputs)
         {
-            const dateKey = generateKey(today.getFullYear(), today.getMonth(), today.getDate());
-            const inputs = $('#' + dateKey + ' input[type="time"]');
-            let allInputsFilled = true;
-            for (let input of inputs)
-            {
-                allInputsFilled &= $(input).val().length !== 0;
-            }
-            enableButton = !allInputsFilled;
+            allInputsFilled &= $(input).val().length !== 0;
         }
-        this._togglePunchButton(enableButton);
+        return allInputsFilled;
     }
 
     /**
@@ -436,6 +442,11 @@ class BaseCalendar
             !this._showDay(year, month, day))
         {
             return;
+        }
+        
+        if (this._areAllInputsFilled(year, month, day))
+        {
+            this._addTodayEntries();   
         }
 
         const value = hourMinToHourFormatted(hour, min);

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -321,10 +321,6 @@ class FlexibleDayCalendar extends BaseCalendar
                     }
 
                     calendar._updateTimeDay(dateKey);
-                    setTimeout(() =>
-                    {
-                        calendar._checkTodayPunchButton();
-                    }, 0);
                 });
             }
         }
@@ -340,14 +336,18 @@ class FlexibleDayCalendar extends BaseCalendar
             {
                 calendar._updateTimeDayCallback($(this).attr('data-date'));
             });
-            setTimeout(() =>
-            {
-                calendar._checkTodayPunchButton();
-            }, 0);
         }
 
         $('.sign-cell:has(span.plus-sign)').off('click').on('click', addEntries);
         $('.sign-cell:has(span.minus-sign)').off('click').on('click', removeEntries);
+    }
+
+    /**
+     * Responsible for adding new entries to the calendar view.
+     */
+    _addTodayEntries()
+    {
+        $('.sign-cell:has(span.plus-sign)').trigger('click');
     }
 
     /**
@@ -473,8 +473,6 @@ class FlexibleDayCalendar extends BaseCalendar
 
         const leaveBy = this._calculateLeaveBy();
         $('#leave-by').val(leaveBy <= '23:59' ? leaveBy : '--:--');
-
-        this._checkTodayPunchButton();
 
         const dayTotal = $('.day-total span').html();
         if (dayTotal !== undefined && dayTotal.length > 0)

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -355,10 +355,6 @@ class FlexibleMonthCalendar extends BaseCalendar
             {
                 calendar._updateTimeDayCallback($(this).attr('data-date'));
             });
-            setTimeout(() =>
-            {
-                calendar._checkTodayPunchButton();
-            }, 0);
         }
 
         $('.plus-sign span').off('click').on('click', function()
@@ -391,10 +387,6 @@ class FlexibleMonthCalendar extends BaseCalendar
                     row.slice(sliceNum).remove();
                     calendar._updateTimeDay($(element).attr('id'));
                     toggleArrowColor(element);
-                    setTimeout(() =>
-                    {
-                        calendar._checkTodayPunchButton();
-                    }, 0);
                 });
             }
         }
@@ -410,6 +402,15 @@ class FlexibleMonthCalendar extends BaseCalendar
             this.scrollLeft -= (delta * 30);
             e.preventDefault();
         });
+    }
+
+    /**
+     * Responsible for adding new entries to the calendar view.
+     */
+    _addTodayEntries()
+    {
+        const dateKey = generateKey(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
+        $(`#${dateKey}`).parent().find('.plus-sign span').trigger('click');
     }
 
     /**
@@ -581,8 +582,6 @@ class FlexibleMonthCalendar extends BaseCalendar
 
         const leaveBy = this._calculateLeaveBy();
         $('#leave-by').val(leaveBy <= '23:59' ? leaveBy : '--:--');
-
-        this._checkTodayPunchButton();
 
         const dateKey = generateKey(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate());
         const dayTotal = $('#' + dateKey).parent().find(' .day-total span').html();


### PR DESCRIPTION
#### Related issue
Closes #506

#### Context / Background
Let punch button even when day is done. Adds pairs of entries if all are filled.

#### What change is being introduced by this PR?
Changed toggle enable to stop checking for filled inputs
Added call to add entries on punch date if all entries are filled.

![punc](https://user-images.githubusercontent.com/37311270/115997274-f8b35580-a5b8-11eb-8c0c-73187106fe96.gif)
![punch2](https://user-images.githubusercontent.com/37311270/115997277-f9e48280-a5b8-11eb-92eb-8f22f478777c.gif)
