### PR TITLE
Improve preferences interface - hours worked & break time fields

### DIFF
--- a/src/preferences.html
+++ b/src/preferences.html
@@ -47,7 +47,21 @@
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.hoursPerDay">Hours per day</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
+                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" type="text" list="hours-options" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
+                    <datalist id="hours-options">
+                        <option>01:00</option>
+                        <option>02:00</option>
+                        <option>03:00</option>
+                        <option>04:00</option>
+                        <option>05:00</option>
+                        <option>06:00</option>
+                        <option>07:00</option>
+                        <option>08:00</option>
+                        <option>09:00</option>
+                        <option>10:00</option>
+                        <option>11:00</option>
+                        <option>12:00</option>
+                    </datalist>
             </div>
             <div class="flex-box">
                 <p><i class="fas fa-utensils"></i><span data-i18n="$Preferences.enablePrefillBreakTime">Enable prefilling of break time</span></p>
@@ -55,9 +69,17 @@
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.breakTimeInterval">Break time interval</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day" type="text" name="break-time-interval" id="break-time-interval" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="00:30" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '00:30'">
+                <input data-i18n="[placeholder]$Preferences.hours-per-day" type="text" list="break-time-options" name="break-time-interval" id="break-time-interval" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="00:30" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '00:30'">
+                    <datalist id="break-time-options">
+                        <option>00:15</option>
+                        <option>00:30</option>
+                        <option>00:45</option>
+                        <option>01:00</option>
+                        <option>01:30</option>
+                        <option>02:00</option>
+                    </datalist>
             </div>
-            
+
         </section>
 
         <section>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -63,6 +63,9 @@
         <section>
             <div class="section-title" data-i18n="$Preferences.notification">Notification</div>
             <div class="flex-box">
+                <p><span>**Desktop notifications must be enabled in system settings**</span></p>
+            </div>
+            <div class="flex-box">
                 <p><i class="far fa-bell"></i> <span data-i18n="$Preferences.notification">Notification</span></p>
                 <label class="switch"><input type="checkbox" id="notification" name="notification"><span class="slider round"></span></label>
             </div>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -85,9 +85,6 @@
         <section>
             <div class="section-title" data-i18n="$Preferences.notification">Notification</div>
             <div class="flex-box">
-                <p><span>**Desktop notifications must be enabled in system settings**</span></p>
-            </div>
-            <div class="flex-box">
                 <p><i class="far fa-bell"></i> <span data-i18n="$Preferences.notification">Notification</span></p>
                 <label class="switch"><input type="checkbox" id="notification" name="notification"><span class="slider round"></span></label>
             </div>


### PR DESCRIPTION
#### Related issue
Closes #914

#### Context / Background
Hello, I am a first time contributor and I would greatly appreciate any feedback - please let me know if you have any suggestions! Thank you.

To improve user experience it is possible to utilize an HTML combo box in the preferences interface, which provides the user with selected options for hours worked and break times, while also preserving their ability to enter custom values or more obscure time durations. Currently, the user has to somewhat infer that they must enter a duration in the format HH:MM specifically, though they are currently notified when their entered values do not meet the required format.

#### What change is being introduced by this PR?

Originally my intent was to add the capability of the hours worked and break time fields to take custom inputs in formats other than HH:MM, such as a single digit hour amount or a decimal amount (8.5 converting to 08:30). I was unable to trace inputs and their respective validity checks to a specific function in the code, and I assume this is an Electron or JQuery feature which I am unfamiliar with. An easy HTML solution I was able to implement is to use combo boxes in /src/preferences.html, which act as a dropdown while preserving the ability to enter custom values. This involves simply specifying "list" in the relevant HTML input lines and specifying a datalist which contains any template/selectable values. Background on this functionality: https://www.educba.com/combobox-in-html/ . The dropdown, however, overlaps the "Please match the requested format" alert and this could be further improved upon.

#### How will this be tested?

The Jest test suites show no changes in coverage, rendering, updating of variables, or any other observable field. Manual testing also shows that both when selecting a value from the dropdown field or entering a value into the text box, that value passes validity checks and is saved upon closing the preferences interface.

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
