### PR TITLE
Fix changelog updater

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,124 +20,123 @@ Who built 2.0.2:
 -   mayankmohak
 -   omerisildak
 -   thamara
--   tupaschoal
 
 <!--- End users - Do not remove -->
 
 ## 2.0.1
 
-Accessibility: [#447] Including focus ring/outline for inputs in the App
-Enhancement: [#226] Make app appear on Windows searchbar
-Enhancement: [#328] Swap position for overall and month balance on day view
-Enhancement: [#333] Adding start date for overall balance on preferences
-Enhancement: [#357] Adding flexible table format for month calendar with variable number of entries per day
-Enhancement: [#369] Adding flexible table format for day calendar as well
-Enhancement: [#383] Adding system default theme that auto-detect if dark or light mode is set
-Enhancement: [#394] Adding option to control the behavior of the Minimize button
-Enhancement: [#414] Right-align content of selection boxes from Preferences Window
-Enhancement: [#442] Modernizing scrollbar styling
-Enhancement: [#445] Move delete button to the leftmost column on workday waiver window
-Enhancement: [#448] Changed link color in Workday Waiver Manager to match themes
-Enhancement: [#455] Small adjustments on the Punch button
-Enhancement: [#455] Small adjustments on the alignment of the date on the Preferences Window
-Enhancement: [#563] Making the preferences window more organized and pretty
-Enhancement: [#591] You can now set up an automatic break time which will automatically add the next entry when you leave for a break punching the time.
-Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
-Fix: [#214] Check that lunch has beginning and end, if there is lunch
-Fix: [#334] Improving performance of overall balance calculation and fixing balance target date after month change
-Fix: [#362] Fixed initial size of preferences window
-Fix: [#377] Fixed the layout which was broken when width < 768px
-Fix: [#395] Fixing uncaught exception in main.js on day refresh
-Fix: [#442] Make border and background on waiver manager tab the same color
-Fix: [#584] When counting today is enabled, move the balance row after the current day
-Fix: [#598] Correct number of working days on flexible calendar
-Fix: [#612] Fix Linux tray menu to have options: Punch time, Show App and Quit
-New and beautiful site for the app! Available in timetoleave.app
-Translation: Time to Leave is now available in Brazilian Portuguese (pt-BR)!
-Translation: Time to Leave is now available in Catalan (ca-CA)!
-Translation: Time to Leave is now available in Dutch (nl)!
-Translation: Time to Leave is now available in French (fr-fr)!
-Translation: Time to Leave is now available in German (de-DE)!
-Translation: Time to Leave is now available in Hindi (hi)!
-Translation: Time to Leave is now available in Indonesian (id)!
-Translation: Time to Leave is now available in Italian (it)!
-Translation: Time to Leave is now available in Japanese (ja)!
-Translation: Time to Leave is now available in Korean (ko)!
-Translation: Time to Leave is now available in Marathi (mr)!
-Translation: Time to Leave is now available in Polish (pl)!
-Translation: Time to Leave is now available in Spanish (es)!
-Translation: Time to Leave is now available in Tamil (ta)!
-Translation: Time to Leave is now available in Thai (th-TH)!
-Translation: Time to Leave is now available in Traditional Chinese (zh-TW)!
+-   Accessibility: [#447] Including focus ring/outline for inputs in the App
+-   Enhancement: [#226] Make app appear on Windows searchbar
+-   Enhancement: [#328] Swap position for overall and month balance on day view
+-   Enhancement: [#333] Adding start date for overall balance on preferences
+-   Enhancement: [#357] Adding flexible table format for month calendar with variable number of entries per day
+-   Enhancement: [#369] Adding flexible table format for day calendar as well
+-   Enhancement: [#383] Adding system default theme that auto-detect if dark or light mode is set
+-   Enhancement: [#394] Adding option to control the behavior of the Minimize button
+-   Enhancement: [#414] Right-align content of selection boxes from Preferences Window
+-   Enhancement: [#442] Modernizing scrollbar styling
+-   Enhancement: [#445] Move delete button to the leftmost column on workday waiver window
+-   Enhancement: [#448] Changed link color in Workday Waiver Manager to match themes
+-   Enhancement: [#455] Small adjustments on the Punch button
+-   Enhancement: [#455] Small adjustments on the alignment of the date on the Preferences Window
+-   Enhancement: [#563] Making the preferences window more organized and pretty
+-   Enhancement: [#591] You can now set up an automatic break time which will automatically add the next entry when you leave for a break punching the time.
+-   Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
+-   Fix: [#214] Check that lunch has beginning and end, if there is lunch
+-   Fix: [#334] Improving performance of overall balance calculation and fixing balance target date after month change
+-   Fix: [#362] Fixed initial size of preferences window
+-   Fix: [#377] Fixed the layout which was broken when width < 768px
+-   Fix: [#395] Fixing uncaught exception in main.js on day refresh
+-   Fix: [#442] Make border and background on waiver manager tab the same color
+-   Fix: [#584] When counting today is enabled, move the balance row after the current day
+-   Fix: [#598] Correct number of working days on flexible calendar
+-   Fix: [#612] Fix Linux tray menu to have options: Punch time, Show App and Quit
+-   New and beautiful site for the app! Available in timetoleave.app
+-   Translation: Time to Leave is now available in Brazilian Portuguese (pt-BR)!
+-   Translation: Time to Leave is now available in Catalan (ca-CA)!
+-   Translation: Time to Leave is now available in Dutch (nl)!
+-   Translation: Time to Leave is now available in French (fr-fr)!
+-   Translation: Time to Leave is now available in German (de-DE)!
+-   Translation: Time to Leave is now available in Hindi (hi)!
+-   Translation: Time to Leave is now available in Indonesian (id)!
+-   Translation: Time to Leave is now available in Italian (it)!
+-   Translation: Time to Leave is now available in Japanese (ja)!
+-   Translation: Time to Leave is now available in Korean (ko)!
+-   Translation: Time to Leave is now available in Marathi (mr)!
+-   Translation: Time to Leave is now available in Polish (pl)!
+-   Translation: Time to Leave is now available in Spanish (es)!
+-   Translation: Time to Leave is now available in Tamil (ta)!
+-   Translation: Time to Leave is now available in Thai (th-TH)!
+-   Translation: Time to Leave is now available in Traditional Chinese (zh-TW)!
 
 Who built 1.5.6:
 
-06b
-1-byte-man
-akaash11
-aldoalprak
-alsvader
-amitchakraborti9
-anatdagan
-anujpatel224
-aqmalio
-araujoarthur0
-BamButz
-BenjaminRochez
-bobsany16
-cbanupama
-ccsCoder
-code-reaper08
-damirJa
-daretobedifferent18
-DevDaveFrame
-dofbi
-Esot3riA
-fikimaul
-Flodgar
-giovannipessiva
-Gnoyoyo
-greyGroot
-ibamibrhm
-jcombs0929
-JoseNavy
-jrasmith0
-jswildcards
-ju-pinheiro
-kumaranshu72
-loiscodes
-mecm1993
-mfayaq
-michaelknowles
-MichaelYogar
-nightgrey
-nilold
-parikhdhruv24791
-parnus01
-radiohazard-dev
-RafaelDavisH
-RuteshRathod
-sajeevan16
-samin-batra
-sano2019
-SaviPrograms
-Semvrij
-servatj
-SJellen
-skevprog
-SolKuczala
-sooster910
-Squizzi3
-suke6mix
-susheelg1197
-Tailine
-taismassaro
-thamara
-tiagohermano
-tilenmiklavic
-tupaschoal
-tuxinaut
-virginiarcruz
+-   06b
+-   1-byte-man
+-   akaash11
+-   aldoalprak
+-   alsvader
+-   amitchakraborti9
+-   anatdagan
+-   anujpatel224
+-   aqmalio
+-   araujoarthur0
+-   BamButz
+-   BenjaminRochez
+-   bobsany16
+-   cbanupama
+-   ccsCoder
+-   code-reaper08
+-   damirJa
+-   daretobedifferent18
+-   DevDaveFrame
+-   dofbi
+-   Esot3riA
+-   fikimaul
+-   Flodgar
+-   giovannipessiva
+-   Gnoyoyo
+-   greyGroot
+-   ibamibrhm
+-   jcombs0929
+-   JoseNavy
+-   jrasmith0
+-   jswildcards
+-   ju-pinheiro
+-   kumaranshu72
+-   loiscodes
+-   mecm1993
+-   mfayaq
+-   michaelknowles
+-   MichaelYogar
+-   nightgrey
+-   nilold
+-   parikhdhruv24791
+-   parnus01
+-   radiohazard-dev
+-   RafaelDavisH
+-   RuteshRathod
+-   sajeevan16
+-   samin-batra
+-   sano2019
+-   SaviPrograms
+-   Semvrij
+-   servatj
+-   SJellen
+-   skevprog
+-   SolKuczala
+-   sooster910
+-   Squizzi3
+-   suke6mix
+-   susheelg1197
+-   Tailine
+-   taismassaro
+-   thamara
+-   tiagohermano
+-   tilenmiklavic
+-   tupaschoal
+-   tuxinaut
+-   virginiarcruz
 
 ## 1.5.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -69,7 +69,7 @@ Who built 2.0.2:
 -   Translation: Time to Leave is now available in Thai (th-TH)!
 -   Translation: Time to Leave is now available in Traditional Chinese (zh-TW)!
 
-Who built 1.5.6:
+Who built 2.0.1:
 
 -   06b
 -   1-byte-man
@@ -140,47 +140,47 @@ Who built 1.5.6:
 
 ## 1.5.5
 
-Enhancement: [#11] Introducing an easy way of sourcing holidays based on user location
-Enhancement: [#164] Overall Balance to replace Month Sum - Now you get an all time balance of your working hours. (Too much overtime huh?!)
-Enhancement: [#299] Introducing new theme: Cadent Star
+-   Enhancement: [#11] Introducing an easy way of sourcing holidays based on user location
+-   Enhancement: [#164] Overall Balance to replace Month Sum - Now you get an all time balance of your working hours. (Too much overtime huh?!)
+-   Enhancement: [#299] Introducing new theme: Cadent Star
 
 Who built 1.5.5:
 
-thamara
-tupaschoal
-araujoarthur0
+-   thamara
+-   tupaschoal
+-   araujoarthur0
 
 ## 1.5.4
 
-Fix: [#276] Fixed launch of app in debian
+-   Fix: [#276] Fixed launch of app in debian
 
 Who built 1.5.3:
 
-thamara
+-   thamara
 
 ## 1.5.3 - Skipped
 
 ## 1.5.2
 
-Fix: [#27] Adding day balance on when to leave bar after day is done
-Fix: [#209] Punch time button to only fill one entry (not the entire row)
-Fix: [#210] Count today preference is respected
-Fix: [#211] Adjusted preferences window size to fit the whole content
-Fix: [#213] Count today preference fixed to work as expected.
-Fix: [#215] Fixed exception: isNan is not defined
-Fix: [#229] Count Today in totals no longer causes problem in the month balance
-Fix: [#232] Total bar not updating on day change
-Fix: [#233] Fixes crash when opening the waiver for a day
-Fix: [#239] Punch button is disabled when current day is waived
-Fix: [#240] Waiver using electron dialog instead of js confirm/alert
-Fix: [#244] Waiver opens with filled date when clicking from calendar
-Fix: [#249] Fix loading preferences
-Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
-Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
-Fix: [#255] Avoiding issue when closing preferences window without changing anything
-Fix: [#258] Fixing crash when changing network while opening TTL
-Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
-Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
-Enhancement: [#241] Changing input format for notification interval and hours per day on preferences
-Enhancement: [#245] DevTools shortcut (Ctrl+Shift+I) on Preferences and Waiver windows
-Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day
+-   Fix: [#27] Adding day balance on when to leave bar after day is done
+-   Fix: [#209] Punch time button to only fill one entry (not the entire row)
+-   Fix: [#210] Count today preference is respected
+-   Fix: [#211] Adjusted preferences window size to fit the whole content
+-   Fix: [#213] Count today preference fixed to work as expected.
+-   Fix: [#215] Fixed exception: isNan is not defined
+-   Fix: [#229] Count Today in totals no longer causes problem in the month balance
+-   Fix: [#232] Total bar not updating on day change
+-   Fix: [#233] Fixes crash when opening the waiver for a day
+-   Fix: [#239] Punch button is disabled when current day is waived
+-   Fix: [#240] Waiver using electron dialog instead of js confirm/alert
+-   Fix: [#244] Waiver opens with filled date when clicking from calendar
+-   Fix: [#249] Fix loading preferences
+-   Fix: [#250] Silently ignoring waiver on non-working day or non-working day range
+-   Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
+-   Fix: [#255] Avoiding issue when closing preferences window without changing anything
+-   Fix: [#258] Fixing crash when changing network while opening TTL
+-   Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
+-   Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
+-   Enhancement: [#241] Changing input format for notification interval and hours per day on preferences
+-   Enhancement: [#245] DevTools shortcut (Ctrl+Shift+I) on Preferences and Waiver windows
+-   Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day

--- a/changelog.md
+++ b/changelog.md
@@ -37,11 +37,10 @@ Who built 2.0.2:
 -   Enhancement: [#442] Modernizing scrollbar styling
 -   Enhancement: [#445] Move delete button to the leftmost column on workday waiver window
 -   Enhancement: [#448] Changed link color in Workday Waiver Manager to match themes
--   Enhancement: [#455] Small adjustments on the Punch button
 -   Enhancement: [#455] Small adjustments on the alignment of the date on the Preferences Window
+-   Enhancement: [#455] Small adjustments on the Punch button
 -   Enhancement: [#563] Making the preferences window more organized and pretty
 -   Enhancement: [#591] You can now set up an automatic break time which will automatically add the next entry when you leave for a break punching the time.
--   Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
 -   Fix: [#214] Check that lunch has beginning and end, if there is lunch
 -   Fix: [#334] Improving performance of overall balance calculation and fixing balance target date after month change
 -   Fix: [#362] Fixed initial size of preferences window
@@ -51,6 +50,7 @@ Who built 2.0.2:
 -   Fix: [#584] When counting today is enabled, move the balance row after the current day
 -   Fix: [#598] Correct number of working days on flexible calendar
 -   Fix: [#612] Fix Linux tray menu to have options: Punch time, Show App and Quit
+-   Fix: Fixed behavior of calendar when moving to next/previous month when current day is in the range of 29-31.
 -   New and beautiful site for the app! Available in timetoleave.app
 -   Translation: Time to Leave is now available in Brazilian Portuguese (pt-BR)!
 -   Translation: Time to Leave is now available in Catalan (ca-CA)!
@@ -146,9 +146,9 @@ Who built 2.0.1:
 
 Who built 1.5.5:
 
+-   araujoarthur0
 -   thamara
 -   tupaschoal
--   araujoarthur0
 
 ## 1.5.4
 
@@ -162,6 +162,11 @@ Who built 1.5.3:
 
 ## 1.5.2
 
+-   Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
+-   Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
+-   Enhancement: [#241] Changing input format for notification interval and hours per day on preferences
+-   Enhancement: [#245] DevTools shortcut (Ctrl+Shift+I) on Preferences and Waiver windows
+-   Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day
 -   Fix: [#27] Adding day balance on when to leave bar after day is done
 -   Fix: [#209] Punch time button to only fill one entry (not the entire row)
 -   Fix: [#210] Count today preference is respected
@@ -179,8 +184,3 @@ Who built 1.5.3:
 -   Fix: [#252] Prevent multiple preferences and workday waiver windows to be opened
 -   Fix: [#255] Avoiding issue when closing preferences window without changing anything
 -   Fix: [#258] Fixing crash when changing network while opening TTL
--   Enhancement: [#152] Adding a "Copy" option in the "About message", making it easier to copy information when opening an issue
--   Enhancement: [#228] Improved performance of TTL - Now moving through the calendar is much faster
--   Enhancement: [#241] Changing input format for notification interval and hours per day on preferences
--   Enhancement: [#245] DevTools shortcut (Ctrl+Shift+I) on Preferences and Waiver windows
--   Enhancement: [#247] Day View - new minimalist view that shows the calendar day by day

--- a/scripts/update-changelog.py
+++ b/scripts/update-changelog.py
@@ -35,7 +35,7 @@ def get_updated_file_content(current_changelog_lines: str, new_change: any, new_
     processed_info = False
 
     for line in current_changelog_lines:
-        line = remove_prefix(line.strip(), g_prefix_line)
+        line = line.strip()
         if line == g_end_changes:
             is_sourcing_changes = False
             new_file_content.extend(get_sorted_unique_entries(changes))
@@ -54,10 +54,10 @@ def get_updated_file_content(current_changelog_lines: str, new_change: any, new_
             new_file_content.append(line)
 
         if is_sourcing_changes:
-            changes.append(line)
+            changes.append(remove_prefix(line, g_prefix_line))
 
         if is_sourcing_users:
-            users.append(line)
+            users.append(remove_prefix(line, g_prefix_line))
 
         if line == g_begin_changes:
             is_sourcing_changes = True


### PR DESCRIPTION
#### Related issue
N/A

#### Context / Background
Our changelog updater is modifying older versions changes

#### What change is being introduced by this PR?

**Recommendation:** See it commit by commit
- The script used to strip the prefix on all lines, but did not add them back for lines outside the current scope of changes and users. It now just adds the line as it is when it's not modifying the current block
- A bunch of formatting improvement changes on the changelog.md itself, to make it consistent

#### How will this be tested?
- Tested locally using the same command line as the CI
- Will test with the own bot in this PR, after merging.
