### PR TITLE
Use Author role on ChangelogUpdater approval

### DIFF
--- a/.github/workflows/ChangelogUpdater.yml
+++ b/.github/workflows/ChangelogUpdater.yml
@@ -24,7 +24,7 @@ jobs:
           git config --global user.name 'Changelog Bot'
           git config --global user.email 'changelog-bot@users.noreply.github.com'
       - name: Update Changelog
-        if: (github.event.comment.user.login == 'thamara' || github.event.comment.user.login == 'tupaschoal' || github.event.comment.user.login == 'araujoarthur0') && steps.check.outputs.triggered == 'true'
+        if: (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'COLLABORATOR') && steps.check.outputs.triggered == 'true'
         env:
           COMMENT_BODY: ${{github.event.comment.body}}
           USER: ${{github.event.comment.user.login}}


### PR DESCRIPTION
#### Related issue
N/A

#### Context / Background
We had our names hardcoded, but that doesn't look too pretty. I found a parameter that checks our association with the repository instead: https://docs.github.com/en/graphql/reference/enums#commentauthorassociation

I think these two roles will suffice

#### What change is being introduced by this PR?
Changelog Updater will now check for the role of the person that made the comment, instead of their username.

#### How will this be tested?
I guess live :D
