### PR TITLE
Fix month balance by using DB to get day total

### DIFF
--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -177,6 +177,57 @@ class BaseCalendar
     }
 
     /**
+     * Gets the total for a specific day by looking into both stores.
+     * @param {number} year
+     * @param {number} month
+     * @param {number} day
+     * @return {string|undefined}
+     */
+     _getDayTotal(year, month, day)
+     {
+         const dateKey = generateKey(year, month, day);
+         const values = this._getStore(dateKey);
+         if (values !== undefined)
+         {
+             const validatedTimes = this._validateTimes(values);
+             const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
+             const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
+             const hasDayEnded = inputsHaveExpectedSize && validatedTimesOk;
+ 
+             let dayTotal = undefined;
+             if (hasDayEnded)
+             {
+                 dayTotal = '00:00';
+                 let timesAreProgressing = true;
+                 if (validatedTimes.length >= 2 && validatedTimes.length % 2 === 0)
+                 {
+                     for (let i = 0; i < validatedTimes.length; i += 2)
+                     {
+                         const difference = subtractTime(validatedTimes[i], validatedTimes[i + 1]);
+                         dayTotal = sumTime(dayTotal, difference);
+                         if (validatedTimes[i] >= validatedTimes[i + 1])
+                         {
+                             timesAreProgressing = false;
+                         }
+                     }
+                 }
+                 if (!timesAreProgressing)
+                 {
+                     return undefined;
+                 }
+             }
+             return dayTotal;
+         }
+ 
+         const waiverTotal = this._getWaiverStore(year, month, day);
+         if (waiverTotal !== undefined)
+         {
+             return waiverTotal['hours'];
+         }
+         return undefined;
+     }
+
+    /**
      * Alias to Calendar::draw()
      */
     redraw()

--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -367,57 +367,6 @@ class FlexibleDayCalendar extends BaseCalendar
     }
 
     /**
-     * Gets the total for a specific day by looking into both stores.
-     * @param {number} year
-     * @param {number} month
-     * @param {number} day
-     * @return {string|undefined}
-     */
-    _getDayTotal(year, month, day)
-    {
-        const dateKey = generateKey(year, month, day);
-        const values = this._getStore(dateKey);
-        if (values !== undefined)
-        {
-            const validatedTimes = this._validateTimes(values);
-            const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
-            const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
-            const hasDayEnded = inputsHaveExpectedSize && validatedTimesOk;
-
-            let dayTotal = undefined;
-            if (hasDayEnded)
-            {
-                dayTotal = '00:00';
-                let timesAreProgressing = true;
-                if (validatedTimes.length >= 2 && validatedTimes.length % 2 === 0)
-                {
-                    for (let i = 0; i < validatedTimes.length; i += 2)
-                    {
-                        const difference = subtractTime(validatedTimes[i], validatedTimes[i + 1]);
-                        dayTotal = sumTime(dayTotal, difference);
-                        if (validatedTimes[i] >= validatedTimes[i + 1])
-                        {
-                            timesAreProgressing = false;
-                        }
-                    }
-                }
-                if (!timesAreProgressing)
-                {
-                    return undefined;
-                }
-            }
-            return dayTotal;
-        }
-
-        const waiverTotal = this._getWaiverStore(year, month, day);
-        if (waiverTotal !== undefined)
-        {
-            return waiverTotal['hours'];
-        }
-        return undefined;
-    }
-
-    /**
      * Updates the monthly time balance and triggers the all time balance update at end.
      */
     _updateBalance()

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -494,8 +494,7 @@ class FlexibleMonthCalendar extends BaseCalendar
                 continue;
             }
 
-            const dateKey = generateKey(this._getCalendarYear(), this._getCalendarMonth(), day);
-            let dayTotal = $('#' + dateKey).parent().find('.day-total span').html();
+            const dayTotal = this._getDayTotal(this._getCalendarYear(), this._getCalendarMonth(), day);
             if (dayTotal !== undefined && dayTotal.length !== 0)
             {
                 countDays = true;


### PR DESCRIPTION
#### Related issue
Closes #650

#### Context / Background
The way we used to retrieve the day total was broken for the rows of waivers, capturing always the next day total. To avoid rewriting the HTML for the rows, I have chosen to use the same function used the in the day calendar.

#### What change is being introduced by this PR?
Moved code from Day Calendar to Base Calendar 

#### How will this be tested?
Validated that the month balance is now correct. No test can be added now :(
