### PR TITLE
Update codecov-action to 2.0.*

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -45,7 +45,7 @@ jobs:
           path: 'COV_REPORT/'
       - name: '      CodeCov'
         if: success()
-        uses: codecov/codecov-action@v1.0.12
+        uses: codecov/codecov-action@v2.0.1
         with:
           file: 'COV_REPORT*'
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I'm not really sure we even still use it, I think we do. Just saw on the new release that v1 will be deprecated in a few months, so better be prepared.

https://github.com/codecov/codecov-action/releases/tag/v2.0.0