### PR TITLE
Avoid intermitent failures in computeTimeBalance

### DIFF
--- a/__tests__/__main__/time-balance.js
+++ b/__tests__/__main__/time-balance.js
@@ -6,6 +6,7 @@ const {
     computeAllTimeBalanceUntil,
     getFirstInputInDb
 } = require('../../js/time-balance');
+const { resetPreferences } = require('../../js/user-preferences');
 
 const flexibleStore = new Store({name: 'flexible-store'});
 const waivedWorkdays = new Store({name: 'waived-workdays'});
@@ -16,6 +17,7 @@ describe('Time Balance', () =>
     {
         flexibleStore.clear();
         waivedWorkdays.clear();
+        resetPreferences();
     });
 
     test('getFirstInputInDb: no input', () =>

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -287,6 +287,14 @@ function repetitionIsEnabled()
     return preferences['repetition'];
 }
 
+/*
+ * Resets the preferences to their default value.
+ */
+function resetPreferences()
+{
+    savePreferences(defaultPreferences);
+}
+
 module.exports = {
     defaultPreferences,
     getDefaultWidthHeight,
@@ -300,5 +308,6 @@ module.exports = {
     isNotBoolean,
     isNotificationInterval,
     notificationIsEnabled,
-    repetitionIsEnabled
+    repetitionIsEnabled,
+    resetPreferences
 };

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -159,7 +159,7 @@ function addWaiver()
         tempDate.setDate(tempDate.getDate() + 1);
     }
     sortTable();
-    
+
     //Cleanup
     $('#reason').val('');
     toggleAddButton('waive-button', $('#reason').val());


### PR DESCRIPTION
Some tests related to computeTimeBalance were failing intermittently because the preference was not the default one (it was setting saturday/sunday as work days).
In this PR I'm including a resetPreferences function, which is then used before running the tests in time-balance.js.