### PR TITLE
 Resolved holiday part of the Workday Waiver Menu #798 

### DIFF
--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -21,10 +21,10 @@
         </div>
         <ul class="nav nav-tabs window-tab" role="tablist">
             <li class="nav-item">
-                <a class="nav-link active" id="add-waiver-tab" data-toggle="tab" href="#add-waiver" role="tab" aria-controls="add-waiver" aria-selected="true" data-i18n="$WorkdayWaiver.add-waiver">Add Waiver</a>
+                <a class="nav-link active" id="add-waiver-tab" data-bs-toggle="tab "data-bs-target="#add-waiver" href="#add-waiver" role="tab" aria-controls="add-waiver" aria-selected="true" data-i18n="$WorkdayWaiver.add-waiver">Add Waiver</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" id="holiday-tab" data-toggle="tab" href="#holiday" role="tab" aria-controls="holiday" aria-selected="false" data-i18n="$WorkdayWaiver.nav-holiday">Holiday</a>
+                <a class="nav-link " id="holiday-tab " data-bs-toggle="tab" data-bs-target="#holiday" href="#holiday" role="tab" aria-controls="holiday" aria-selected="false" data-i18n="$WorkdayWaiver.nav-holiday">Holiday</a>
             </li>
         </ul>
 

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -15,7 +15,7 @@
 <body id="workday-waiver-window" class="common-window">
     <div class="container">
         <div class="header-title" data-i18n="$WorkdayWaiver.waiver-manager">
-             Workday Waiver Manager
+            Workday Waiver Manager
             <p class="header-help" data-i18n="$WorkdayWaiver.header-help">
                 Changes take effect when closing this window</p>
         </div>

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -24,7 +24,7 @@
                 <a class="nav-link active" id="add-waiver-tab" data-bs-toggle="tab "data-bs-target="#add-waiver" href="#add-waiver" role="tab" aria-controls="add-waiver" aria-selected="true" data-i18n="$WorkdayWaiver.add-waiver">Add Waiver</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link " id="holiday-tab " data-bs-toggle="tab" data-bs-target="#holiday" href="#holiday" role="tab" aria-controls="holiday" aria-selected="false" data-i18n="$WorkdayWaiver.nav-holiday">Holiday</a>
+                <a class="nav-link" id="holiday-tab" data-bs-toggle="tab" data-bs-target="#holiday" href="#holiday" role="tab" aria-controls="holiday" aria-selected="false" data-i18n="$WorkdayWaiver.nav-holiday">Holiday</a>
             </li>
         </ul>
 

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -15,7 +15,7 @@
 <body id="workday-waiver-window" class="common-window">
     <div class="container">
         <div class="header-title" data-i18n="$WorkdayWaiver.waiver-manager">
-            Workday Waiver Manager
+             Workday Waiver Manager
             <p class="header-help" data-i18n="$WorkdayWaiver.header-help">
                 Changes take effect when closing this window</p>
         </div>


### PR DESCRIPTION
Closes #792 The holiday part of the Workday Waiver is a broken issue .Resolved this issue by adding the data-target attribute that points to the HTML element that will be changed on click on the anchor tag