### PR TITLE
change function to applyTheme when render  preferences window

### DIFF
--- a/src/preferences.js
+++ b/src/preferences.js
@@ -106,7 +106,7 @@ function renderPreferencesWindow()
         .children('option:selected')
         .val();
     preferences[theme] = selectedThemeOption;
-    $('html').attr('data-theme', selectedThemeOption);
+    applyTheme(selectedThemeOption);
 
     /* istanbul ignore else */
     if ('view' in usersStyles)


### PR DESCRIPTION
#### Related issue
Closes #724

#### Context / Background
Theme not match with system default on Preferences Menu

#### What change is being introduced by this PR?
change this `$('html').attr('data-theme', selectedThemeOption);` to `applyTheme(selectedThemeOption);` on function `renderPreferencesWindow()`

#### How will this be tested?
Preferences window must dark mode when theme selected is system default and the system using dark mode.
![image](https://user-images.githubusercontent.com/18456011/136504163-13c75e0c-95a4-46d9-9da0-257311a0d705.png)

