### PR TITLE
Fix #858: Missing Month Name in Month View

### DIFF
--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -16,7 +16,6 @@ import {
 } from '../workday-waiver-aux.js';
 import { showDay, switchCalendarView } from '../user-preferences.js';
 import { getDateStr, getMonthLength } from '../date-aux.js';
-import { getMonthName } from '../date-to-string-util.js';
 import { computeAllTimeBalanceUntilAsync } from '../time-balance.js';
 import { generateKey } from '../date-db-formatter.js';
 import { getTranslationInLanguageData } from '../../renderer/i18n-translator.js';
@@ -126,14 +125,6 @@ class BaseCalendar
         }
 
         return balanceRowPosition;
-    }
-
-    /**
-     * Updates the code of the table header of the calendar, to be called on demand.
-     */
-    _updateTableHeader()
-    {
-        $('#month-year').html(`${getMonthName(this._languageData.data, this._getCalendarMonth())} ${this._getCalendarYear()}`);
     }
 
     /**

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -14,7 +14,7 @@ import {
     displayWaiverWindow
 } from '../workday-waiver-aux.js';
 import { showDialog } from '../window-aux.js';
-import { getDayAbbr } from '../date-to-string-util.js';
+import { getMonthName, getDayAbbr } from '../date-to-string-util.js';
 import { BaseCalendar } from './BaseCalendar.js';
 
 class FlexibleMonthCalendar extends BaseCalendar
@@ -243,6 +243,7 @@ class FlexibleMonthCalendar extends BaseCalendar
      */
     _updateTableHeader()
     {
+        $('#month-year').html(`${getMonthName(this._languageData.data, this._getCalendarMonth())} ${this._getCalendarYear()}`);
         $('.header-day').text(this._getTranslation('$FlexibleMonthCalendar.day'));
         $('.header-day-total').text(this._getTranslation('$FlexibleMonthCalendar.total'));
     }


### PR DESCRIPTION
#### Related issue
Closes #858 

#### Context / Background
The month name is returned to month view.

#### How will this be tested?
Manually observed. Switched languages and months. Clicked on "go to current month".

![image](https://user-images.githubusercontent.com/37311270/196006969-9186bc57-3c06-4e49-9493-7079dff1e598.png)

