### PR TITLE
Adapting Preferences window to use a non-remote environment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
         "ecmaFeatures": {
             "jsx": true
         },
-        "ecmaVersion": 2018
+        "ecmaVersion": 2018,
+        "sourceType": "module"
     },
     "rules": {
         "block-spacing": "error",

--- a/__tests__/__main__/themes.js
+++ b/__tests__/__main__/themes.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-undef */
+'use strict';
+
+const {
+    isValidTheme
+} = require('../../js/themes.js');
+
+describe('Main: Theme Functions', function()
+{
+    describe('isValidTheme()', function()
+    {
+        test('should validate', () =>
+        {
+            expect(isValidTheme('system-default')).toBeTruthy();
+            expect(isValidTheme('light')).toBeTruthy();
+            expect(isValidTheme('dark')).toBeTruthy();
+            expect(isValidTheme('cadent-star')).toBeTruthy();
+        });
+    });
+
+    describe('isValidTheme()', function()
+    {
+        test('should not validate', () =>
+        {
+            expect(isValidTheme('foo')).not.toBeTruthy();
+            expect(isValidTheme('bar')).not.toBeTruthy();
+        });
+    });
+});

--- a/__tests__/__renderer__/preferences.js
+++ b/__tests__/__renderer__/preferences.js
@@ -6,12 +6,20 @@ const path = require('path');
 const {
     defaultPreferences,
     getPreferencesFilePath,
+    getUserPreferences,
     savePreferences
 } = require('../../js/user-preferences');
+const { preferencesApi } = require('../../renderer/preload-scripts/preferences-api.js');
 const i18n = require('../../src/configs/i18next.config');
 
 /* eslint-disable-next-line no-global-assign */
 window.$ = require('jquery');
+
+// APIs from the preload script of the preferences window
+window.mainApi = preferencesApi;
+// Mocking with the actual access that main would have
+window.mainApi.getUserPreferencesPromise = () => { return new Promise((resolve) => resolve(getUserPreferences()));}
+
 const {
     refreshContent,
     populateLanguages,
@@ -86,17 +94,18 @@ describe('Test Preferences Window', () =>
 
     describe('Changing values of items in window', () =>
     {
-        beforeEach(() =>
+        beforeEach((async (done) =>
         {
             prepareMockup();
+            await refreshContent();
             renderPreferencesWindow();
             populateLanguages(i18n);
             listenerLanguage();
-        });
+            done();
+        }));
         afterEach(() =>
         {
             savePreferences(testPreferences);
-            refreshContent();
         });
         test('Change count-today to true', () =>
         {

--- a/__tests__/__renderer__/themes.js
+++ b/__tests__/__renderer__/themes.js
@@ -1,15 +1,14 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const {
+import {
     applyTheme,
     isValidTheme
-} = require('../../js/themes');
+} from '../../renderer/themes.js';
 window.$ = window.jQuery = require('jquery');
 
 describe('Theme Functions', function()
 {
-
     describe('isValidTheme()', function()
     {
         test('should validate', () =>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <script>window.$ = window.jQuery = require('jquery');</script>
     <script src="node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
     <script src="node_modules/jquery-mousewheel/jquery.mousewheel.js"></script>
-    <script src="js/calendar.js" charset="utf-8"></script>
+    <script type="module" src="js/calendar.js" charset="utf-8"></script>
 </head>
 
 <body>

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { applyTheme } from '../renderer/themes.js';
+
 const { ipcRenderer } = require('electron');
 const {
     subtractTime,
@@ -14,7 +16,6 @@ const {
     notificationIsEnabled,
     repetitionIsEnabled
 } = require('./js/user-preferences.js');
-const { applyTheme } = require('./js/themes.js');
 const { CalendarFactory } = require('./js/classes/CalendarFactory.js');
 const { getDateStr } = require('./js/date-aux.js');
 const i18n = require('./src/configs/i18next.config.js');

--- a/js/menus.js
+++ b/js/menus.js
@@ -125,8 +125,9 @@ function getEditMenuTemplate(mainWindow)
                     resizable: true,
                     icon: appConfig.iconpath,
                     webPreferences: {
-                        enableRemoteModule: true,
-                        nodeIntegration: true
+                        nodeIntegration: true,
+                        preload: path.join(__dirname, '../renderer/preload-scripts/preferences-bridge.js'),
+                        contextIsolation: true
                     } });
                 prefWindow.setMenu(null);
                 prefWindow.loadURL(htmlPath);
@@ -139,6 +140,13 @@ function getEditMenuTemplate(mainWindow)
                     {
                         savePreferences(savedPreferences);
                         mainWindow.webContents.send('PREFERENCE_SAVED', savedPreferences);
+                    }
+                });
+                prefWindow.webContents.on('before-input-event', (event, input) =>
+                {
+                    if (input.control && input.shift && input.key.toLowerCase() === 'i')
+                    {
+                        BrowserWindow.getFocusedWindow().webContents.toggleDevTools();
                     }
                 });
             },

--- a/js/themes.js
+++ b/js/themes.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// TODO: this is duplicated in renderer/themes.js and in preferences.html.
+// Please concentrate it in a single place, probably a JSON.
 const themeOptions = ['system-default', 'light', 'dark', 'cadent-star'];
 
 /**
@@ -12,29 +14,6 @@ function isValidTheme(testTheme)
     return themeOptions.indexOf(testTheme) >= 0;
 }
 
-/**
- * Takes the provided theme key, and loads into a data-attribute on the DOM
- * @param {string} theme
- * @return {boolean} If the theme application was successful
- * */
-function applyTheme(theme)
-{
-    if (isValidTheme(theme) === false)
-    {
-        return false;
-    }
-
-    if (theme === 'system-default')
-    {
-        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-
-    // Applies to the Primary view
-    $('html').attr('data-theme', theme);
-    return true;
-}
-
 module.exports = {
-    isValidTheme,
-    applyTheme
+    isValidTheme
 };

--- a/main.js
+++ b/main.js
@@ -58,6 +58,14 @@ ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) =>
     openWaiverManagerWindow(mainWindow);
 });
 
+ipcMain.handle('USER_DATA_PATH', () =>
+{
+    return new Promise((resolve) =>
+    {
+        resolve(app.getPath('userData'));
+    });
+});
+
 let launchDate = new Date();
 
 // Logic for recommending user to punch in when they've been idle for too long

--- a/package-lock.json
+++ b/package-lock.json
@@ -773,15 +773,227 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz",
-      "integrity": "sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+      "integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-simple-access": "^7.15.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.15.8",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.8",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+          "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.6",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+          "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.15.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+          "integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.15.4",
+            "@babel/helper-replace-supers": "^7.15.4",
+            "@babel/helper-simple-access": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "@babel/template": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.6"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+          "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+          "dev": true
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+          "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.15.4",
+            "@babel/helper-optimise-call-expression": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+          "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.8",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+          "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "license": "GPL-3.0",
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.15.4",
     "@jest-runner/electron": "^3.0.0",
     "electron": "^11.5.0",
     "electron-mocha": "^10.1.0",
@@ -78,5 +79,14 @@
   "engines": {
     "node": ">=14.15.5",
     "yarn": "YARN NO LONGER USED - use npm instead."
+  },
+  "babel": {
+    "env": {
+      "test": {
+        "plugins": [
+          "@babel/plugin-transform-modules-commonjs"
+        ]
+      }
+    }
   }
 }

--- a/renderer/i18n-translator.js
+++ b/renderer/i18n-translator.js
@@ -1,0 +1,49 @@
+'use strict';
+
+function translatePage(language)
+{
+    const languageData = window.mainApi.getDataByLanguage(language)['translation'];
+    $('html').attr('lang', language);
+
+    function getDataRecursive(array, keyList)
+    {
+        if (keyList.length === 0)
+        {
+            throw new Error('Empty key list');
+        }
+        if (keyList.length === 1)
+        {
+            return array[keyList];
+        }
+        else
+        {
+            return getDataRecursive(array[keyList[0]], keyList.splice(1));
+        }
+    }
+
+    function getDataInMap(key)
+    {
+        const keyList = key.split('.');
+        return getDataRecursive(languageData, keyList);
+    }
+
+    function translateElement(element)
+    {
+        const attr = $(element).attr('data-i18n');
+        if (typeof attr !== 'undefined' && attr !== false && attr.length > 0)
+        {
+            $(element).html(getDataInMap(attr));
+        }
+    }
+
+    const callback = (key, value) => { translateElement(value); };
+    $('title').each(callback);
+    $('body').each(callback);
+    $('p').each(callback);
+    $('label').each(callback);
+    $('div').each(callback);
+    $('span').each(callback);
+    $('option').each(callback);
+}
+
+export { translatePage };

--- a/renderer/preload-scripts/preferences-api.js
+++ b/renderer/preload-scripts/preferences-api.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { ipcRenderer } = require('electron');
+const config = require('../../src/configs/app.config');
+const { getUserPreferencesPromise } = require('../../js/user-preferences.js');
+const i18n = require('../../src/configs/i18next.config');
+
+function notifyNewPreferences(preferences)
+{
+    ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
+}
+
+let isI18nLoaded = false;
+i18n.on('loaded', () =>
+{
+    isI18nLoaded = true;
+    i18n.off('loaded');
+    i18n.off('languageChanged');
+});
+
+const i18nLoadedPromise = new Promise(
+    (resolve) =>
+    {
+        setTimeout(
+            function()
+            {
+                if (isI18nLoaded)
+                {
+                    resolve();
+                }
+            }, 300);
+    }
+);
+
+const preferencesApi = {
+    notifyNewPreferences: (preferences) => notifyNewPreferences(preferences),
+    getLanguageMap: () => config.getLanguageMap(),
+    getUserPreferencesPromise: () => getUserPreferencesPromise(),
+    changeLanguage: (code) => { return i18n.changeLanguage(code); },
+    i18nLoadedPromise: i18nLoadedPromise,
+    getDataByLanguage: (code) => i18n.getDataByLanguage(code)
+};
+
+module.exports = {
+    preferencesApi
+};

--- a/renderer/preload-scripts/preferences-bridge.js
+++ b/renderer/preload-scripts/preferences-bridge.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const { contextBridge } = require('electron');
+const { preferencesApi } = require('./preferences-api.js');
+
+contextBridge.exposeInMainWorld(
+    'mainApi', preferencesApi
+);

--- a/renderer/themes.js
+++ b/renderer/themes.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// TODO: this is duplicated in js/themes.js and in preferences.html.
+// Please concentrate it in a single place, probably a JSON.
+const themeOptions = ['system-default', 'light', 'dark', 'cadent-star'];
+
+/**
+ * Checks whether the provided theme is valid. This list should be reflected in the `styles.css` file.
+ * @param {string} testTheme
+ * @return {boolean}
+ */
+function isValidTheme(testTheme)
+{
+    return themeOptions.indexOf(testTheme) >= 0;
+}
+
+/**
+ * Takes the provided theme key, and loads into a data-attribute on the DOM
+ * @param {string} theme
+ * @return {boolean} If the theme application was successful
+ * */
+function applyTheme(theme)
+{
+    if (isValidTheme(theme) === false)
+    {
+        return false;
+    }
+
+    if (theme === 'system-default')
+    {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    // Applies to the Primary view
+    $('html').attr('data-theme', theme);
+    return true;
+}
+
+export {
+    isValidTheme,
+    applyTheme
+};

--- a/src/configs/app.config.js
+++ b/src/configs/app.config.js
@@ -23,6 +23,15 @@ const languages = {
 };
 
 /**
+* Get supported language map
+* @return {Map<String,String>}
+*/
+function getLanguageMap()
+{
+    return languages;
+}
+
+/**
 * Get supported language codes
 * @return {Array}
 */
@@ -44,6 +53,7 @@ function getLanguageName(code)
 module.exports = {
     fallbackLng: 'en',
     namespace: 'translation',
+    getLanguageMap,
     getLanguagesCodes,
     getLanguageName
 };

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -8,11 +8,13 @@
     <link rel="stylesheet" href="../css/styles.css">
 
     <!-- First we need to declare jQuery and $ globals with jquery -->
+    <script src="../node_modules/jquery/dist/jquery.min.js" charset="utf-8"></script>
     <script>
-        window.$ = window.jQuery = require('jquery');
+        window.$ = window.jQuery;
     </script>
+
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
-    <script src="preferences.js"></script>
+    <script type="module" src="preferences.js"></script>
 </head>
 
 <body id="preferences-window" class="common-window">

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -9,7 +9,7 @@
     <!-- First we need to declare jQuery and $ globals with jquery -->
     <script>window.$ = window.jQuery = require('jquery');</script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
-    <script src="workday-waiver.js"></script>
+    <script type="module" src="workday-waiver.js"></script>
 </head>
 
 <body id="workday-waiver-window" class="common-window">

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import { applyTheme } from '../renderer/themes.js';
+
 const { remote } = require('electron');
 const Store = require('electron-store');
 const Holidays = require('date-holidays');
 
 const { getUserPreferences, showDay } = require('../js/user-preferences.js');
 const { validateTime, diffDays } = require('../js/time-math.js');
-const { applyTheme } = require('../js/themes.js');
 const { getDateStr } = require('../js/date-aux.js');
 const { bindDevToolsShortcut, showAlert, showDialog } = require('../js/window-aux.js');
 const i18n = require('./configs/i18next.config.js');


### PR DESCRIPTION
#### Related issue
Doesn't close #646, but helps.

#### Context / Background
In #646 we are trying to update electron to the newest version, but we're blocked because we're using electron remote, and that is deprecated in the newest versions.

#### What change is being introduced by this PR?
In this patch I adapt the Preferences window to work through a preload script, and an isolated environment, without any node module dependencies outside of what the preload API offers.

Basically, I exposed an API on the new files renderer/preload-scripts/preferences-api.js and preferences-bridge.js using the ContextBridge electron object (see https://www.electronjs.org/docs/latest/api/context-bridge). This API is defined via the main process, and is set to the global window object, and can be accessed in the preferences.js file, loaded in a BrowserWindow, inside a new renderer process.

The renderer js files are now ES6 modules, the only way I found the renderer process files to include others, now that node is not allowed in those files. Using "type=module" on the .js includes in the html files allow us to use ES6 modules.

I had to adapt the i18n flow as I tried to make it only available in the main process. We're now only returning the map of translated strings to the renderer process, and that process (i18n-translator.js) is responsible for iterating over the html elements it has to translate while searching on the map. We'll stop depending on jquery-i18n-next due to this, and in the future we may be able to only load i18n once on the main process, avoiding the multiple loads we had to do for each window.

The process to bind the dev tools opening to the key ctrl+shift+I was changed to use BrowserWindow callbacks instead of binding through electron remote.

#### How will this be tested?
I had to add babel to the project to allow jest to run with the ES6 modules. But the preferences test is now working fine, as it has access both to the renderer js and the APIs defined outside.
I split themes.js tests into main and renderer since the code is duplicated now.

PS: There's a change to ESlint to allow it to parse the ES6 module files.