### PR TITLE
Fix: Non-working days preference not working on month view

### DIFF
--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -249,6 +249,11 @@ class FlexibleMonthCalendar extends BaseCalendar
 
         for (let day = 1; day <= monthLength; ++day)
         {
+            if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day) && this._getHideNonWorkingDays())
+            {
+                continue;
+            }
+
             html += this._getInputsRowCode(this._getCalendarYear(), this._getCalendarMonth(), day);
             if (day === balanceRowPosition)
             {


### PR DESCRIPTION
#### Related issue
None

#### Context / Background
The "Hide non-working days" preference was not working on the draft for release 2.0.0

#### What change is being introduced by this PR?
Now the setting is properly respected on the month view.

#### How will this be tested?
I tested it manually, and it works :X