### PR TITLE
Hour issue

### DIFF
--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -183,49 +183,49 @@ class BaseCalendar
      * @param {number} day
      * @return {string|undefined}
      */
-     _getDayTotal(year, month, day)
-     {
-         const dateKey = generateKey(year, month, day);
-         const values = this._getStore(dateKey);
-         if (values !== undefined)
-         {
-             const validatedTimes = this._validateTimes(values);
-             const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
-             const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
-             const hasDayEnded = inputsHaveExpectedSize && validatedTimesOk;
- 
-             let dayTotal = undefined;
-             if (hasDayEnded)
-             {
-                 dayTotal = '00:00';
-                 let timesAreProgressing = true;
-                 if (validatedTimes.length >= 2 && validatedTimes.length % 2 === 0)
-                 {
-                     for (let i = 0; i < validatedTimes.length; i += 2)
-                     {
-                         const difference = subtractTime(validatedTimes[i], validatedTimes[i + 1]);
-                         dayTotal = sumTime(dayTotal, difference);
-                         if (validatedTimes[i] >= validatedTimes[i + 1])
-                         {
-                             timesAreProgressing = false;
-                         }
-                     }
-                 }
-                 if (!timesAreProgressing)
-                 {
-                     return undefined;
-                 }
-             }
-             return dayTotal;
-         }
- 
-         const waiverTotal = this._getWaiverStore(year, month, day);
-         if (waiverTotal !== undefined)
-         {
-             return waiverTotal['hours'];
-         }
-         return undefined;
-     }
+    _getDayTotal(year, month, day)
+    {
+        const dateKey = generateKey(year, month, day);
+        const values = this._getStore(dateKey);
+        if (values !== undefined)
+        {
+            const validatedTimes = this._validateTimes(values);
+            const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
+            const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
+            const hasDayEnded = inputsHaveExpectedSize && validatedTimesOk;
+
+            let dayTotal = undefined;
+            if (hasDayEnded)
+            {
+                dayTotal = '00:00';
+                let timesAreProgressing = true;
+                if (validatedTimes.length >= 2 && validatedTimes.length % 2 === 0)
+                {
+                    for (let i = 0; i < validatedTimes.length; i += 2)
+                    {
+                        const difference = subtractTime(validatedTimes[i], validatedTimes[i + 1]);
+                        dayTotal = sumTime(dayTotal, difference);
+                        if (validatedTimes[i] >= validatedTimes[i + 1])
+                        {
+                            timesAreProgressing = false;
+                        }
+                    }
+                }
+                if (!timesAreProgressing)
+                {
+                    return undefined;
+                }
+            }
+            return dayTotal;
+        }
+
+        const waiverTotal = this._getWaiverStore(year, month, day);
+        if (waiverTotal !== undefined)
+        {
+            return waiverTotal['hours'];
+        }
+        return undefined;
+    }
 
     /**
      * Alias to Calendar::draw()

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -48,7 +48,7 @@
                             <tr>
                                 <th data-i18n="$WorkdayWaiver.hours">Hours</th>
                                 <td>
-                                    <input data-i18n="[placeholder]$Preferences.hours-per-day" type="text" id="hours" maxlength=8 pattern="^\d+:\d+$" size=8>
+                                    <input data-i18n="[placeholder]$Preferences.hours-per-day" type="text" id="hours" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00'">
                                 </td>
                             </tr>
                             <tr>

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -416,9 +416,9 @@ $(() =>
 
     populateList();
 
-    $('#reason').on('input', () =>
+    $('#reason, #hours').on('input', () =>
     {
-        toggleAddButton('waive-button', $('#reason').val());
+        toggleAddButton('waive-button', $('#reason').val() && $('#hours')[0].checkValidity());
     });
 
     $('#waive-button').on('click', () =>

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -416,7 +416,7 @@ $(() =>
 
     populateList();
 
-    $('#reason, #hours').on('input', () =>
+    $('#reason, #hours').on('input blur', () =>
     {
         toggleAddButton('waive-button', $('#reason').val() && $('#hours')[0].checkValidity());
     });

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -416,7 +416,7 @@ $(() =>
 
     populateList();
 
-    $('#reason').on('keyup', () =>
+    $('#reason').on('input', () =>
     {
         toggleAddButton('waive-button', $('#reason').val());
     });


### PR DESCRIPTION
Related issue
Closes #660

Context / Background
Solving the mentioned problem( #660 )and improving performance (noticable change)

What change is being introduced by this PR?
I added a regex check (HH:mm) to the hours input field before removing disabled prop of waive button.
I also replaced "keyup" events with "input" events as keyup is noticeably slower.

How will this be tested?
Can be tested by typing a non-hour string in the hours input.