### PR TITLE
Calendar needs to open with two pairs by default

### DIFF
--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -706,7 +706,7 @@ class FlexibleMonthCalendar extends BaseCalendar
             return index % 3 !== 2;
         }
 
-        function lessThanTwoEntries(index)
+        function lessThanThreeEntries(index)
         {
             return index < 3;
         }

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -714,7 +714,7 @@ class FlexibleMonthCalendar extends BaseCalendar
         // One pair of entries is a special case in which no more entries are added
         const onlyOnePair = values.length == 2;
 
-        while (!onlyOnePair && (lessThanTwoEntries(i) || inputGroupFullyPrinted(i)))
+        while (!onlyOnePair && (lessThanThreeEntries(i) || inputGroupFullyPrinted(i)))
         {
             ++i;
             if (indexIsInterval(i))

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -708,10 +708,13 @@ class FlexibleMonthCalendar extends BaseCalendar
 
         function lessThanTwoEntries(index)
         {
-            return index < 2;
+            return index < 3;
         }
 
-        while (lessThanTwoEntries(i) || inputGroupFullyPrinted(i))
+        // One pair of entries is a special case in which no more entries are added
+        const onlyOnePair = values.length == 2;
+
+        while (!onlyOnePair && (lessThanTwoEntries(i) || inputGroupFullyPrinted(i)))
         {
             ++i;
             if (indexIsInterval(i))


### PR DESCRIPTION
#### Context / Background
Month calendar was opening with only one pair by default, while it should have been two pairs.
Added a strict check for two values to have it open with a pair and not add anything else.
No values, one value, three values will still default to 4 entries.

![fix](https://user-images.githubusercontent.com/37311270/116796798-c3759e80-aab5-11eb-88e8-43b13d887aa2.gif)
