### PR TITLE
add Time To Leave in notify method

### DIFF
--- a/js/notification.js
+++ b/js/notification.js
@@ -34,6 +34,7 @@ function notify(msg, actions)
             sound: true, // Only Notification Center or Windows Toasters
             wait: true,
             actions: actions,
+            appID: 'Time To Leave'
         }, (error, action) =>
         {
             if (error) reject(error);


### PR DESCRIPTION
#### Related issue
Closes #810

#### Context / Background
Attempt to remove the 'SnoreToast' text in Windows notifications

#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
looked up info for appID and it's syntax for the notify method

- What changes did you make to achieve the goal?
add an appID: line in the notify method

- What are the indirect and direct consequences of the change?
intention of removing 'SnoreToast' text from notifications, replaced by "Time to Leave"
-->

#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
reinstalling and testing
-->

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
