### PR TITLE
Fix #884: Slightly moving the date picker icon margin in Day view

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1011,7 +1011,7 @@ html[data-view='flexible-day'] #calendar input[type="date" i]::-webkit-calendar-
   background-image: var(--day-calendar-select-icon);
   height: 10px;
   margin-left: 2px;
-  margin-right: -5px;
+  margin-right: -3px;
   width: 10px;
 }
 


### PR DESCRIPTION
#### Related issue
Closes #884

Look at the right side of the date picker icon in day view:

Before:
![image](https://user-images.githubusercontent.com/37311270/197652816-416b453f-12cc-49de-aebf-9d8136aca4f8.png)

After:
![image](https://user-images.githubusercontent.com/37311270/197653219-5cd158e1-0022-4e6b-a08d-653dc3eba02e.png)
