### PR TITLE
Fix #792: Broken holiday tab on Workday Waiver Window

### DIFF
--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -21,7 +21,7 @@
         </div>
         <ul class="nav nav-tabs window-tab" role="tablist">
             <li class="nav-item">
-                <a class="nav-link active" id="add-waiver-tab" data-bs-toggle="tab "data-bs-target="#add-waiver" href="#add-waiver" role="tab" aria-controls="add-waiver" aria-selected="true" data-i18n="$WorkdayWaiver.add-waiver">Add Waiver</a>
+                <a class="nav-link active" id="add-waiver-tab" data-bs-toggle="tab" data-bs-target="#add-waiver" href="#add-waiver" role="tab" aria-controls="add-waiver" aria-selected="true" data-i18n="$WorkdayWaiver.add-waiver">Add Waiver</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" id="holiday-tab" data-bs-toggle="tab" data-bs-target="#holiday" href="#holiday" role="tab" aria-controls="holiday" aria-selected="false" data-i18n="$WorkdayWaiver.nav-holiday">Holiday</a>


### PR DESCRIPTION
#### Related issue
Closes #<!--Related issue-->

#### Context / Background
<!--
Waiver tabs

Related issue: 792
Closes # 792

Context / Background
PR review changes to: Buggy tab functionality, broken navigation between Holiday and Add Waiver tabs.
Changes requested by araujoarthur0

What change is being introduced by this PR?
- I got rid of the unnecessary change to the demo-generator.js file. 
- I installed version 9.0.1 of mocha in my package.json

How will this be tested?
I ran both npm run lint-fix and got All matched files use Prettier code style! and ran npm run test:jest and got
```
Test Suites: 15 passed, 15 total
Tests:       141 passed, 141 total
Snapshots:   0 total
Time:        65.193 s
```
-->
