### PR TITLE
Fixes #827: Show balance even though month ends on non-work day

### DIFF
--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -257,7 +257,8 @@ class FlexibleMonthCalendar extends BaseCalendar
         const monthLength = getMonthLength(this._getCalendarYear(), this._getCalendarMonth());
         const balanceRowPosition = this._getBalanceRowPosition();
 
-        for (let day = 1; day <= monthLength; ++day)
+        let day;
+        for (day = 1; day <= monthLength; ++day)
         {
             if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day) && this._getHideNonWorkingDays())
             {
@@ -265,11 +266,13 @@ class FlexibleMonthCalendar extends BaseCalendar
             }
 
             html += this._getInputsRowCode(this._getCalendarYear(), this._getCalendarMonth(), day);
-            if (day === balanceRowPosition)
-            {
-                html += this._getBalanceRowCode();
-            }
         }
+
+        if (day >= balanceRowPosition)
+        {
+            html += this._getBalanceRowCode();
+        }
+
         return html;
     }
 


### PR DESCRIPTION
#### Related issue
Closes #827

#### Context / Background
Seemed like an easy issue to fix, so I took it on. Shouldn't break anything; nothing was added or removed, just shifted some blocks around inside one function.

#### What change is being introduced by this PR?
In `generateTableBody()` in `FlexibleMonthCalendar,js`, moved out the if statement block with  `_getBalanceRowCode()` call outside the for loop. Also moved the declaration of block variable `day` outside the for loop so it can be accessed afterwards. Before, the bug was caused by skipping for loop iterations with `continue` after evaluating `_showDay() && _getHideNonWorkingDays()` to true.

#### How will this be tested?
Ran the test suite with `npm run test:jest`, all tests green. I've done some quick testing on my machine, switching over to other months, switching "Hide non-working days" on and off. Everything behaves as expected.
