### PR TITLE
Fix #941: Pop-up confirmation to remove entry shows wrong month

### DIFF
--- a/js/classes/FlexibleMonthCalendar.js
+++ b/js/classes/FlexibleMonthCalendar.js
@@ -409,9 +409,11 @@ class FlexibleMonthCalendar extends BaseCalendar
             if (row.length > 3)
             {
                 const dateKey = $(element).attr('id');
+                const [year, month, day] = dateKey.split('-');
+                const date = [year, parseInt(month) + 1, day].join('-');
                 const removeEntriesDialogOptions = {
                     title: `${calendar._getTranslation('$FlexibleMonthCalendar.remove-entry')}`,
-                    message: `${calendar._getTranslation('$FlexibleMonthCalendar.entry-removal-confirmation')} ${dateKey}?`,
+                    message: `${calendar._getTranslation('$FlexibleMonthCalendar.entry-removal-confirmation')} ${date}?`,
                     type: 'info',
                     buttons: [calendar._getTranslation('$FlexibleMonthCalendar.yes'), calendar._getTranslation('$FlexibleMonthCalendar.no')]
                 };


### PR DESCRIPTION
#### Related issue
Closes #941

#### Context / Background
Displays human readable month number when showing `remove two last entries from calendar` dialog.

#### What change is being introduced by this PR?
Converts JS based month number to human readable format.

#### How will this be tested?
Manually.

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
