### PR TITLE
Add test for getMonthLength in date-aux.js

### DIFF
--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -1,27 +1,30 @@
 /* eslint-disable no-undef */
-'use strict';
+"use strict";
 
-const { getDateStr } = require('../../js/date-aux');
+const { getDateStr, getCurrentDateTimeStr } = require("../../js/date-aux");
 
-describe('Date Functions', () =>
-{
-    const badDate = ['this', 'is', 'not', 'a', 'date'];
-    const testDate = new Date();
-    const expectedDate = new Date(testDate.getTime() - (testDate.getTimezoneOffset() * 60000)).toISOString().substr(0, 10);
+describe("Date Functions", () => {
+  const badDate = ["this", "is", "not", "a", "date"];
+  const testDate = new Date();
+  const expectedDate = new Date(
+    testDate.getTime() - testDate.getTimezoneOffset() * 60000
+  )
+    .toISOString()
+    .substr(0, 10);
 
-    describe('getDateStr(Date())', () =>
-    {
-        test('Given a JS Date() object, should return YYYY-MM-DD', () =>
-        {
-            expect(getDateStr(testDate)).toBe(expectedDate);
-        });
-
-        test('Given an insane object, should return an error', () =>
-        {
-            expect(getDateStr(badDate)).not.toBe(expectedDate);
-        });
-
+  describe("getDateStr(Date())", () => {
+    test("Given a JS Date() object, should return YYYY-MM-DD", () => {
+      expect(getDateStr(testDate)).toBe(expectedDate);
     });
+
+    test("Given an insane object, should return an error", () => {
+      expect(getDateStr(badDate)).not.toBe(expectedDate);
+    });
+  });
+
+  describe("getCurrentDateTimeStr()", () => {
+    test("Returns DateTime string in YYYY_MM_DD_HH_MM_SS format", () => {
+      expect(getCurrentDateTimeStr().toBe());
+    });
+  });
 });
-
-

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -25,11 +25,20 @@ describe('Date Functions', () =>
     describe('getMonthLength(Year, Month)', () =>
     {
         const testYear = 2024;
-        const testMonth = 1;
-        const expectedLength = 29;
-        test('Given a JS Year and Month, should return number of days in month', () =>
+        test('Given for the Year(2024) and Months, should return number of days in month', () =>
         {
-            expect(getMonthLength(testYear, testMonth)).toBe(expectedLength);
+            expect(getMonthLength(testYear, 1)).toBe(29);
+            expect(getMonthLength(testYear, 2)).toBe(31);
+            expect(getMonthLength(testYear, 3)).toBe(30);
+            expect(getMonthLength(testYear, 4)).toBe(31);
+            expect(getMonthLength(testYear, 5)).toBe(30);
+            expect(getMonthLength(testYear, 6)).toBe(31);
+            expect(getMonthLength(testYear, 7)).toBe(31);
+            expect(getMonthLength(testYear, 8)).toBe(30);
+            expect(getMonthLength(testYear, 9)).toBe(31);
+            expect(getMonthLength(testYear, 10)).toBe(30);
+            expect(getMonthLength(testYear, 11)).toBe(31);
+            expect(getMonthLength(testYear, 12)).toBe(31);
         });
     });
 

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const { getDateStr, getCurrentDateTimeStr } = require('../../js/date-aux');
+const { getDateStr, getCurrentDateTimeStr, getMonthLength } = require('../../js/date-aux');
 
 describe('Date Functions', () =>
 {
@@ -20,6 +20,17 @@ describe('Date Functions', () =>
         test('Given an insane object, should return an error', () =>
         {
             expect(getDateStr(badDate)).not.toBe(expectedDate);
+        });
+    });
+
+    describe('getMonthLength(Year, Month)', () =>
+    {
+        const testYear = 2024;
+        const testMonth = 1;
+        const expectedLength = 29;
+        test('Given a JS Year and Month, should return number of days in month', () =>
+        {
+            expect(getMonthLength(testYear, testMonth)).toBe(expectedLength);
         });
     });
 

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -27,6 +27,7 @@ describe('Date Functions', () =>
         const testYear = 2024;
         test('Given for the Year(2024) and Months, should return number of days in month', () =>
         {
+            expect(getMonthLength(testYear, 0)).toBe(31);
             expect(getMonthLength(testYear, 1)).toBe(29);
             expect(getMonthLength(testYear, 2)).toBe(31);
             expect(getMonthLength(testYear, 3)).toBe(30);
@@ -38,7 +39,6 @@ describe('Date Functions', () =>
             expect(getMonthLength(testYear, 9)).toBe(31);
             expect(getMonthLength(testYear, 10)).toBe(30);
             expect(getMonthLength(testYear, 11)).toBe(31);
-            expect(getMonthLength(testYear, 12)).toBe(31);
         });
     });
 

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const { getDateStr, getCurrentDateTimeStr } = require('../../js/date-aux');
+const { getDateStr, getCurrentDateTimeStr, getMonthLength } = require('../../js/date-aux');
 
 describe('Date Functions', () =>
 {
@@ -19,6 +19,17 @@ describe('Date Functions', () =>
         test('Given an insane object, should return an error', () =>
         {
             expect(getDateStr(badDate)).not.toBe(expectedDate);
+        });
+    });
+
+    describe('getMonthLength(Year, Month)', () =>
+    {
+        const testYear = 2024;
+        const testMonth = 1;
+        const expectedLength = 29;
+        test('Given a JS Year and Month, should return number of days in month', () =>
+        {
+            expect(getMonthLength(testYear, testMonth)).toBe(expectedLength);
         });
     });
 

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -1,31 +1,37 @@
 /* eslint-disable no-undef */
-"use strict";
+'use strict';
 
-const { getDateStr, getCurrentDateTimeStr } = require("../../js/date-aux");
+const { getDateStr, getCurrentDateTimeStr } = require('../../js/date-aux');
 
-describe("Date Functions", () => {
-  const badDate = ["this", "is", "not", "a", "date"];
-  const testDate = new Date();
-  const expectedDate = new Date(
-    testDate.getTime() - testDate.getTimezoneOffset() * 60000
-  )
-    .toISOString()
-    .substr(0, 10);
+describe('Date Functions', () =>
+{
+    const badDate = ['this', 'is', 'not', 'a', 'date'];
+    const testDate = new Date();
+    const expectedDate = new Date(
+        testDate.getTime() - testDate.getTimezoneOffset() * 60000
+    )
+        .toISOString()
+        .substr(0, 10);
 
-  describe("getDateStr(Date())", () => {
-    test("Given a JS Date() object, should return YYYY-MM-DD", () => {
-      expect(getDateStr(testDate)).toBe(expectedDate);
+    describe('getDateStr(Date())', () =>
+    {
+        test('Given a JS Date() object, should return YYYY-MM-DD', () =>
+        {
+            expect(getDateStr(testDate)).toBe(expectedDate);
+        });
+
+        test('Given an insane object, should return an error', () =>
+        {
+            expect(getDateStr(badDate)).not.toBe(expectedDate);
+        });
     });
 
-    test("Given an insane object, should return an error", () => {
-      expect(getDateStr(badDate)).not.toBe(expectedDate);
+    describe('getCurrentDateTimeStr()', () =>
+    {
+        const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
+        test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters', () =>
+        {
+            expect(regexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);
+        });
     });
-  });
-
-  describe("getCurrentDateTimeStr()", () => {
-    const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
-    test("Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters", () => {
-      expect(regexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);
-    });
-  });
 });

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const { getDateStr, getCurrentDateTimeStr, getMonthLength } = require('../../js/date-aux');
+const { getDateStr, getCurrentDateTimeStr } = require('../../js/date-aux');
 
 describe('Date Functions', () =>
 {
@@ -20,17 +20,6 @@ describe('Date Functions', () =>
         test('Given an insane object, should return an error', () =>
         {
             expect(getDateStr(badDate)).not.toBe(expectedDate);
-        });
-    });
-
-    describe('getMonthLength(Year, Month)', () =>
-    {
-        const testYear = 2024;
-        const testMonth = 1;
-        const expectedLength = 29;
-        test('Given a JS Year and Month, should return number of days in month', () =>
-        {
-            expect(getMonthLength(testYear, testMonth)).toBe(expectedLength);
         });
     });
 

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -8,8 +8,6 @@ describe('Date Functions', () =>
     const badDate = ['this', 'is', 'not', 'a', 'date'];
     const testDate = new Date();
     const expectedDate = new Date(testDate.getTime() - (testDate.getTimezoneOffset() * 60000)).toISOString().substr(0, 10);
-    const looseRegexCurrentDateTime = /(\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2})/g;
-    const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
 
     describe('getDateStr(Date())', () =>
     {
@@ -26,6 +24,9 @@ describe('Date Functions', () =>
 
     describe('getCurrentDateTimeStr()', () =>
     {
+        const looseRegexCurrentDateTime = /(\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2})/g;
+        const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
+
         test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters making sure it accepts digits', () =>
         {
             expect(looseRegexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -7,7 +7,7 @@ describe('Date Functions', () =>
 {
     const badDate = ['this', 'is', 'not', 'a', 'date'];
     const testDate = new Date();
-    const expectedDate = new Date(testDate.getTime() - testDate.getTimezoneOffset() * 60000).toISOString().substr(0, 10);
+    const expectedDate = new Date(testDate.getTime() - (testDate.getTimezoneOffset() * 60000)).toISOString().substr(0, 10);
     const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
 
     describe('getDateStr(Date())', () =>

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -7,11 +7,8 @@ describe('Date Functions', () =>
 {
     const badDate = ['this', 'is', 'not', 'a', 'date'];
     const testDate = new Date();
-    const expectedDate = new Date(
-        testDate.getTime() - testDate.getTimezoneOffset() * 60000
-    )
-        .toISOString()
-        .substr(0, 10);
+    const expectedDate = new Date(testDate.getTime() - testDate.getTimezoneOffset() * 60000).toISOString().substr(0, 10);
+    const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
 
     describe('getDateStr(Date())', () =>
     {
@@ -28,7 +25,6 @@ describe('Date Functions', () =>
 
     describe('getCurrentDateTimeStr()', () =>
     {
-        const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
         test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters', () =>
         {
             expect(regexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -8,6 +8,7 @@ describe('Date Functions', () =>
     const badDate = ['this', 'is', 'not', 'a', 'date'];
     const testDate = new Date();
     const expectedDate = new Date(testDate.getTime() - (testDate.getTimezoneOffset() * 60000)).toISOString().substr(0, 10);
+    const looseRegexCurrentDateTime = /(\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2})/g;
     const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
 
     describe('getDateStr(Date())', () =>
@@ -25,6 +26,11 @@ describe('Date Functions', () =>
 
     describe('getCurrentDateTimeStr()', () =>
     {
+        test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters making sure it accepts digits', () =>
+        {
+            expect(looseRegexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);
+        });
+
         test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters', () =>
         {
             expect(regexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);

--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -23,8 +23,9 @@ describe("Date Functions", () => {
   });
 
   describe("getCurrentDateTimeStr()", () => {
-    test("Returns DateTime string in YYYY_MM_DD_HH_MM_SS format", () => {
-      expect(getCurrentDateTimeStr().toBe());
+    const regexCurrentDateTime = /(\d{4}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01])_(0\d|1\d|2[0-3])_([0-5]\d)_([0-5]\d))/g;
+    test("Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters", () => {
+      expect(regexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);
     });
   });
 });


### PR DESCRIPTION
#### Related issue
Closes #788 

#### Context / Background
Added new test case for `getMonthLength()` in this PR.

#### What change is being introduced by this PR?
- How did you approach this problem?
> Created a test case to send test year and test month to validate the number of days in the month.
- What changes did you make to achieve the goal?
> Triggering function `getMonthLength()` using year and month.
- What are the indirect and direct consequences of the change?
> It tests the functionality of `getCurrentDateTimeStr()` in `date-aux.js`

#### How will this be tested?
- How will you verify whether your changes worked as expected once merged?
> I've already tested the test case functionality locally attaching the screenshot.

![Test Image](https://user-images.githubusercontent.com/22577475/137847797-05efd054-1744-439f-b536-f92f62a3a1e5.png)