### PR TITLE
Fix #699: Get Day Total actually getting the value of waived store

### DIFF
--- a/__tests__/__renderer__/classes/FlexibleDayCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleDayCalendar.js
@@ -113,6 +113,55 @@ describe('FlexibleDayCalendar class Tests', () =>
         expect(calendar._getWaiverStore(2010, 11, 31)).toStrictEqual({ reason: 'New Year\'s eve', hours: '08:00' });
     });
 
+    describe('Testing getDayTotal', () =>
+    {
+        test('getDayTotal on workdays', () =>
+        {
+            // Original dates
+            expect(calendar._getDayTotal(2020, 3, 1)).toStrictEqual('08:00');
+            expect(calendar._getDayTotal(2020, 3, 2)).toStrictEqual('08:00');
+
+            // Day that doesn't have contents
+            expect(calendar._getDayTotal(2010, 3, 1)).toStrictEqual(undefined);
+
+            // Adding a different set
+            calendar._setStore('2010-3-1', ['05:00', '07:00', '09:00', '10:00']);
+            expect(calendar._getStore('2010-3-1')).toStrictEqual(['05:00', '07:00', '09:00', '10:00']);
+            expect(calendar._getDayTotal(2010, 3, 1)).toStrictEqual('03:00');
+
+            // Clearing entry - back to undefined value
+            calendar._removeStore('2010-3-1');
+            expect(calendar._getDayTotal(2010, 3, 1)).toStrictEqual(undefined);
+        });
+
+        test('getDayTotal on waived days', () =>
+        {
+            // Original dates
+            expect(calendar._getDayTotal(2019, 11, 31)).toStrictEqual('08:00');
+            expect(calendar._getDayTotal(2020, 0, 1)).toStrictEqual('08:00');
+            expect(calendar._getDayTotal(2020, 3, 10)).toStrictEqual('08:00');
+
+            // Day that doesn't have contents
+            expect(calendar._getDayTotal(2010, 2, 1)).toStrictEqual(undefined);
+
+            // Adding a different set
+            const newWaivedEntry = {
+                '2010-03-01': { reason: 'Test', hours: '06:00' }
+            };
+            waivedWorkdays.set(newWaivedEntry);
+
+            calendar.loadInternalWaiveStore();
+            expect(calendar._getWaiverStore(2010, 2, 1)).toStrictEqual({ reason: 'Test', hours: '06:00' });
+            expect(calendar._getDayTotal(2010, 2, 1)).toStrictEqual('06:00');
+
+            // Clearing entry - back to undefined value
+            waivedWorkdays.clear();
+            waivedWorkdays.set(waivedEntries);
+            calendar.loadInternalWaiveStore();
+            expect(calendar._getDayTotal(2010, 2, 1)).toStrictEqual(undefined);
+        });
+    });
+
     test('FlexibleDayCalendar Day Changes', () =>
     {
         expect(calendar._getCalendarDate()).toBe(today.getDate());

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -187,7 +187,7 @@ class BaseCalendar
     {
         const dateKey = generateKey(year, month, day);
         const values = this._getStore(dateKey);
-        if (values !== undefined)
+        if (values !== undefined && values.length > 0)
         {
             const validatedTimes = this._validateTimes(values);
             const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;


### PR DESCRIPTION
#### Related issue
Closes #669

#### Context / Background
Day view was not counting the waived value when looking at a waived day, and then the balance was wrong.

#### What change is being introduced by this PR?
Base calendar was not falling back to waiver value when getting the day total.

#### How will this be tested?
Added new tests
