### PR TITLE
Fix #671: Remove unused languages variable

### DIFF
--- a/src/configs/app.config.js
+++ b/src/configs/app.config.js
@@ -40,7 +40,6 @@ function getLanguageName(code)
 }
 
 module.exports = {
-    languages: ['en', 'pt-BR', 'es', 'it', 'zh-TW', 'de-DE', 'hi', 'mr', 'pl', 'nl', 'th-TH', 'dev', 'ta','tr-TR'],
     fallbackLng: 'en',
     namespace: 'translation',
     getLanguagesCodes,


### PR DESCRIPTION
#### Related issue
Closes #671 

#### Context / Background
app.config.js was exporting a variable that was never used, likely superseded by getLanguagesCodes

#### What change is being introduced by this PR?
Removed the variable

#### How will this be tested?
- Running the app without it doesn't fail
- Code inspection didn't show any user of that variable