### PR TITLE
Checkout PR before updating changelog - fixes #732

### DIFF
--- a/.github/workflows/ChangelogUpdater.yml
+++ b/.github/workflows/ChangelogUpdater.yml
@@ -1,7 +1,5 @@
 name: Changelog Updater
 on:
-  pull_request:
-    types: [opened]
   issue_comment:
     types: [created]
 
@@ -9,17 +7,25 @@ jobs:
   update-changelog:
     runs-on: macos-latest
     steps:
-      - uses: khan/pull-request-comment-trigger@master
+      - name: Check trigger
         id: check
+        uses: khan/pull-request-comment-trigger@master
         with:
           trigger: '\changelog-update'
           reaction: rocket
+          prefix_only: 'true'
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'
       - name: Clone git repo
-        uses: actions/checkout@v2
         if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+      - name: Checkout pull request
+        if: steps.check.outputs.triggered == 'true'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: hub pr checkout ${{github.event.issue.number}}
       - name: Configure Git Agent
+        if: steps.check.outputs.triggered == 'true'
         run: |
           git config --global user.name 'Changelog Bot'
           git config --global user.email 'changelog-bot@users.noreply.github.com'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,4 @@ For bugs, it's good to provide some step-by-step instructions to reproduce the i
 ### When you open a pull request
 
 All PRs are very welcome, and we'll do our best to review them as fast as possible.
-Check the [development](DEVELOPMENT.md) instructions to understand how to setup a developer's environment, build and test Time to Leave.
+Check the [development](DEVELOPMENT.md) instructions to understand how to setup a developer's environment, build and test Time to Leave. Please enable `Allow edits by maintainers` when raising the PR.


### PR DESCRIPTION
#### Related issue
Closes #732

#### Context / Background
When triggered, the `Changelog Updater` should update-commit-push the changelog file on the PR's source branch itself rather than the `main` branch. This will ensure that the changes from the PR as well as the changelog update flow together to `main` branch.

#### What change is being introduced by this PR?
| Sr. No. | File | Changes | Comments |
| - | - | - | - |
| 1 | `ChangelogUpdater.yml` | 1. Removed the `pull_request` trigger. <br> 2. Added `prefix_only: 'true'` for step with `id: check`. <br> 3. Added `Checkout the pull request` step. | 1. We are triggering the updater manually. If we want to retain the `pull_request` trigger, we should limit it to PRs against `main` branch. <br> 2. The updater should not be triggered if the triggering message format is part of an `issue_comment` event that was not intended to trigger the bot (Example: if [this issue message](https://github.com/thamara/time-to-leave/issues/732#issue-1020969824) had been an issue_comment, the bot would have triggered erroneously). However, this will take effect only after [prefix_only doesn't work - issue #18 on pull-request-comment-trigger repo](https://github.com/Khan/pull-request-comment-trigger/issues/18) is fixed. <br> 3. This will switch to the PR's source branch before updating the changelog. More info can be found [on this link](https://github.com/actions/checkout/issues/331). |
| 2 | `CONTRIBUTING.md` | Updated the guidelines to enable "Allow edits by maintainers" on PRs. | This will be required to ensure that the workflows run successfully. |

#### How will this be tested?
Once this PR is merged:
1. A new, dummy PR should be raised.
2. The `Changelog Updater` should be triggered by posting a comment as mentioned in #732.
3. Run history of the `Changelog Updater` workflow should be inspected for the expected behaviour (as mentioned in `Context / Background` above).
4. Ensure no changelog commits are made on the `main` branch by the bot.
5. Ensure a changelog commit is made on the PR's source branch by the bot.