### PR TITLE
Update export datebase name format

### DIFF
--- a/js/date-aux.js
+++ b/js/date-aux.js
@@ -24,6 +24,24 @@ function getMonthLength(year, month)
     return d.getDate();
 }
 
+/*
+ * Returns the current datetime string in the format YYYY_MM_DD_HH_MM_SS.
+ */
+function getCurrentDateTimeStr()
+{
+    const date = new Date();
+    const reg = /[-:]/g;
+    const currentTimeStr = date.toLocaleTimeString([], {hour: '2-digit', hourCycle: 'h23', minute:'2-digit', second:'2-digit'}).substr(0, 8);
+    try
+    {
+        return `${getDateStr(date)}_${currentTimeStr}`.replace(reg,'_');
+    }
+    catch (err)
+    {
+        return new Error(err);
+    }
+}
+
 module.exports = {
-    getDateStr, getMonthLength
+    getDateStr, getMonthLength, getCurrentDateTimeStr
 };

--- a/js/menus.js
+++ b/js/menus.js
@@ -14,6 +14,8 @@ const Store = require('electron-store');
 const i18n = require('../src/configs/i18next.config');
 let { openWaiverManagerWindow, prefWindow } = require('./windows');
 
+const { getCurrentDateTimeStr } = require('./date-aux');
+
 function getMainMenuTemplate(mainWindow)
 {
     return [
@@ -148,7 +150,7 @@ function getEditMenuTemplate(mainWindow)
             {
                 let options = {
                     title: i18n.t('$Menu.export-db-to-file'),
-                    defaultPath : 'time_to_leave',
+                    defaultPath : `time_to_leave_${getCurrentDateTimeStr()}`,
                     buttonLabel : i18n.t('$Menu.export'),
 
                     filters : [


### PR DESCRIPTION
#### Related issue
Closes #648 

#### Context / Background
- "Export Database" option currently has the database name as "time_to_leave". This needs to be changed to the format of "time_to_leave_YYYY_MM_DD_HH_MM_SS"

#### What change is being introduced by this PR?
- Added a new funtion called `getCurrentDateTimeStr` in `date-aux.js` which returns the current date-time in the required format
- Above function is being used in `menus.js` where the database name is being set.

#### How will this be tested?
- Validated that the database export now has the new format.
- As the newly added function doesn't accept any parameter and relies on the current date, no new test has been added.
