### PR TITLE
Fix #877: Dialogs open in wrong monitor in multi-monitor configuration

### DIFF
--- a/js/menus.js
+++ b/js/menus.js
@@ -120,8 +120,8 @@ function getEditMenuTemplate(mainWindow)
                 const htmlPath = path.join('file://', __dirname, '../src/preferences.html');
                 prefWindow = new BrowserWindow({ width: 500,
                     height: 620,
-                    x: mainWindow.getBounds().x + 30,
-                    y: mainWindow.getBounds().y + 30,
+                    x: Math.round(mainWindow.getBounds().x + mainWindow.getBounds().width/2 - 500/2),
+                    y: Math.round(mainWindow.getBounds().y + mainWindow.getBounds().height/2 - 620/2) - 30,
                     parent: mainWindow,
                     resizable: true,
                     icon: appConfig.iconpath,

--- a/js/menus.js
+++ b/js/menus.js
@@ -120,6 +120,8 @@ function getEditMenuTemplate(mainWindow)
                 const htmlPath = path.join('file://', __dirname, '../src/preferences.html');
                 prefWindow = new BrowserWindow({ width: 500,
                     height: 620,
+                    x: mainWindow.getBounds().x + 30,
+                    y: mainWindow.getBounds().y + 30,
                     parent: mainWindow,
                     resizable: true,
                     icon: appConfig.iconpath,

--- a/js/menus.js
+++ b/js/menus.js
@@ -9,12 +9,11 @@ const { getSavedPreferences } = require('./saved-preferences.js');
 const { importDatabaseFromFile, exportDatabaseToFile } = require('./import-export.js');
 const { notify } = require('./notification');
 const { getCurrentTranslation } = require('../src/configs/i18next.config');
-let { openWaiverManagerWindow, prefWindow } = require('./windows');
+let { openWaiverManagerWindow, prefWindow, getDialogCoordinates } = require('./windows');
 
 import { appConfig, getDetails } from './app-config.js';
 import { savePreferences } from './user-preferences.js';
 import { getCurrentDateTimeStr } from './date-aux.js';
-import { getDialogCoordinates } from './windows.js';
 
 function getMainMenuTemplate(mainWindow)
 {

--- a/js/menus.js
+++ b/js/menus.js
@@ -14,6 +14,7 @@ let { openWaiverManagerWindow, prefWindow } = require('./windows');
 import { appConfig, getDetails } from './app-config.js';
 import { savePreferences } from './user-preferences.js';
 import { getCurrentDateTimeStr } from './date-aux.js';
+import { getDialogCoordinates } from './windows.js';
 
 function getMainMenuTemplate(mainWindow)
 {
@@ -118,10 +119,11 @@ function getEditMenuTemplate(mainWindow)
                 }
 
                 const htmlPath = path.join('file://', __dirname, '../src/preferences.html');
+                const dialogCoordinates = getDialogCoordinates(500, 620, mainWindow);
                 prefWindow = new BrowserWindow({ width: 500,
                     height: 620,
-                    x: Math.round(mainWindow.getBounds().x + mainWindow.getBounds().width/2 - 500/2),
-                    y: Math.round(mainWindow.getBounds().y + mainWindow.getBounds().height/2 - 620/2) - 30,
+                    x: dialogCoordinates.x,
+                    y: dialogCoordinates.y,
                     parent: mainWindow,
                     resizable: true,
                     icon: appConfig.iconpath,

--- a/js/windows.js
+++ b/js/windows.js
@@ -64,15 +64,11 @@ function getDialogCoordinates(dialogWidth, dialogHeight, mainWindow)
     };
 }
 
-export {
-    getDialogCoordinates
-};
-
-
 module.exports = {
     waiverWindow,
     prefWindow,
     tray,
     contextMenu,
-    openWaiverManagerWindow
+    openWaiverManagerWindow,
+    getDialogCoordinates
 };

--- a/js/windows.js
+++ b/js/windows.js
@@ -28,8 +28,8 @@ function openWaiverManagerWindow(mainWindow, event)
     const htmlPath = path.join('file://', __dirname, '../src/workday-waiver.html');
     waiverWindow = new BrowserWindow({ width: 600,
         height: 500,
-        x: mainWindow.getBounds().x + 30,
-        y: mainWindow.getBounds().y + 30,
+        x: Math.round(mainWindow.getBounds().x + mainWindow.getBounds().width/2 - 600/2),
+        y: Math.round(mainWindow.getBounds().y + mainWindow.getBounds().height/2 - 500/2),
         parent: mainWindow,
         resizable: true,
         icon: appConfig.iconpath,

--- a/js/windows.js
+++ b/js/windows.js
@@ -28,6 +28,8 @@ function openWaiverManagerWindow(mainWindow, event)
     const htmlPath = path.join('file://', __dirname, '../src/workday-waiver.html');
     waiverWindow = new BrowserWindow({ width: 600,
         height: 500,
+        x: mainWindow.getBounds().x + 30,
+        y: mainWindow.getBounds().y + 30,
         parent: mainWindow,
         resizable: true,
         icon: appConfig.iconpath,

--- a/js/windows.js
+++ b/js/windows.js
@@ -26,10 +26,11 @@ function openWaiverManagerWindow(mainWindow, event)
         global.waiverDay = getDateStr(today);
     }
     const htmlPath = path.join('file://', __dirname, '../src/workday-waiver.html');
+    const dialogCoordinates = getDialogCoordinates(600, 500, mainWindow);
     waiverWindow = new BrowserWindow({ width: 600,
         height: 500,
-        x: Math.round(mainWindow.getBounds().x + mainWindow.getBounds().width/2 - 600/2),
-        y: Math.round(mainWindow.getBounds().y + mainWindow.getBounds().height/2 - 500/2),
+        x: dialogCoordinates.x,
+        y: dialogCoordinates.y,
         parent: mainWindow,
         resizable: true,
         icon: appConfig.iconpath,
@@ -46,6 +47,27 @@ function openWaiverManagerWindow(mainWindow, event)
         mainWindow.webContents.send('WAIVER_SAVED');
     });
 }
+
+/**
+ * Return the x and y coordinate for a dialog window, 
+ * so the dialog window is centered on the TTL window.
+ * Round values, as coordinates have to be integers.
+ * @param {number} dialogWidth
+ * @param {number} dialogHeight
+ * @param {object} mainWindow
+ */
+function getDialogCoordinates(dialogWidth, dialogHeight, mainWindow)
+{
+    return{
+        x : Math.round(mainWindow.getBounds().x + mainWindow.getBounds().width/2 - dialogWidth/2),
+        y : Math.round(mainWindow.getBounds().y + mainWindow.getBounds().height/2 - dialogHeight/2),
+    };
+}
+
+export {
+    getDialogCoordinates
+};
+
 
 module.exports = {
     waiverWindow,


### PR DESCRIPTION
#### Related issue
Closes #877 

#### Context / Background
At the moment, the Preferences dialog and the Waiver Manager dialog are always opening centered in the main monitor instead of the secondary monitor, no matter where the main TTL window is.
Also, if the TTL window is, for example, in the right corner of the screen, the dialog window still opens up in the center of the main monitor.

#### What change is being introduced by this PR?
I fixed this issue by specifying concrete x and y values for the dialog window related to the bounds of the mainWindow. This way, the dialog window always opens up in the upper left corner of the TLL window, no matter where the window is currently located.
If it is a design choice to always open the dialog window in the center, I can further change my PR.

![image](https://user-images.githubusercontent.com/60743257/200314798-81748e07-97dd-4bc8-8d8f-5d6c867464c6.png)


#### How will this be tested?
Steps to test this:
1. Open TTL
2. Move it to a secondary display
3. Click on 'Preferences'
4. See it open on the current display, in the upper left corner of the TLL window
