### PR TITLE
Adding utility for generating random entries for TTL

### DIFF
--- a/js/demo-generator.js
+++ b/js/demo-generator.js
@@ -1,0 +1,83 @@
+const { hourMinToHourFormatted, sumTime } = require('./time-math.js');
+const Store = require('electron-store');
+const { generateKey } = require('./date-db-formatter');
+
+/**
+* Converts a string in the format YYYY-MM-DD to a Date object.
+* @param {string} dateStr String in the format 'YYYY-MM-DD'
+* @return {Date} Equivalent date object for the given string.
+*/
+function strToDate(dateStr)
+{
+    const dateParts = dateStr.split('-');
+    return new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
+}
+
+/**
+ * Returns a random integer between min (inclusive) and max (inclusive), rounding up to closest multiple of 5
+ * @param {int} min Minimum value
+ * @param {int} max Maximum value
+ * @returns Random number between min and max
+ */
+function randomIntFromInterval(min, max)
+{ // min and max included
+    function round5(x)
+    {
+        return Math.ceil(x / 5) * 5;
+    }
+    return round5(Math.floor(Math.random() * (max - min + 1) + min));
+}
+
+/**
+ * Generated a random incremental time string in the format 'HH:MM' (negative or positive)
+ * The random time should be between 0 and 59
+ * @param {int} min Minimum value
+ * @param {int} max Maximum value
+ * @returns Random time between min and max
+ */
+function randomIncremental(min, max)
+{
+    const rand = randomIntFromInterval(min, max);
+    const timeStr = hourMinToHourFormatted(0/*hour*/, rand/*min*/);
+    const negative = randomIntFromInterval(0, 1) === 1;
+    return `${negative ? '-' : ''}${timeStr}`;
+}
+
+/**
+ * Generate random entries for the given date range, respecting the given working days and using as a base the usual times.
+ * Usage example: generateDemoInformation('2021-01-01', '2021-10-18', [1, 2, 3, 4, 5], ['10:00', '13:00', '14:00', '19:00']);
+ * @param  {string} dateFromStr Starting date in the form YYYY-MM-DD
+ * @param {string} dateToStr Ending date in the form YYYY-MM-DD
+ * @param {string[]} workingDays Array of integers representing the working days of the week (0 = Sunday, 6 = Saturday)
+ * @param {string[]} workingTimes Array of strings representing the usual times of breaks in a day (start time, lunch begin, lunch end and leave time)
+ */
+function generateDemoInformation(dateFromStr, dateToStr, workingDays, usualTimes = ['9:00', '12:00', '13:00', '18:00'])
+{
+    const dateFrom = strToDate(dateFromStr);
+    const dateTo = strToDate(dateToStr);
+
+    console.log(`Generating random entried from: ${dateFrom} to ${dateTo}`);
+
+    const valuesToStore = {};
+    for (let day = dateFrom; day <= dateTo; day.setDate(day.getDate() + 1))
+    {
+        if (!workingDays.includes(day.getDay()))
+        {
+            continue;
+        }
+
+        const entry0 = sumTime(usualTimes[0], randomIncremental(0, 30));
+        const entry1 = sumTime(usualTimes[1], randomIncremental(0, 15));
+        const entry2 = sumTime(usualTimes[2], randomIncremental(0, 15));
+        const entry3 = sumTime(usualTimes[3], randomIncremental(0, 30));
+        const flexibleEntry = { values: [entry0, entry1, entry2, entry3] };
+        valuesToStore[generateKey(day.getFullYear(), day.getMonth(), day.getDate())] = flexibleEntry;
+    }
+    console.log(`Generated ${Object.keys(valuesToStore).length} entries`);
+    const flexibleStore = new Store({name: 'flexible-store'});
+    flexibleStore.set(valuesToStore);
+}
+
+module.exports = {
+    generateDemoInformation
+};

--- a/js/demo-generator.js
+++ b/js/demo-generator.js
@@ -9,6 +9,7 @@ const Store = require('electron-store');
  * @returns Random number between min and max
  */
 function randomIntFromInterval(min, max)
+{
     round5 = (x) => Math.ceil(x / 5) * 5;
     return round5(Math.floor(Math.random() * (max - min + 1) + min));
 }
