### PR TITLE
Apply refurb changes to python scripts

### DIFF
--- a/scripts/check_languages.py
+++ b/scripts/check_languages.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from math import floor
+from pathlib import Path
 from urllib.parse import urlencode, unquote, urlparse, parse_qsl, ParseResult
 
 LOCALES_PATH = 'locales/'
@@ -163,7 +164,7 @@ def get_keys_to_ignore(locale : str, scope : str) -> list:
 # Compare two languages, passing over all scopes, returning the erros for the language
 def compare_language(locale : str, baseline_language : dict, language : dict) -> dict:
     scopes = [x for x in baseline_language]
-    errors = dict()
+    errors = {}
     for scope in scopes:
         if scope in language:
             keys_to_ignore = get_keys_to_ignore(locale, scope)
@@ -176,7 +177,7 @@ def compare_language(locale : str, baseline_language : dict, language : dict) ->
 # Check if there's any missing key or scope in language, returning the erros
 def get_missing_keys(baseline_language : dict, language : dict) -> dict:
     scopes = [x for x in baseline_language]
-    missing_keys = dict()
+    missing_keys = {}
     for scope in scopes:
         baseline_keys = baseline_language[scope].keys()
         if scope in language:
@@ -327,8 +328,8 @@ def main():
 
     baseline_language = get_language(BASELINE_LANGUAGE)
 
-    errors_missing_keys = dict()
-    errors_extra_keys = dict()
+    errors_missing_keys = {}
+    errors_extra_keys = {}
 
     for locale in locales:
         mising_keys = get_missing_keys(baseline_language, get_language(locale))
@@ -338,7 +339,7 @@ def main():
         if extra_keys:
             errors_extra_keys[locale] = extra_keys
 
-    missing_translations = dict()
+    missing_translations = {}
     for locale in locales:
         language = get_language(locale)
         language_error = compare_language(locale, baseline_language, language)
@@ -349,8 +350,7 @@ def main():
     report.generate()
     
     if args.raw_report:
-        with open(args.raw_report, 'w') as f:
-            f.write(report.toJson())
+        Path(args.raw_report).write_text(report.toJson())
 
 if __name__ == "__main__":
     main()

--- a/scripts/compare_language_reports.py
+++ b/scripts/compare_language_reports.py
@@ -27,8 +27,8 @@ class ComparisonReport:
         return set(filter(lambda x: x, out))
 
     def process(baseline_info : dict, target_info : dict):
-        fixed_report = dict()
-        introduced_report = dict()
+        fixed_report = {}
+        introduced_report = {}
         for locale in set(baseline_info | target_info):
             baseline = ComparisonReport.flattenize_keys(baseline_info.get(locale, {}))
             target = ComparisonReport.flattenize_keys(target_info.get(locale, {}))

--- a/scripts/update-changelog.py
+++ b/scripts/update-changelog.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import re
+from pathlib import Path
 
 # Parses a comment that must follow the strict rule of being:
 # <trigger expression>
@@ -76,8 +77,7 @@ def update_changelog(changelog_filename: str, new_change: any, new_user: any):
         lines = file_handler.readlines()
         new_file_content = get_updated_file_content(lines, new_change, new_user)
 
-    with open(changelog_filename, "w") as file_handler:
-        file_handler.write('\n'.join(new_file_content))
+    Path(changelog_filename).write_text('\n'.join(new_file_content))
 
 def get_arguments():
     parser = argparse.ArgumentParser()

--- a/scripts/update_release.py
+++ b/scripts/update_release.py
@@ -66,7 +66,7 @@ class ChangeLogParser:
     users = []
 
     def __init__(self, changelog_file: str, version: str = None):
-        self._file_path = str(changelog_file)
+        self._file_path = changelog_file
         self.version = version
 
     def parse(self):


### PR DESCRIPTION
#### Related issue
N/A

#### Context / Background
I found out about this https://github.com/dosisod/refurb tool and wanted to try it on a few python scripts I knew.

#### What change is being introduced by this PR?
Fixes all of the following warnings:
```
scripts\check_languages.py:166:14 [FURB112]: Use `{}` instead of `dict()`
scripts\check_languages.py:179:20 [FURB112]: Use `{}` instead of `dict()`
scripts\check_languages.py:330:27 [FURB112]: Use `{}` instead of `dict()`
scripts\check_languages.py:331:25 [FURB112]: Use `{}` instead of `dict()`
scripts\check_languages.py:341:28 [FURB112]: Use `{}` instead of `dict()`
scripts\check_languages.py:352:9 [FURB103]: Use `y = Path(x).write_text(y)` instead of `with open(x, ...) as f: f.write(y)`
scripts\update_release.py:69:27 [FURB123]: Use `x` instead of `str(x)`
scripts\update-changelog.py:79:5 [FURB103]: Use `y = Path(x).write_text(y)` instead of `with open(x, ...) as f: f.write(y)`
scripts\compare_language_reports.py:30:24 [FURB112]: Use `{}` instead of `dict()`
scripts\compare_language_reports.py:31:29 [FURB112]: Use `{}` instead of `dict()`
```

#### How will this be tested?
I ran the scripts manually to confirm they work properly