### PR TITLE
Refactor calendar and raise coverage

### DIFF
--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -1,0 +1,294 @@
+import ElectronStore from 'electron-store';
+import { BaseCalendar } from '../../../js/classes/BaseCalendar';
+import { getUserPreferences, resetPreferences, savePreferences } from '../../../js/user-preferences';
+const timeBalance = require('../../../js/time-balance');
+jest.mock('../../../js/time-math', () =>
+{
+    const originalModule = jest.requireActual('../../../js/time-math');
+    return {
+        __esModule: true,
+        ...originalModule,
+        isNegative: jest.fn()
+    };
+});
+const timeMath = require('../../../js/time-math');
+window.$ = require('jquery');
+
+describe('BaseCalendar.js', () =>
+{
+    class ExtendedClass extends BaseCalendar
+    {
+        constructor(preferences, languageData)
+        {
+            super(preferences, languageData);
+        }
+    }
+
+    /**
+     * @type {{[key: string]: jest.Mock}}
+     */
+    const mocks = {};
+
+    beforeEach(() =>
+    {
+        const flexibleStore = new ElectronStore({name: 'flexible-store'});
+        flexibleStore.clear();
+        const waivedWorkdays = new ElectronStore({name: 'waived-workdays'});
+        waivedWorkdays.clear();
+        ExtendedClass.prototype._initCalendar = () => {};
+        ExtendedClass.prototype._getTargetDayForAllTimeBalance = () => {};
+    });
+
+    describe('constructor', () =>
+    {
+        test('Should not build with default values', () =>
+        {
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            delete ExtendedClass.prototype._initCalendar;
+            delete ExtendedClass.prototype._getTargetDayForAllTimeBalance;
+            expect(() => new ExtendedClass(preferences, languageData)).toThrow('Please implement this.');
+        });
+
+        test('Should not run _getTargetDayForAllTimeBalance with default values', () =>
+        {
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            delete ExtendedClass.prototype._getTargetDayForAllTimeBalance;
+            expect(() => new ExtendedClass(preferences, languageData)._getTargetDayForAllTimeBalance()).toThrow('Please implement this.');
+        });
+
+        test('Should build with default values', (done) =>
+        {
+            ExtendedClass.prototype._initCalendar = () => { done(); };
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            expect(calendar._calendarDate).toBeInstanceOf(Date);
+            expect(calendar._languageData).toEqual(languageData);
+            expect(calendar._internalStore).toEqual({});
+            expect(calendar._internalWaiverStore).toEqual({});
+            expect(calendar._preferences).toEqual(preferences);
+        });
+
+        test('Should build with default internal store values', (done) =>
+        {
+            ExtendedClass.prototype._initCalendar = () => { done(); };
+            const flexibleStore = new ElectronStore({name: 'flexible-store'});
+            flexibleStore.set('flexible', 'store');
+
+            const waivedWorkdays = new ElectronStore({name: 'waived-workdays'});
+            waivedWorkdays.set('2022-01-01', {
+                reason: 'dismiss',
+                hours: '10:00'
+            });
+
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            expect(calendar._calendarDate).toBeInstanceOf(Date);
+            expect(calendar._languageData).toEqual(languageData);
+            expect(calendar._internalStore).toEqual({
+                flexible: 'store'
+            });
+            expect(calendar._internalWaiverStore).toEqual({
+                '2022-01-01': {
+                    reason: 'dismiss',
+                    hours: '10:00'
+                }
+            });
+            expect(calendar._preferences).toEqual(preferences);
+        });
+    });
+
+    describe('_updateAllTimeBalance', () =>
+    {
+        test('Should not update value because of no implementation', (done) =>
+        {
+            delete ExtendedClass.prototype._getTargetDayForAllTimeBalance;
+            mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockImplementation(() => Promise.resolve());
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            expect(() => calendar._updateAllTimeBalance()).toThrow('Please implement this.');
+            expect(mocks.compute).toHaveBeenCalledTimes(0);
+            done();
+        });
+
+        test('Should not update value because of rejection', (done) =>
+        {
+            mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockImplementation(() => Promise.reject());
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            calendar._updateAllTimeBalance();
+            setTimeout(() =>
+            {
+                expect(mocks.compute).toHaveBeenCalledTimes(1);
+                done();
+            }, 500);
+        });
+
+        test('Should not update value because no overall-balance element', (done) =>
+        {
+            window.$ = () => false;
+            mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockResolvedValue('2022-02-31');
+            mocks.isNegative = jest.spyOn(timeMath, 'isNegative').mockImplementation(() => true);
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            calendar._updateAllTimeBalance();
+            setTimeout(() =>
+            {
+                expect(mocks.isNegative).toHaveBeenCalledTimes(0);
+                expect(mocks.compute).toHaveBeenCalledTimes(1);
+                window.$ = require('jquery');
+                done();
+            }, 500);
+        });
+
+        test('Should update value with negative class', (done) =>
+        {
+            $('body').append('<span id="overall-balance" value="12:12">12:12</span>');
+            $('#overall-balance').val('12:12');
+            mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockResolvedValue('2022-02-31');
+            mocks.isNegative = jest.spyOn(timeMath, 'isNegative').mockImplementation(() => true);
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            calendar._updateAllTimeBalance();
+            setTimeout(() =>
+            {
+                expect(mocks.compute).toHaveBeenCalledTimes(1);
+                expect($('#overall-balance').val()).toBe('2022-02-31');
+                expect($('#overall-balance').hasClass('text-danger')).toBe(true);
+                done();
+            }, 500);
+        });
+
+        test('Should update value with positive class', (done) =>
+        {
+            $('body').append('<span class="text-success text-danger" id="overall-balance" value="12:12">12:12</span>');
+            $('#overall-balance').val('12:12');
+            mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockResolvedValue('2022-02-31');
+            mocks.isNegative = jest.spyOn(timeMath, 'isNegative').mockImplementation(() => false);
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            calendar._updateAllTimeBalance();
+            setTimeout(() =>
+            {
+                expect(mocks.compute).toHaveBeenCalledTimes(1);
+                expect($('#overall-balance').val()).toBe('2022-02-31');
+                expect($('#overall-balance').hasClass('text-success')).toBe(true);
+                done();
+            }, 500);
+        });
+
+    });
+
+    describe('_addTodayEntries', () =>
+    {
+        test('Should throw error', () =>
+        {
+            expect(() => new ExtendedClass({}, {})._addTodayEntries()).toThrow('Please implement this.');
+        });
+    });
+
+    describe('refreshOnDayChange', () =>
+    {
+        test('Should throw error', () =>
+        {
+            expect(() => new ExtendedClass({}, {}).refreshOnDayChange()).toThrow('Please implement this.');
+        });
+    });
+
+    describe('_getEnablePrefillBreakTime', () =>
+    {
+        test('Should return preferences value', () =>
+        {
+            const preferences = getUserPreferences();
+            expect(new ExtendedClass(preferences, {})._getEnablePrefillBreakTime()).toEqual(preferences['enable-prefill-break-time']);
+        });
+    });
+
+    describe('_getBreakTimeInterval', () =>
+    {
+        test('Should return preferences value', () =>
+        {
+            const preferences = getUserPreferences();
+            expect(new ExtendedClass(preferences, {})._getBreakTimeInterval()).toEqual(preferences['break-time-interval']);
+        });
+    });
+
+    describe('_validateTimes', () =>
+    {
+        test('Shold return empty array', () =>
+        {
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            const validatedTimes = calendar._validateTimes([]);
+            expect(validatedTimes).toEqual([]);
+        });
+
+        test('Should not remove invalid endings', () =>
+        {
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            const validatedTimes = calendar._validateTimes(['10:00', '25:83']);
+            expect(validatedTimes).toEqual(['10:00', '--:--']);
+        });
+
+        test('Should remove invalid endings', () =>
+        {
+            const preferences = {view: 'day'};
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(preferences, languageData);
+            const validatedTimes = calendar._validateTimes(['10:00', '25:83'], true);
+            expect(validatedTimes).toEqual(['10:00']);
+        });
+    });
+
+    describe('_switchView', () =>
+    {
+        test('Should change calendar view', () =>
+        {
+            savePreferences({...getUserPreferences(), view: 'day'});
+            const languageData = {hello: 'hola'};
+            const calendar = new ExtendedClass(getUserPreferences(), languageData);
+            calendar._switchView();
+            const updatedPreferences = getUserPreferences();
+            expect(updatedPreferences.view).toEqual('month');
+        });
+    });
+
+    afterEach(() =>
+    {
+        ExtendedClass.prototype._initCalendar = () =>
+        {
+            throw Error('Please implement this.');
+        };
+
+        ExtendedClass.prototype._getTargetDayForAllTimeBalance = () =>
+        {
+            throw Error('Please implement this.');
+        };
+
+        for (const mock of Object.values(mocks))
+        {
+            mock.mockRestore();
+        }
+        $('#overall-balance').remove();
+        resetPreferences();
+    });
+
+    afterAll(() =>
+    {
+        const flexibleStore = new ElectronStore({name: 'flexible-store'});
+        flexibleStore.clear();
+        const waivedWorkdays = new ElectronStore({name: 'waived-workdays'});
+        waivedWorkdays.clear();
+    });
+});

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -31,7 +31,6 @@ describe('BaseCalendar.js', () =>
      * @type {{[key: string]: jest.Mock}}
      */
     const mocks = {};
-
     beforeEach(() =>
     {
         const flexibleStore = new ElectronStore({name: 'flexible-store'});
@@ -127,7 +126,7 @@ describe('BaseCalendar.js', () =>
             expect(mocks.compute).toHaveBeenCalledTimes(1);
         });
 
-        test('Should not update value because no overall-balance element', (done) =>
+        test('Should not update value because no overall-balance element', () =>
         {
             window.$ = () => false;
             mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockResolvedValue('2022-02-31');
@@ -136,13 +135,8 @@ describe('BaseCalendar.js', () =>
             const languageData = {hello: 'hola'};
             const calendar = new ExtendedClass(preferences, languageData);
             calendar._updateAllTimeBalance();
-            setTimeout(() =>
-            {
-                expect(mocks.isNegative).toHaveBeenCalledTimes(0);
-                expect(mocks.compute).toHaveBeenCalledTimes(1);
-                window.$ = require('jquery');
-                done();
-            }, 500);
+            expect(mocks.isNegative).toHaveBeenCalledTimes(0);
+            expect(mocks.compute).toHaveBeenCalledTimes(1);
         });
 
         test('Should update value with text-danger class', (done) =>
@@ -160,6 +154,7 @@ describe('BaseCalendar.js', () =>
                 expect(mocks.compute).toHaveBeenCalledTimes(1);
                 expect($('#overall-balance').val()).toBe('2022-02-31');
                 expect($('#overall-balance').hasClass('text-danger')).toBe(true);
+                expect($('#overall-balance').hasClass('text-success')).toBe(false);
                 done();
             }, 500);
         });
@@ -178,6 +173,7 @@ describe('BaseCalendar.js', () =>
             {
                 expect(mocks.compute).toHaveBeenCalledTimes(1);
                 expect($('#overall-balance').val()).toBe('2022-02-31');
+                expect($('#overall-balance').hasClass('text-danger')).toBe(false);
                 expect($('#overall-balance').hasClass('text-success')).toBe(true);
                 done();
             }, 500);
@@ -427,6 +423,7 @@ describe('BaseCalendar.js', () =>
         {
             mock.mockRestore();
         }
+        window.$ = require('jquery');
         $('#overall-balance').remove();
         resetPreferences();
     });

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -106,7 +106,7 @@ describe('BaseCalendar.js', () =>
 
     describe('_updateAllTimeBalance', () =>
     {
-        test('Should not update value because of no implementation', (done) =>
+        test('Should not update value because of no implementation', () =>
         {
             delete ExtendedClass.prototype._getTargetDayForAllTimeBalance;
             mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockImplementation(() => Promise.resolve());
@@ -115,7 +115,6 @@ describe('BaseCalendar.js', () =>
             const calendar = new ExtendedClass(preferences, languageData);
             expect(() => calendar._updateAllTimeBalance()).toThrow('Please implement this.');
             expect(mocks.compute).toHaveBeenCalledTimes(0);
-            done();
         });
 
         test('Should not update value because of rejection', (done) =>

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -1,6 +1,5 @@
 import ElectronStore from 'electron-store';
 import { BaseCalendar } from '../../../js/classes/BaseCalendar.js';
-import { generateKey } from '../../../js/date-db-formatter.js';
 import { getUserPreferences, resetPreferences, savePreferences } from '../../../js/user-preferences.js';
 const timeBalance = require('../../../js/time-balance');
 
@@ -320,14 +319,12 @@ describe('BaseCalendar.js', () =>
                     expect(mocks._areAllInputsFilled).toHaveBeenCalledTimes(0);
                 }
             },
-            {   it: 'Should fail on checking day',
+            {   it: 'Should not punch date',
                 setup: () =>
                 {
                     mocks._areAllInputsFilled = jest.spyOn(ExtendedClass.prototype, '_areAllInputsFilled');
                     mocks._updateTimeDayCallback = jest.spyOn(ExtendedClass.prototype, '_updateTimeDayCallback');
                     mocks._addTodayEntries = jest.spyOn(ExtendedClass.prototype, '_addTodayEntries').mockImplementation(() => {});
-                    const dateKey = generateKey(today.getFullYear(), today.getMonth(), today.getDate());
-                    $('#' + dateKey + ' input[type="time"]').val('08:00');
                 },
                 date: new Date(),
                 getCalendar: () =>

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -117,18 +117,14 @@ describe('BaseCalendar.js', () =>
             expect(mocks.compute).toHaveBeenCalledTimes(0);
         });
 
-        test('Should not update value because of rejection', (done) =>
+        test('Should not update value because of rejection', () =>
         {
             mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockImplementation(() => Promise.reject());
             const preferences = {view: 'day'};
             const languageData = {hello: 'hola'};
             const calendar = new ExtendedClass(preferences, languageData);
             calendar._updateAllTimeBalance();
-            setTimeout(() =>
-            {
-                expect(mocks.compute).toHaveBeenCalledTimes(1);
-                done();
-            }, 500);
+            expect(mocks.compute).toHaveBeenCalledTimes(1);
         });
 
         test('Should not update value because no overall-balance element', (done) =>

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -150,7 +150,7 @@ describe('BaseCalendar.js', () =>
             }, 500);
         });
 
-        test('Should update value with negative class', (done) =>
+        test('Should update value with text-danger class', (done) =>
         {
             $('body').append('<span id="overall-balance" value="12:12">12:12</span>');
             $('#overall-balance').val('12:12');
@@ -169,7 +169,7 @@ describe('BaseCalendar.js', () =>
             }, 500);
         });
 
-        test('Should update value with positive class', (done) =>
+        test('Should update value with text-success class', (done) =>
         {
             $('body').append('<span class="text-success text-danger" id="overall-balance" value="12:12">12:12</span>');
             $('#overall-balance').val('12:12');
@@ -348,7 +348,7 @@ describe('BaseCalendar.js', () =>
                     ExtendedClass.prototype._updateLeaveBy = () => {};
                     ExtendedClass.prototype._updateBalance = () => {};
                     const newDate = new Date();
-                    const key = generateKey(newDate.getFullYear(),newDate.getMonth(), newDate.getDate());
+                    const key = generateKey(newDate.getFullYear(), newDate.getMonth(), newDate.getDate());
                     mocks._areAllInputsFilled = jest.spyOn(ExtendedClass.prototype, '_areAllInputsFilled');
                     mocks._updateTimeDayCallback = jest.spyOn(ExtendedClass.prototype, '_updateTimeDayCallback');
                     mocks._updateTimeDay = jest.spyOn(ExtendedClass.prototype, '_updateTimeDay');
@@ -373,7 +373,7 @@ describe('BaseCalendar.js', () =>
                     expect(mocks._updateLeaveBy).toHaveBeenCalledTimes(1);
                     expect(mocks._updateBalance).toHaveBeenCalledTimes(1);
                     const newDate = new Date();
-                    const key = generateKey(newDate.getFullYear(),newDate.getMonth(), newDate.getDate());
+                    const key = generateKey(newDate.getFullYear(), newDate.getMonth(), newDate.getDate());
                     $(`#${key}`).remove();
                 }
             }
@@ -396,7 +396,7 @@ describe('BaseCalendar.js', () =>
         test('Should not update when day has not ended', () =>
         {
             const newDate = new Date();
-            const key = generateKey(newDate.getFullYear(),newDate.getMonth(), newDate.getDate());
+            const key = generateKey(newDate.getFullYear(), newDate.getMonth(), newDate.getDate());
             $('body').append(`<div id="${key}" ></div>`);
             $(`#${key}`).append('<input type="time" value="--:--" />');
             const calendar = new ExtendedClass(getUserPreferences(), {});
@@ -409,7 +409,7 @@ describe('BaseCalendar.js', () =>
         {
             const flexibleStore = new Store({name: 'flexible-store'});
             const newDate = new Date();
-            const key = generateKey(newDate.getFullYear(),newDate.getMonth(), newDate.getDate());
+            const key = generateKey(newDate.getFullYear(), newDate.getMonth(), newDate.getDate());
             flexibleStore.set(key, '08:00');
             flexibleStore.set(key, '16:00');
             $('body').append(`<div id="${key}" ></div>`);

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -428,25 +428,11 @@ describe('BaseCalendar.js', () =>
 
     afterEach(() =>
     {
-        ExtendedClass.prototype._initCalendar = () =>
-        {
-            throw Error('Please implement this.');
-        };
-
-        ExtendedClass.prototype._getTargetDayForAllTimeBalance = () =>
-        {
-            throw Error('Please implement this.');
-        };
-
         for (const mock of Object.values(mocks))
         {
             mock.mockRestore();
         }
         $('#overall-balance').remove();
         resetPreferences();
-        const flexibleStore = new ElectronStore({name: 'flexible-store'});
-        flexibleStore.clear();
-        const waivedWorkdays = new ElectronStore({name: 'waived-workdays'});
-        waivedWorkdays.clear();
     });
 });

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -1,7 +1,8 @@
 import ElectronStore from 'electron-store';
-import { BaseCalendar } from '../../../js/classes/BaseCalendar';
-import { getUserPreferences, resetPreferences, savePreferences } from '../../../js/user-preferences';
+import { BaseCalendar } from '../../../js/classes/BaseCalendar.js';
+import { getUserPreferences, resetPreferences, savePreferences } from '../../../js/user-preferences.js';
 const timeBalance = require('../../../js/time-balance');
+
 jest.mock('../../../js/time-math', () =>
 {
     const originalModule = jest.requireActual('../../../js/time-math');

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -414,7 +414,6 @@ describe('BaseCalendar.js', () =>
             const dayTotalSpan = $('#' + key).parent().find('.day-total-cell span');
             $(`#${key}`).remove();
             expect(dayTotalSpan.html()).toBe('08:30');
-
         });
     });
 

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -396,6 +396,7 @@ describe('BaseCalendar.js', () =>
             $(`#${key}`).remove();
             expect(dayTotalSpan.text()).toBe('');
         });
+
         test('Should update when day has ended', () =>
         {
             const flexibleStore = new Store({name: 'flexible-store'});

--- a/__tests__/__renderer__/classes/CalendarFactory.js
+++ b/__tests__/__renderer__/classes/CalendarFactory.js
@@ -25,7 +25,7 @@ jest.mock('electron', () =>
     };
 });
 
-const {ipcRenderer} = require('electron');
+const { ipcRenderer } = require('electron');
 
 describe('CalendarFactory', () =>
 {

--- a/__tests__/__renderer__/classes/CalendarFactory.js
+++ b/__tests__/__renderer__/classes/CalendarFactory.js
@@ -38,7 +38,6 @@ describe('CalendarFactory', () =>
 
     describe('FlexibleDayCalendar', () =>
     {
-
         test('Should fail wrong view', () =>
         {
             let calls = 0;
@@ -110,7 +109,6 @@ describe('CalendarFactory', () =>
             expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
             expect(calls).toBe(1);
         });
-
     });
 
     describe('FlexibleMonthCalendar', () =>

--- a/__tests__/__renderer__/classes/CalendarFactory.js
+++ b/__tests__/__renderer__/classes/CalendarFactory.js
@@ -1,0 +1,172 @@
+import { CalendarFactory } from '../../../js/classes/CalendarFactory';
+import { FlexibleDayCalendar } from '../../../js/classes/FlexibleDayCalendar';
+import { FlexibleMonthCalendar } from '../../../js/classes/FlexibleMonthCalendar';
+
+jest.mock('../../../js/classes/BaseCalendar.js', () =>
+{
+    class BaseCalendar
+    {
+        constructor() { }
+    }
+
+    return { BaseCalendar };
+});
+
+jest.mock('electron', () =>
+{
+    const originalModule = jest.requireActual('electron');
+    return {
+        __esModule: true,
+        ...originalModule,
+        ipcRenderer: {
+            ...originalModule.ipcRenderer,
+            send: jest.fn()
+        }
+    };
+});
+
+const {ipcRenderer} = require('electron');
+
+describe('CalendarFactory', () =>
+{
+    test('Should fail wrong view', () =>
+    {
+        expect(() => CalendarFactory.getInstance({
+            view: 'not_supported'
+        })).toThrow('Could not instantiate not_supported');
+    });
+
+    describe('FlexibleDayCalendar', () =>
+    {
+
+        test('Should fail wrong view', () =>
+        {
+            let calls = 0;
+            const testCalendar = {
+                constructor: {
+                    name: 'FlexibleDayCalendar',
+                },
+                updateLanguageData: () => { calls++; },
+                updatePreferences: () => { calls++; },
+                redraw: () => { calls++; },
+            };
+            const calendar = CalendarFactory.getInstance({
+                view: 'day',
+            }, {}, testCalendar);
+            expect(calendar).toEqual(testCalendar);
+            expect(calls).toBe(3);
+        });
+
+        test('Should return new calendar without resizing', () =>
+        {
+            let calls = 0;
+            const testCalendar = {
+                constructor: {
+                    name: 'NOT FlexibleDayCalendar',
+                },
+                updateLanguageData: () => { calls++; },
+                updatePreferences: () => { calls++; },
+                redraw: () => { calls++; },
+            };
+            const calendar = CalendarFactory.getInstance({
+                view: 'day',
+            }, {}, testCalendar);
+            expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
+            expect(calls).toBe(0);
+        });
+
+        test('Should return new calendar without resizing', () =>
+        {
+            let calls = 0;
+            jest.spyOn(ipcRenderer, 'send').mockImplementation(() =>
+            {
+                calls++;
+            });
+            const calendar = CalendarFactory.getInstance({
+                view: 'day',
+            }, {}, undefined);
+            expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
+            expect(calls).toBe(0);
+        });
+
+        test('Should return new calendar with resizing', () =>
+        {
+            let calls = 0;
+            const testCalendar = {
+                constructor: {
+                    name: 'NOT FlexibleDayCalendar',
+                },
+                updateLanguageData: () => { calls++; },
+                updatePreferences: () => { calls++; },
+                redraw: () => { calls++; },
+            };
+            jest.spyOn(ipcRenderer, 'send').mockImplementation(() =>
+            {
+                calls++;
+            });
+            const calendar = CalendarFactory.getInstance({
+                view: 'day',
+            }, {}, testCalendar);
+            expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
+            expect(calls).toBe(1);
+        });
+
+    });
+
+    describe('FlexibleMonthCalendar', () =>
+    {
+        test('Should fail wrong view', () =>
+        {
+            let calls = 0;
+            const testCalendar = {
+                constructor: {
+                    name: 'FlexibleMonthCalendar',
+                },
+                updateLanguageData: () => { calls++; },
+                updatePreferences: () => { calls++; },
+                redraw: () => { calls++; },
+            };
+            const calendar = CalendarFactory.getInstance({
+                view: 'month',
+            }, {}, testCalendar);
+            expect(calendar).toEqual(testCalendar);
+            expect(calls).toBe(3);
+        });
+
+        test('Should return new calendar without resizing', () =>
+        {
+            let calls = 0;
+            jest.spyOn(ipcRenderer, 'send').mockImplementation(() =>
+            {
+                calls++;
+            });
+            const calendar = CalendarFactory.getInstance({
+                view: 'month',
+            }, {}, undefined);
+            expect(calendar).toBeInstanceOf(FlexibleMonthCalendar);
+            expect(calls).toBe(0);
+        });
+
+        test('Should return new calendar with resizing', () =>
+        {
+            let calls = 0;
+            const testCalendar = {
+                constructor: {
+                    name: 'NOT FlexibleMonthCalendar',
+                },
+                updateLanguageData: () => { calls++; },
+                updatePreferences: () => { calls++; },
+                redraw: () => { calls++; },
+            };
+            jest.spyOn(ipcRenderer, 'send').mockImplementation(() =>
+            {
+                calls++;
+            });
+            const calendar = CalendarFactory.getInstance({
+                view: 'month',
+            }, {}, testCalendar);
+            expect(calendar).toBeInstanceOf(FlexibleMonthCalendar);
+            expect(calls).toBe(1);
+        });
+    });
+});

--- a/__tests__/__renderer__/classes/CalendarFactory.js
+++ b/__tests__/__renderer__/classes/CalendarFactory.js
@@ -1,6 +1,6 @@
-import { CalendarFactory } from '../../../js/classes/CalendarFactory';
-import { FlexibleDayCalendar } from '../../../js/classes/FlexibleDayCalendar';
-import { FlexibleMonthCalendar } from '../../../js/classes/FlexibleMonthCalendar';
+import { CalendarFactory } from '../../../js/classes/CalendarFactory.js';
+import { FlexibleDayCalendar } from '../../../js/classes/FlexibleDayCalendar.js';
+import { FlexibleMonthCalendar } from '../../../js/classes/FlexibleMonthCalendar.js';
 
 jest.mock('../../../js/classes/BaseCalendar.js', () =>
 {

--- a/__tests__/__renderer__/classes/FlexibleDayCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleDayCalendar.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-undef */
 
 const Store = require('electron-store');
-const { defaultPreferences } = require('../../../js/user-preferences');
-const { CalendarFactory } = require('../../../js/classes/CalendarFactory');
+import { defaultPreferences } from '../../../js/user-preferences.js';
+import { CalendarFactory } from '../../../js/classes/CalendarFactory.js';
 
 window.$ = window.jQuery = require('jquery');
 
@@ -308,4 +308,5 @@ describe('FlexibleDayCalendar class Tests', () =>
         calendar = CalendarFactory.getInstance(testPreferences, languageData, calendar);
         expect(calendar.constructor.name).toBe('FlexibleDayCalendar');
     });
+
 });

--- a/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const Store = require('electron-store');
-const { defaultPreferences } = require('../../../js/user-preferences');
-const { CalendarFactory } = require('../../../js/classes/CalendarFactory');
+import { defaultPreferences } from '../../../js/user-preferences.js';
+import { CalendarFactory } from '../../../js/classes/CalendarFactory.js';
 
 window.$ = window.jQuery = require('jquery');
 

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -410,7 +410,7 @@ class BaseCalendar
      */
     loadInternalStore()
     {
-        this._internalStore = [];
+        this._internalStore = {};
 
         for (const entry of flexibleStore)
         {

--- a/js/classes/BaseCalendar.js
+++ b/js/classes/BaseCalendar.js
@@ -619,7 +619,7 @@ class BaseCalendar
         const validatedTimes = this._validateTimes(values);
 
         const storeHasExpectedSize = values.length === inputs.length;
-        const inputsHaveExpectedSize = values.length >= 2 && values.length % 2 === 0;
+        const inputsHaveExpectedSize = inputs.length >= 2 && inputs.length % 2 === 0;
         const validatedTimesOk = validatedTimes.length > 0 && validatedTimes.every(time => time !== '--:--');
         const hasDayEnded = storeHasExpectedSize && inputsHaveExpectedSize && validatedTimesOk;
 

--- a/js/classes/CalendarFactory.js
+++ b/js/classes/CalendarFactory.js
@@ -12,45 +12,25 @@ class CalendarFactory
     {
         const view = preferences['view'];
         const widthHeight = getDefaultWidthHeight();
-        if (view === 'day')
+        if (view !== 'day' && view !== 'month')
+            throw new Error(`Could not instantiate ${view}`);
+
+        const constructorName = view === 'day' ? 'FlexibleDayCalendar': 'FlexibleMonthCalendar';
+        const CalendarClass = view === 'day' ? FlexibleDayCalendar: FlexibleMonthCalendar;
+        if (calendar === undefined || calendar.constructor.name !== constructorName)
         {
-            if (calendar === undefined || calendar.constructor.name !== 'FlexibleDayCalendar')
+            if (calendar !== undefined && calendar.constructor.name !== constructorName)
             {
-                if (calendar !== undefined && calendar.constructor.name !== 'FlexibleDayCalendar')
-                {
-                    ipcRenderer.send('RESIZE_MAIN_WINDOW', widthHeight.width, widthHeight.height);
-                }
-                return new FlexibleDayCalendar(preferences, languageData);
+                ipcRenderer.send('RESIZE_MAIN_WINDOW', widthHeight.width, widthHeight.height);
             }
-            else
-            {
-                calendar.updateLanguageData(languageData);
-                calendar.updatePreferences(preferences);
-                calendar.redraw();
-                return calendar;
-            }
-        }
-        else if (view === 'month')
-        {
-            if (calendar === undefined || calendar.constructor.name !== 'FlexibleMonthCalendar')
-            {
-                if (calendar !== undefined && calendar.constructor.name !== 'FlexibleMonthCalendar')
-                {
-                    ipcRenderer.send('RESIZE_MAIN_WINDOW', widthHeight.width, widthHeight.height);
-                }
-                return new FlexibleMonthCalendar(preferences, languageData);
-            }
-            else
-            {
-                calendar.updateLanguageData(languageData);
-                calendar.updatePreferences(preferences);
-                calendar.redraw();
-                return calendar;
-            }
+            return new CalendarClass(preferences, languageData);
         }
         else
         {
-            throw new Error(`Could not instantiate ${view}`);
+            calendar.updateLanguageData(languageData);
+            calendar.updatePreferences(preferences);
+            calendar.redraw();
+            return calendar;
         }
     }
 }

--- a/js/classes/CalendarFactory.js
+++ b/js/classes/CalendarFactory.js
@@ -13,7 +13,9 @@ class CalendarFactory
         const view = preferences['view'];
         const widthHeight = getDefaultWidthHeight();
         if (view !== 'day' && view !== 'month')
+        {
             throw new Error(`Could not instantiate ${view}`);
+        }
 
         const constructorName = view === 'day' ? 'FlexibleDayCalendar': 'FlexibleMonthCalendar';
         const CalendarClass = view === 'day' ? FlexibleDayCalendar: FlexibleMonthCalendar;


### PR DESCRIPTION
#### Related issue
Not a specific issue but an attempt to raise the coverage

#### Context / Background
During a previous PR I was getting that the coverage was not enough so I started writing tests, but ended up being bigger than expected. So now I started to group tests and changes that are only related between themselves. 

#### What change is being introduced by this PR?
- CalendarFactory was simplified in order to use the same steps when building calendars
- Small issue on BaseCalendar that was checking the wrong variable. Also internalStore was defined as an array and then used as an object. Now is both and object. 
- Raise the coverage by adding tests on `CalendarFactory` and `BaseCalendar`. Since this was already big, I decided to close it here and then continue with `FlexibleDayCalendar` and `FlexiblemonthCalendar` on another steps.

#### How will this be tested?
- I tried to be as extensive as I could. Not all of them are 100% coverage but it is better than before

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
