### PR TITLE
Test Localization report action

### DIFF
--- a/.github/workflows/localization-report.yml
+++ b/.github/workflows/localization-report.yml
@@ -37,6 +37,11 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}" 
           echo ::set-output name=log::$body
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: fc
@@ -52,3 +57,4 @@ jobs:
           body: |
             ${{ steps.report.outputs.log }}
           edit-mode: replace
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
After some investigation, the issue with the localization report failing is that it was using the default GITHUB_TOKEN. As per the comment in the action's page:

In public repositories this action does not work in pull_request workflows when triggered by forks. Any attempt will be met with the error, Resource not accessible by integration. This is due to token restrictions put in place by GitHub Actions. Private repositories can be configured to [enable workflows](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) from forks to run without restriction. See [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks) for further explanation. Alternatively, use the [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event to comment on pull requests.