### PR TITLE
Fix #890: Redraw 'Leave By' on removal of entries

### DIFF
--- a/js/classes/FlexibleDayCalendar.js
+++ b/js/classes/FlexibleDayCalendar.js
@@ -330,6 +330,7 @@ class FlexibleDayCalendar extends BaseCalendar
                         }
                         removeLastEntryPair(existingEntryPairs);
                         calendar._updateTimeDay(dateKey);
+                        calendar._updateLeaveBy();
                     });
                 }
                 else

--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -398,6 +398,7 @@ class FlexibleMonthCalendar extends BaseCalendar
             const sliceNum = row.length === 6 ? -1 : (row.length === 7 ? -2 : -3);
             row.slice(sliceNum).remove();
             calendar._updateTimeDay($(element).attr('id'));
+            calendar._updateLeaveBy();
             toggleArrowColor(element);
             toggleMinusSign(element);
         }


### PR DESCRIPTION
#### Related issue
Closes #890

#### Context / Background
Removing entries didn't trigger updates to the 'Leave By' label.

#### What change is being introduced by this PR?
The `calendar._updateLeaveBy()` callback is now called when entry pairs are removed.
This causes _(unsurprisingly)_ the 'Leave By' time label to be updated :P

#### How will this be tested?
Manually, for the time being.
