### PR TITLE
Fix #866: Fixing the saving of the preference 'minutes between notifications'

### DIFF
--- a/__tests__/__main__/user-preferences.js
+++ b/__tests__/__main__/user-preferences.js
@@ -77,5 +77,40 @@ describe('Preferences Main', () =>
             expect(preferences['view']).toBe('month');
         });
     });
+
+    describe('Notification interval', () =>
+    {
+        function saveNewInterval(val)
+        {
+            const preferences = getUserPreferences();
+            preferences['notifications-interval'] = val;
+            savePreferences(preferences);
+        }
+
+        beforeEach(() => {
+            expect(defaultPreferences['notifications-interval']).toBe('5');
+            savePreferences(defaultPreferences);
+
+            expect(getUserPreferences()['notifications-interval']).toBe('5');
+        });
+
+        test('Saving valid number', () =>
+        {
+            saveNewInterval('6');
+            expect(getUserPreferences()['notifications-interval']).toBe('6');
+        });
+
+        test('Saving invalid number', () =>
+        {
+            saveNewInterval('0');
+            expect(getUserPreferences()['notifications-interval']).toBe('5');
+        });
+
+        test('Saving invalid text', () =>
+        {
+            saveNewInterval('ab');
+            expect(getUserPreferences()['notifications-interval']).toBe('5');
+        });
+    });
 });
 

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -2,7 +2,6 @@
 
 const { ipcRenderer } = require('electron');
 
-import { validateTime } from './time-math.js';
 import { isValidTheme } from '../renderer/themes.js';
 import { getLanguagesCodes } from '../src/configs/app.config.js';
 
@@ -182,7 +181,7 @@ function initPreferencesFileIfNotExistsOrInvalid(filePath = getPreferencesFilePa
         if (timeInputs.includes(key))
         {
             // Set default preference value if notification or time interval is not valid
-            if ((key === 'notifications-interval' && !isNotificationInterval(value)) || !validateTime(value))
+            if (key === 'notifications-interval' && !isNotificationInterval(value))
             {
                 derivedPrefs[key] = defaultPreferences[key];
                 shouldSaveDerivedPrefs = true;


### PR DESCRIPTION
#### Related issue
Closes #866

#### Context / Background
When changing the preference 'minutes between notifications', the value set is not saved, and goes back to '5'.

#### What change is being introduced by this PR?
After closing the window, the value set was correctly saved to the preferences.

However, anytime after that when we tried to retrieve the current preferences, there is a call that validates all preferences and fixes them in case any is wrong. For the notification internval, there is a call to `validateTime()` applied to the value. The call was performed on the value set in the window, and that function expected a HH:mm string, instead of simple numbers 1 < x < 60 like the window had on the field. It always failed and then the value was replaced by the default '5' value again..

#### How will this be tested?
Tested manually. Added new tests.