### PR TITLE
Fix punch button locale not synchronizing after locale change

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,12 +20,7 @@
 
 <body>
     <div id="calendar" class="container"></div>
-    <div class="footer">
-        <button class="punch-button" id="punch-button" disabled>
-            <img src="assets/fingerprint.svg" height="36" width="36">
-            <label for="punch-button" id="punch-button-label">Punch time</label>
-        </button>
-    </div>
+    <div id="footer" class="footer"></div>
 </body>
 
 </html>

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -122,8 +122,6 @@ $(() =>
             calendar = CalendarFactory.getInstance(preferences);
             setInterval(notifyTimeToLeave, 60000);
             applyTheme(preferences.theme);
-
-            $('#punch-button').on('click', () => { calendar.punchDate(); });
         })
         .catch(err =>
         {

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -18,6 +18,7 @@ const { getDateStr, getMonthLength } = require('../date-aux.js');
 const { getMonthName } = require('../date-to-string-util.js');
 const { computeAllTimeBalanceUntilAsync } = require('../time-balance.js');
 const { generateKey } = require('../date-db-formatter.js');
+const i18n = require('../../src/configs/i18next.config.js');
 
 // Global values for calendar
 const flexibleStore = new Store({name: 'flexible-store'});
@@ -133,6 +134,26 @@ class BaseCalendar
     }
 
     /**
+     * Returns the code of the table footer of the calendar.
+     * @return {string}
+     */
+    _generateTableFooter()
+    {
+        return '<button class="punch-button" id="punch-button" disabled>' +
+            '<img src="assets/fingerprint.svg" height="36" width="36"></img>' +
+            `<label for="punch-button" id="punch-button-label">${i18n.t('$Menu.punch-time')}</label>` +
+            '</button>\n';
+    }
+
+    /**
+     * Updates the code of the table footer of the calendar, to be called on demand.
+     */
+    _updateTableFooter()
+    {
+        $('#footer').html(this._generateTableFooter());
+    }
+
+    /**
      * Reloads internal DBs based on external DBs and then redraws the calendar.
      */
     reload()
@@ -149,6 +170,7 @@ class BaseCalendar
     {
         this._updateTableHeader();
         this._updateTableBody();
+        this._updateTableFooter();
         this._updateBasedOnDB();
 
         const isCurrentMonth = this._getTodayMonth() === this._getCalendarMonth() && this._getTodayYear() === this._getCalendarYear();
@@ -159,6 +181,9 @@ class BaseCalendar
         this._updateLeaveBy();
 
         const calendar = this;
+
+        $('#punch-button').on('click', () => { calendar.punchDate(); });
+
         $('input[type=\'time\']').off('input propertychange').on('input propertychange', function()
         {
             //  deepcode ignore no-invalid-this: jQuery use

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -140,9 +140,9 @@ class BaseCalendar
     _generateTableFooter()
     {
         return '<button class="punch-button" id="punch-button" disabled>' +
-            '<img src="assets/fingerprint.svg" height="36" width="36"></img>' +
-            `<label for="punch-button" id="punch-button-label">${i18n.t('$Menu.punch-time')}</label>` +
-            '</button>\n';
+                   '<img src="assets/fingerprint.svg" height="36" width="36"></img>' +
+                   `<label for="punch-button" id="punch-button-label">${i18n.t('$Menu.punch-time')}</label>` +
+               '</button>\n';
     }
 
     /**


### PR DESCRIPTION
#### Related issue
Closes #793 

#### Context / Background
This refactors the punch button into being re-localized when locale changes along with the rest of the calendar layout.

#### What change is being introduced by this PR?
By moving the rendering of the footer over into the calendar, we streamline the re-rendering of the app when, for example, the language is changed.

This introduced a minor issue where the button was losing its binding.

#### How will this be tested?
1. Open TTL
1. Go to preferences (Edit menu)
1. Change the language to some other than English
1. Close the preference window
1. See the text is translated
1. Press the button to punch in the time!
