### PR TITLE
Broken preferences window after #786

### DIFF
--- a/src/preferences.js
+++ b/src/preferences.js
@@ -2,7 +2,6 @@
 
 import { applyTheme } from '../renderer/themes.js';
 import { translatePage } from '../renderer/i18n-translator.js';
-import userPreferences from '../js/user-preferences.js';
 
 // Global values for preferences page
 let usersStyles;


### PR DESCRIPTION
#### Context / Background
I pulled and tried to open the preferences window after the merge in #786 and apparently the window was broken because of a bad import. Turns out there was an extra line importing a file as if it was an ES6 module.
I wonder why no tests caught this.

![image](https://user-images.githubusercontent.com/37311270/138617691-be3bd552-01d2-4239-b0e1-805863a0e09f.png)
