### PR TITLE
Improve check-languages script to generate a summary

### DIFF
--- a/.github/workflows/update-missing-translations.yml
+++ b/.github/workflows/update-missing-translations.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: '3.9'
     - name: Write missing translation to file
       run: |
-        python scripts/check-languages.py -output missing.md -report_key_mismatch -report_missing_translations
+        python scripts/check-languages.py -output missing.md -report_summary -report_key_mismatch -report_missing_translations
     - name: Get comment body
       id: get-comment-body
       run: |

--- a/.github/workflows/update-missing-translations.yml
+++ b/.github/workflows/update-missing-translations.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: '3.9'
     - name: Write missing translation to file
       run: |
-        python scripts/check-languages.py -output missing.md
+        python scripts/check-languages.py -output missing.md -report_key_mismatch -report_missing_translations
     - name: Get comment body
       id: get-comment-body
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ appx/
 website/node_modules
 website/.cache
 website/dist
+
+missing.md

--- a/scripts/check-languages.py
+++ b/scripts/check-languages.py
@@ -56,38 +56,37 @@ LANG_SCOPE_KEY_TO_IGNORE = {'de-DE': {'$Preferences' : ['themes', 'hours-per-day
                                      '$FlexibleMonthCalendar' : ['total']}}
 
 # Source: https://stackoverflow.com/a/25580545/3821823
-def add_url_params(url, params):
-    """ Add GET params to provided URL being aware of existing.
-    :param url: string of target URL
+def add_url_params(url : str , params : dict) -> str:
+    """ Add GET params to provided url being aware of existing params.
+    :param url: string of target url
     :param params: dict containing requested params to be added
-    :return: string with updated URL
+    :return: string with updated url
     >> url = 'http://stackoverflow.com/test?answers=true'
     >> new_params = {'answers': False, 'data': ['some','values']}
     >> add_url_params(url, new_params)
     'http://stackoverflow.com/test?data=some&data=values&answers=false'
     """
-    # Unquoting URL first so we don't loose existing args
+    # Unquoting url first so we don't loose existing args
     url = unquote(url)
     # Extracting url info
     parsed_url = urlparse(url)
-    # Extracting URL arguments from parsed URL
+    # Extracting url arguments from parsed url
     get_args = parsed_url.query
-    # Converting URL arguments to dict
+    # Converting url arguments to dict
     parsed_get_args = dict(parse_qsl(get_args))
-    # Merging URL arguments dict with new params
+    # Merging url arguments dict with new params
     parsed_get_args.update(params)
 
     # Bool and Dict values should be converted to json-friendly values
-    # you may throw this part away if you don't like it :)
     parsed_get_args.update(
         {k: json.dumps(v) for k, v in parsed_get_args.items()
             if isinstance(v, (bool, dict))}
     )
 
-    # Converting URL argument to proper query string
+    # Converting url argument to proper query string
     encoded_get_args = urlencode(parsed_get_args, doseq=True)
     # Creating new parsed result object based on provided with new
-    # URL arguments. Same thing happens inside of urlparse.
+    # url arguments. Same thing happens inside of urlparse.
     new_url = ParseResult(
         parsed_url.scheme, parsed_url.netloc, parsed_url.path,
         parsed_url.params, encoded_get_args, parsed_url.fragment
@@ -205,7 +204,7 @@ def get_report_from_error(total_strings_for_translation : int, errors : dict) ->
 
     return result
 
-def get_count_total_string_with_link(locale : str, missing_translations, link_to_missing : bool) -> str:
+def get_count_total_string_with_link(locale : str, missing_translations : dict, link_to_missing : bool) -> str:
     if not missing_translations or not link_to_missing:
         return f'{count_total_string(missing_translations)}'
     missing_translations_count = count_total_string(missing_translations)

--- a/scripts/check-languages.py
+++ b/scripts/check-languages.py
@@ -193,7 +193,7 @@ def get_report_from_error(total_strings_for_translation : int, errors : dict) ->
     for language in errors:
         missing_keys = errors[language]
         number_missing_keys = count_total_string(missing_keys)
-        result += '## {} ({}/{} - {:.2f}% missing):\n'.format(language,
+        result += '## {}\n{}/{} - {:.2f}% missing:\n'.format(language,
                                                  number_missing_keys,
                                                  total_strings_for_translation,
                                                  percentage_not_translated(total_strings_for_translation, missing_keys))
@@ -203,6 +203,13 @@ def get_report_from_error(total_strings_for_translation : int, errors : dict) ->
             result += '\n```\n{}\n```\n\n'.format(missing_keys)
 
     return result
+
+def get_count_total_string_with_link(locale : str, missing_translations) -> str:
+    if not missing_translations:
+        return '0'
+    missing_translations_count = count_total_string(missing_translations)
+    locale = locale.lower()
+    return f'{missing_translations_count} [(See missing)](#{locale})'
 
 def get_progress_bar(total_strings_for_translation : int, missing_strings : dict) -> str:
     percentage = percentage_translated(total_strings_for_translation, missing_strings)
@@ -225,7 +232,7 @@ def get_summary_report(total_strings_for_translation : int, missing_translations
     output += '|--------|----------------------|-----------------|\n'
     output += '\n'.join('| {} | {} | {} {} |'.format(k,
                         get_progress_bar(total_strings_for_translation, v),
-                        count_total_string(v),
+                        get_count_total_string_with_link(k, v),
                         get_new_issue_url(k, v)) for k, v in missing_translations.items())
     return output + '\n\n'
 


### PR DESCRIPTION
Improving the check-languages script to generate a report with the progress of each supported laguage, as well as links to easily create an issue on TTL for their translation.
The report looks like the following:


# Summary - 21 languages supported (195 strings)
| Locale | Translation progress | Missing strings |
|--------|----------------------|-----------------|
| ca-CA | ![Progress](https://progress-bar.dev/95/?width=200) | 8 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+ca-CA%0ARelevant+file%3A+%60locales%5Cca-CA%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+ca-CA) |
| de-DE | ![Progress](https://progress-bar.dev/96/?width=200) | 7 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+de-DE%0ARelevant+file%3A+%60locales%5Cde-DE%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+de-DE) |
| dev | ![Progress](https://progress-bar.dev/100/?width=200) | 0  |
| es | ![Progress](https://progress-bar.dev/98/?width=200) | 3 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+es%0ARelevant+file%3A+%60locales%5Ces%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+es) |
| fr-FR | ![Progress](https://progress-bar.dev/95/?width=200) | 8 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+fr-FR%0ARelevant+file%3A+%60locales%5Cfr-FR%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+fr-FR) |
| gu | ![Progress](https://progress-bar.dev/99/?width=200) | 1 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+gu%0ARelevant+file%3A+%60locales%5Cgu%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+gu) |
| hi | ![Progress](https://progress-bar.dev/93/?width=200) | 13 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+hi%0ARelevant+file%3A+%60locales%5Chi%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%2C%0A++%22%24UpdateManager%22%3A+%7B%0A++++%22dismissBtn%22%3A+%22Dismiss%22%2C%0A++++%22downloadBtn%22%3A+%22Download+latest+version%22%2C%0A++++%22remindBtn%22%3A+%22Remind+me+later%22%2C%0A++++%22title%22%3A+%22TTL+Check+for+updates%22%2C%0A++++%22upto-date-msg%22%3A+%22Your+TTL+is+up+to+date.%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+hi) |
| id | ![Progress](https://progress-bar.dev/95/?width=200) | 8 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+id%0ARelevant+file%3A+%60locales%5Cid%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+id) |
| it | ![Progress](https://progress-bar.dev/98/?width=200) | 2 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+it%0ARelevant+file%3A+%60locales%5Cit%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22report%22%3A+%22Report%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+it) |
| ja | ![Progress](https://progress-bar.dev/99/?width=200) | 1 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+ja%0ARelevant+file%3A+%60locales%5Cja%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+ja) |
| ko | ![Progress](https://progress-bar.dev/98/?width=200) | 3 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+ko%0ARelevant+file%3A+%60locales%5Cko%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+ko) |
| mr | ![Progress](https://progress-bar.dev/92/?width=200) | 15 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+mr%0ARelevant+file%3A+%60locales%5Cmr%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22export%22%3A+%22Export%22%2C%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%2C%0A++%22%24UpdateManager%22%3A+%7B%0A++++%22dismissBtn%22%3A+%22Dismiss%22%2C%0A++++%22downloadBtn%22%3A+%22Download+latest+version%22%2C%0A++++%22old-version-msg%22%3A+%22You+are+using+an+old+version+of+TTL+and+missing+out+on+a+lot+of+new+cool+things%21%22%2C%0A++++%22remindBtn%22%3A+%22Remind+me+later%22%2C%0A++++%22title%22%3A+%22TTL+Check+for+updates%22%2C%0A++++%22upto-date-msg%22%3A+%22Your+TTL+is+up+to+date.%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+mr) |
| nl | ![Progress](https://progress-bar.dev/99/?width=200) | 1 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+nl%0ARelevant+file%3A+%60locales%5Cnl%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+nl) |
| pl | ![Progress](https://progress-bar.dev/95/?width=200) | 9 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+pl%0ARelevant+file%3A+%60locales%5Cpl%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22failed-entries%22%3A+%22Failed+entries%22%2C%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+pl) |
| pt-BR | ![Progress](https://progress-bar.dev/100/?width=200) | 0  |
| ru-RU | ![Progress](https://progress-bar.dev/98/?width=200) | 2 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+ru-RU%0ARelevant+file%3A+%60locales%5Cru-RU%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Generic%22%3A+%7B%0A++++%22hours-on-invalid%22%3A+%22this.setCustomValidity%28%5C%22Please+enter+the+time+in+valid+24-hour+format+from+00%3A00+to+23%3A59%5C%22%29%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+ru-RU) |
| ta | ![Progress](https://progress-bar.dev/99/?width=200) | 1 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+ta%0ARelevant+file%3A+%60locales%5Cta%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+ta) |
| th-TH | ![Progress](https://progress-bar.dev/95/?width=200) | 8 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+th-TH%0ARelevant+file%3A+%60locales%5Cth-TH%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Menu%22%3A+%7B%0A++++%22fresh-start%22%3A+%22Fresh+Start%22%2C%0A++++%22fresh-start-confirm%22%3A+%22Are+you+sure+you+want+a+fresh+start%3F%22%2C%0A++++%22migrate%22%3A+%22Migrate%22%2C%0A++++%22report%22%3A+%22Report%22%2C%0A++++%22should-migrate-to-flexible%22%3A+%22One+of+the+new+features+of+this+Time+to+Leave+release+is+a+flexible+number+of+entries+for+the+calendar.%5Cn%5CnThis+new+view+uses+a+new+database+format.%5CnTo+use+it%2C+you+can+either+migrate+your+existing+database+to+the+new+format+or+make+a+fresh+start.%22%0A++%7D%2C%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+th-TH) |
| tr-TR | ![Progress](https://progress-bar.dev/99/?width=200) | 1 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+tr-TR%0ARelevant+file%3A+%60locales%5Ctr-TR%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+tr-TR) |
| zh-TW | ![Progress](https://progress-bar.dev/98/?width=200) | 3 [(Open issue)](https://github.com/thamara/time-to-leave/issues/new?labels=localization%2Cgood+first+issue%2CHacktoberfest&body=Add+translations+for+locale+zh-TW%0ARelevant+file%3A+%60locales%5Czh-TW%5Ctranslation.json%60%0A%0A%0A%60%60%60%0A%7B%0A++%22%24Notification%22%3A+%7B%0A++++%22dismiss-for-today%22%3A+%22Dismiss+for+today%22%0A++%7D%2C%0A++%22%24Preferences%22%3A+%7B%0A++++%22enablePrefillBreakTime%22%3A+%22Enable+prefilling+of+break+time%22%2C%0A++++%22breakTimeInterval%22%3A+%22Break+time+interval%22%0A++%7D%0A%7D%0A%60%60%60%0A%0A&title=Add+missing+translations+for+locale+zh-TW) |

# Missing Translations:
## ca-CA
8/195 - 4.10% missing:

```
{
  "$Menu": {
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## de-DE
7/195 - 3.59% missing:

```
{
  "$Menu": {
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## es
3/195 - 1.54% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## fr-FR
8/195 - 4.10% missing:

```
{
  "$Menu": {
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## gu
1/195 - 0.51% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  }
}
```

## hi
13/195 - 6.67% missing:

```
{
  "$Menu": {
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  },
  "$UpdateManager": {
    "dismissBtn": "Dismiss",
    "downloadBtn": "Download latest version",
    "remindBtn": "Remind me later",
    "title": "TTL Check for updates",
    "upto-date-msg": "Your TTL is up to date."
  }
}
```

## id
8/195 - 4.10% missing:

```
{
  "$Menu": {
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## it
2/195 - 1.03% missing:

```
{
  "$Menu": {
    "report": "Report"
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  }
}
```

## ja
1/195 - 0.51% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  }
}
```

## ko
3/195 - 1.54% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## mr
15/195 - 7.69% missing:

```
{
  "$Menu": {
    "export": "Export",
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  },
  "$UpdateManager": {
    "dismissBtn": "Dismiss",
    "downloadBtn": "Download latest version",
    "old-version-msg": "You are using an old version of TTL and missing out on a lot of new cool things!",
    "remindBtn": "Remind me later",
    "title": "TTL Check for updates",
    "upto-date-msg": "Your TTL is up to date."
  }
}
```

## nl
1/195 - 0.51% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  }
}
```

## pl
9/195 - 4.62% missing:

```
{
  "$Menu": {
    "failed-entries": "Failed entries",
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## ru-RU
2/195 - 1.03% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Generic": {
    "hours-on-invalid": "this.setCustomValidity(\"Please enter the time in valid 24-hour format from 00:00 to 23:59\")"
  }
}
```

## ta
1/195 - 0.51% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  }
}
```

## th-TH
8/195 - 4.10% missing:

```
{
  "$Menu": {
    "fresh-start": "Fresh Start",
    "fresh-start-confirm": "Are you sure you want a fresh start?",
    "migrate": "Migrate",
    "report": "Report",
    "should-migrate-to-flexible": "One of the new features of this Time to Leave release is a flexible number of entries for the calendar.\n\nThis new view uses a new database format.\nTo use it, you can either migrate your existing database to the new format or make a fresh start."
  },
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

## tr-TR
1/195 - 0.51% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  }
}
```

## zh-TW
3/195 - 1.54% missing:

```
{
  "$Notification": {
    "dismiss-for-today": "Dismiss for today"
  },
  "$Preferences": {
    "enablePrefillBreakTime": "Enable prefilling of break time",
    "breakTimeInterval": "Break time interval"
  }
}
```

