### PR TITLE
Improving requires in preferences.js

### DIFF
--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -1,14 +1,22 @@
 'use strict';
 
-const electron = require('electron');
-const path = require('path');
-const fs = require('fs');
 const { validateTime } = require('./time-math.js');
 const { isValidTheme } = require('./themes.js');
-const i18n = require('../src/configs/i18next.config');
+
+// Lazy loaded modules
+let fs = null;
+function getFs()
+{
+    if (fs === null)
+    {
+        fs = require('fs');
+    }
+    return fs;
+}
 
 function isValidLocale(locale)
 {
+    const i18n = require('../src/configs/i18next.config');
     return i18n.languages.includes(locale);
 }
 
@@ -71,6 +79,8 @@ const isNotificationInterval = (val) => !Number.isNaN(Number(val)) && isNotBoole
  */
 function getPreferencesFilePath()
 {
+    const path = require('path');
+    const electron = require('electron');
     const userDataPath = (electron.app || electron.remote.app).getPath('userData');
     return path.join(userDataPath, 'preferences.json');
 }
@@ -82,7 +92,7 @@ function savePreferences(preferencesOptions)
 {
     try
     {
-        fs.writeFileSync(getPreferencesFilePath(), JSON.stringify(preferencesOptions));
+        getFs().writeFileSync(getPreferencesFilePath(), JSON.stringify(preferencesOptions));
     }
     catch (err)
     {
@@ -100,7 +110,7 @@ function readPreferences()
     let preferences;
     try
     {
-        preferences = JSON.parse(fs.readFileSync(getPreferencesFilePath()));
+        preferences = JSON.parse(getFs().readFileSync(getPreferencesFilePath()));
     }
     catch (err)
     {
@@ -126,7 +136,7 @@ function getDerivedPrefsFromLoadedPrefs(loadedPreferences)
  */
 function initPreferencesFileIfNotExistsOrInvalid()
 {
-    if (!fs.existsSync(getPreferencesFilePath()))
+    if (!getFs().existsSync(getPreferencesFilePath()))
     {
         savePreferences(defaultPreferences);
         return;

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { ipcRenderer } = require('electron');
-
 const { getUserPreferences } = require('../js/user-preferences.js');
 const { applyTheme } = require('../js/themes.js');
 const { bindDevToolsShortcut } = require('../js/window-aux.js');
@@ -10,6 +8,17 @@ const config = require('../src/configs/app.config');
 
 const $ = require('jquery');
 const jqueryI18next = require('jquery-i18next');
+
+// Lazy loaded modules
+let ipcRenderer = null;
+function getIpcRenderer()
+{
+    if (ipcRenderer === null)
+    {
+        ipcRenderer = require('electron').ipcRenderer;
+    }
+    return ipcRenderer;
+}
 
 // Global values for preferences page
 let usersStyles = getUserPreferences();
@@ -47,7 +56,7 @@ function populateLanguages(i18n)
         preferences['language'] = this.value;
         i18n.changeLanguage(this.value);
         translatePage(this.value);
-        ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
+        getIpcRenderer().send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
     });
 }
 
@@ -60,7 +69,7 @@ function listenerLanguage()
         i18n.changeLanguage(this.value);
         translatePage(this.value);
         populateLanguages(i18n);
-        ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
+        getIpcRenderer().send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
     });
 }
 
@@ -83,7 +92,7 @@ function refreshContent()
 
 function updateUserPreferences()
 {
-    ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
+    getIpcRenderer().send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
 }
 
 function changeValue(type, newVal)


### PR DESCRIPTION
#### Context / Background
Lazy loading some requires, and moving others closer to their usage, to reduce the time spent while loading the .js files.
Doing this I saw the overall ms taken to open the preferences window decrease, but it's not a "deterministic" number as on every reload it took a different number of ms.
The i18n package is still taking around 200ms to load, so we might want to look into it later.