### PR TITLE
fix lint error in CSS file due to duplicate selector

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -314,6 +314,7 @@ body {
 
 .waiver-img {
   filter: invert(var(--svg-invert));
+  display: none;
 }
 
 #calendar input[type="time"]::-webkit-clear-button {
@@ -424,10 +425,6 @@ body {
 
 .punch-button:disabled #punch-button-label {
   cursor: default;
-}
-
-.waiver-img {
-  display: none;
 }
 
 .waiver-trigger:hover {


### PR DESCRIPTION
#### Related issue
Closes #<!--Related issue-->

#### Context / Background
Lint check error in CSS file

#### What change is being introduced by this PR?
Fix the "duplicate selector" lint error in CSS file. I deleted one which was a duplicate and merged it into one.

#### How will this be tested?
Run npm run lint:css you won't see the lint error anymore.