@@ -38,8 +39,8 @@ function randomTime(min, max)
  */
 function generateDemoInformation(dateFromStr, dateToStr, workingDays, usualTimes = ['9:00', '12:00', '13:00', '18:00'])
 {
-    const dateFrom = Date.parse(dateFromStr);
-    const dateTo = Date.parse(dateToStr);
+    const dateFrom = new Date(Date.parse(dateFromStr));
+    const dateTo = new Date(Date.parse(dateToStr));
 
     console.log(`Generating random entried from: ${dateFrom} to ${dateTo}`);
 

--- a/js/demo-generator.js
+++ b/js/demo-generator.js
@@ -1,17 +1,6 @@
 const { hourMinToHourFormatted, sumTime } = require('./time-math.js');
+const { generateKey } = require('./date-db-formatter.js');
 const Store = require('electron-store');
-const { generateKey } = require('./date-db-formatter');
-
-/**
-* Converts a string in the format YYYY-MM-DD to a Date object.
-* @param {string} dateStr String in the format 'YYYY-MM-DD'
-* @return {Date} Equivalent date object for the given string.
-*/
-function strToDate(dateStr)
-{
-    const dateParts = dateStr.split('-');
-    return new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
-}
 
 /**
  * Returns a random integer between min (inclusive) and max (inclusive), rounding up to closest multiple of 5
@@ -20,22 +9,18 @@ function strToDate(dateStr)
  * @returns Random number between min and max
  */
 function randomIntFromInterval(min, max)
-{ // min and max included
-    function round5(x)
-    {
-        return Math.ceil(x / 5) * 5;
-    }
+    round5 = (x) => Math.ceil(x / 5) * 5;
     return round5(Math.floor(Math.random() * (max - min + 1) + min));
 }
 
 /**
- * Generated a random incremental time string in the format 'HH:MM' (negative or positive)
+ * Generated a random time string in the format 'HH:MM' (negative or positive)
  * The random time should be between 0 and 59
  * @param {int} min Minimum value
  * @param {int} max Maximum value
  * @returns Random time between min and max
  */
-function randomIncremental(min, max)
+function randomTime(min, max)
 {
     const rand = randomIntFromInterval(min, max);
     const timeStr = hourMinToHourFormatted(0/*hour*/, rand/*min*/);
@@ -46,15 +31,15 @@ function randomIncremental(min, max)
 /**
  * Generate random entries for the given date range, respecting the given working days and using as a base the usual times.
  * Usage example: generateDemoInformation('2021-01-01', '2021-10-18', [1, 2, 3, 4, 5], ['10:00', '13:00', '14:00', '19:00']);
- * @param  {string} dateFromStr Starting date in the form YYYY-MM-DD
+ * @param {string} dateFromStr Starting date in the form YYYY-MM-DD
  * @param {string} dateToStr Ending date in the form YYYY-MM-DD
  * @param {string[]} workingDays Array of integers representing the working days of the week (0 = Sunday, 6 = Saturday)
  * @param {string[]} workingTimes Array of strings representing the usual times of breaks in a day (start time, lunch begin, lunch end and leave time)
  */
 function generateDemoInformation(dateFromStr, dateToStr, workingDays, usualTimes = ['9:00', '12:00', '13:00', '18:00'])
 {
-    const dateFrom = strToDate(dateFromStr);
-    const dateTo = strToDate(dateToStr);
+    const dateFrom = Date.parse(dateFromStr);
+    const dateTo = Date.parse(dateToStr);
 
     console.log(`Generating random entried from: ${dateFrom} to ${dateTo}`);
 
@@ -66,10 +51,10 @@ function generateDemoInformation(dateFromStr, dateToStr, workingDays, usualTimes
             continue;
         }
 
-        const entry0 = sumTime(usualTimes[0], randomIncremental(0, 30));
-        const entry1 = sumTime(usualTimes[1], randomIncremental(0, 15));
-        const entry2 = sumTime(usualTimes[2], randomIncremental(0, 15));
-        const entry3 = sumTime(usualTimes[3], randomIncremental(0, 30));
+        const entry0 = sumTime(usualTimes[0], randomTime(0, 30));
+        const entry1 = sumTime(usualTimes[1], randomTime(0, 15));
+        const entry2 = sumTime(usualTimes[2], randomTime(0, 15));
+        const entry3 = sumTime(usualTimes[3], randomTime(0, 30));
         const flexibleEntry = { values: [entry0, entry1, entry2, entry3] };
         valuesToStore[generateKey(day.getFullYear(), day.getMonth(), day.getDate())] = flexibleEntry;
     }


### PR DESCRIPTION
This file introduces a random generator for entries on TTL.
The main use for is to help tests, specially performance ones, as well generate entries for demos (screenshots).

Its use is meant for development, so it's not exposed.
To use it, one must open the developer's tools, and run, for example:

```
const { generateDemoInformation } = require('./js/demo-generator.js');
generateDemoInformation('2021-10-15', '2021-10-18', [1, 2, 3, 4, 5], ['10:00', '12:45', '13:30', '18:45']);
```