### PR TITLE
Fix #925: Punch from tray and reload after changing database do not work

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -50,6 +50,7 @@ ipcRenderer.on('PUNCH_DATE', function()
 {
     calendar.punchDate();
 });
+
 /*
  * Reload calendar, used after database altering actions.
  */

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -43,6 +43,21 @@ ipcRenderer.on('WAIVER_SAVED', function()
     calendar.redraw();
 });
 
+/*
+ * Punch the date and time as requested by user.
+ */
+ipcRenderer.on('PUNCH_DATE', function()
+{
+    calendar.punchDate();
+});
+/*
+ * Reload calendar, used after database altering actions.
+ */
+ipcRenderer.on('RELOAD_CALENDAR', function()
+{
+    calendar.reload();
+});
+
 // On page load, create the calendar and setup notification
 $(() =>
 {

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -169,7 +169,7 @@ function proposeFlexibleDbMigration()
     if (response === 0 /*migrate*/)
     {
         const migrateResult = migrateFixedDbToFlexible();
-        getMainWindow().webContents.executeJavaScript('calendar.reload()');
+        getMainWindow().webContents.send('RELOAD_CALENDAR')
         if (migrateResult['result'] === true)
         {
             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),

--- a/js/menus.js
+++ b/js/menus.js
@@ -46,7 +46,7 @@ function getContextMenuTemplate(mainWindow)
             {
                 const now = new Date();
 
-                mainWindow.webContents.executeJavaScript('calendar.punchDate()');
+                mainWindow.webContents.send('PUNCH_DATE');
                 // Slice keeps "HH:MM" part of "HH:MM:SS GMT+HHMM (GMT+HH:MM)" time string
                 notify(`${getCurrentTranslation('$Menu.punched-time')} ${now.toTimeString().slice(0,5)}`);
             }
@@ -74,7 +74,7 @@ function getDockMenuTemplate(mainWindow)
             {
                 const now = new Date();
 
-                mainWindow.webContents.executeJavaScript('calendar.punchDate()');
+                mainWindow.webContents.send('PUNCH_DATE');
                 // Slice keeps "HH:MM" part of "HH:MM:SS GMT+HHMM (GMT+HH:MM)" time string
                 notify(`${getCurrentTranslation('$Menu.punched-time')} ${now.toTimeString().slice(0,5)}`);
             }
@@ -212,7 +212,7 @@ function getEditMenuTemplate(mainWindow)
                     {
                         const importResult = importDatabaseFromFile(response);
                         // Reload only the calendar itself to avoid a flash
-                        mainWindow.webContents.executeJavaScript('calendar.reload()');
+                        mainWindow.webContents.send('RELOAD_CALENDAR');
                         if (importResult['result'])
                         {
                             dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
@@ -273,7 +273,7 @@ function getEditMenuTemplate(mainWindow)
                     waivedWorkdays.clear();
                     flexibleStore.clear();
                     // Reload only the calendar itself to avoid a flash
-                    mainWindow.webContents.executeJavaScript('calendar.reload()');
+                    mainWindow.webContents.send('RELOAD_CALENDAR');
                     dialog.showMessageBox(BrowserWindow.getFocusedWindow(),
                         {
                             title: 'Time to Leave',


### PR DESCRIPTION
#### Related issue
Closes #925

#### Context / Background
The remaining actions that used `executeJavaScript` were broken once `calendar.js` became a module, and thus all of the actions associated to it were broken. This was the reason for the broken promise warnings on the terminal

#### What change is being introduced by this PR?
This changes the actions to send messages to the listeners on `ipcRenderer` instead, which works just fine. There is a consequence that this becomes asynchronous and "uncheckable", which was not true previously, as the `executeJavaScript` returns a promise, which wasn't being used anyway.

#### How will this be tested?
I did some manual testing and it works. No idea how to write tests for these yet.