### PR TITLE
Fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <a href="docs/README-fa-IR.md"><img src="https://img.shields.io/badge/fa--IR-Persian-purple" alt="مستندات برنامه به زبان فارسی"></a>
 <a href="docs/README-bn.md"><img src="https://img.shields.io/badge/bn-বাংলা-purple" alt="এই নথিও পাওয়া যায় বাংলায়"></a>
 <a href="docs/README-he.md"><img src="https://img.shields.io/badge/he-עברית-purple" alt="מסמך זה כתוב גם בעברית"></a>
-<a href="docs/README-sv-SE.md"><img src="https://img.shields.io/badge/sv-SE-svenska-purple" alt="Detta dokument finns tillgängligt på svenska"></a>
+<a href="docs/README-sv-SE.md"><img src="https://img.shields.io/badge/sv-SE--svenska-purple" alt="Detta dokument finns tillgängligt på svenska"></a>
 <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">


### PR DESCRIPTION
The Swedish version of this document contains a typo in the shield, which causes the shield not to be displayed.