### PR TITLE
Encrypt and compress json file

### DIFF
--- a/__tests__/__main__/encrypt-compress-json.js
+++ b/__tests__/__main__/encrypt-compress-json.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const {
-    compressFile,
-    decompressFile
+    compressEncryptFile,
+    decryptDecompressFile
 } = require('../../js/encrypt-compress-json');
 
 const path = require('path');
@@ -31,12 +31,12 @@ describe('Encrypt compress JSON', function()
     {
         test('should compress successfully', async() =>
         {
-            const compressSuccess = await compressFile(filePath, filePathCompressed);
+            const compressSuccess = await compressEncryptFile(filePath, filePathCompressed, '123ervebA#');
             expect(compressSuccess).toBeTruthy();
         });
         test('should decompress successfully', async() =>
         {
-            const decompressSuccess = await decompressFile(filePathCompressed, filePathDecompressed);
+            const decompressSuccess = await decryptDecompressFile(filePathCompressed, filePathDecompressed, '123ervebA#');
             expect(decompressSuccess).toBeTruthy();
         });
         test('decompressed file should equal file before', async() =>

--- a/__tests__/__main__/encrypt-compress-json.js
+++ b/__tests__/__main__/encrypt-compress-json.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const {
+    compressFile,
+    decompressFile
+} = require('../../js/encrypt-compress-json');
+
+const path = require('path');
+const fs = require('fs');
+
+
+describe('Encrypt compress JSON', function()
+{
+    process.env.NODE_ENV = 'test';
+
+    const entriesContent =
+    `[{"type": "flexible","date": "2020-4-1","values": ["08:00","12:00","13:00","17:00"]},
+    {"type": "flexible","date": "2020-4-2","values": ["07:00","11:00","14:00","18:00"]},
+    {"type": "waived","date": "2019-12-31","data": "New Year's eve","hours": "08:00"},
+    {"type": "waived","date": "2020-01-01","data": "New Year's Day","hours": "08:00"},
+    {"type": "waived","date": "2020-04-10","data": "Good Friday","hours": "08:00"}]`;
+
+    const folder = fs.mkdtempSync('encrypt-decrypt');
+    const filePath = path.join('.', folder, 'regular.ttldb');
+    const filePathCompressed = path.join('.',folder, 'compressed.tgz');
+    const filePathDecompressed = path.join('.',folder, 'decompressed');
+
+    fs.writeFileSync(`${folder}/regular.ttldb`, entriesContent, 'utf8');
+
+    describe('de/compress file', function()
+    {
+        test('should compress successfully', async() =>
+        {
+            const compressSuccess = await compressFile(filePath, filePathCompressed);
+            expect(compressSuccess).toBeTruthy();
+        });
+        test('should decompress successfully', async() =>
+        {
+            const decompressSuccess = await decompressFile(filePathCompressed, filePathDecompressed);
+            expect(decompressSuccess).toBeTruthy();
+        });
+        test('decompressed file should equal file before', async() =>
+        {
+            expect(fs.readFileSync(filePath)).toEqual(fs.readFileSync(path.join(filePathDecompressed, 'regular.ttldb')));
+        });
+    });
+
+    afterAll(() =>
+    {
+        fs.rmdirSync(folder, {recursive: true});
+    });
+
+});

--- a/__tests__/__main__/encrypt-compress-json.js
+++ b/__tests__/__main__/encrypt-compress-json.js
@@ -25,23 +25,56 @@ describe('Encrypt compress JSON', function()
     const filePathCompressed = path.join('.',folder, 'compressed.tgz');
     const filePathDecompressed = path.join('.',folder, 'decompressed');
 
+    const filePathCompressedFail = path.join('.',folder, 'compressed-fail.tgz');
+
+    const password = 'Password_123';
+    const wrongPassword = 'NOTpassword_123';
+    const invalidPassword = '123';
+
     fs.writeFileSync(`${folder}/regular.ttldb`, entriesContent, 'utf8');
 
-    describe('de/compress file', function()
+    describe('de/compress and de/encrypt file', function()
     {
-        test('should compress successfully', async() =>
+        test('should compress and encrypt successfully', async() =>
         {
-            const compressSuccess = await compressEncryptFile(filePath, filePathCompressed, '123ervebA#');
+            const compressSuccess = await compressEncryptFile(filePath, filePathCompressed, password);
             expect(compressSuccess).toBeTruthy();
         });
+
+        test('should NOT compress and encrypt successfully', async() =>
+        {
+            // invalid password, see cryptify documentation for password rules
+            const compressFail = await compressEncryptFile(filePath, filePathCompressedFail, invalidPassword);
+            expect(compressFail).not.toBeTruthy();
+            // invalid path
+            const compressFail2 = await compressEncryptFile('invalid/path', filePathCompressedFail, password);
+            expect(compressFail2).not.toBeTruthy();
+        });
+
         test('should decompress successfully', async() =>
         {
-            const decompressSuccess = await decryptDecompressFile(filePathCompressed, filePathDecompressed, '123ervebA#');
+            const decompressSuccess = await decryptDecompressFile(filePathCompressed, filePathDecompressed, password);
             expect(decompressSuccess).toBeTruthy();
         });
+
+        test('should NOT decompress successfully', async() =>
+        {
+            // wrong password
+            const decompressFail = await decryptDecompressFile(filePathCompressed, filePathDecompressed, wrongPassword);
+            expect(decompressFail).not.toBeTruthy();
+            // invalid path
+            const decompressFail2 = await decryptDecompressFile('invalid/path', filePathDecompressed, password);
+            expect(decompressFail2).not.toBeTruthy();
+        });
+
         test('decompressed file should equal file before', async() =>
         {
             expect(fs.readFileSync(filePath)).toEqual(fs.readFileSync(path.join(filePathDecompressed, 'regular.ttldb')));
+        });
+
+        test('compressed file should NOT equal file before', async() =>
+        {
+            expect(fs.readFileSync(filePath)).not.toEqual(fs.readFileSync(filePathCompressed));
         });
     });
 

--- a/js/encrypt-compress-json.js
+++ b/js/encrypt-compress-json.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const compressing = require('compressing');
+
+async function compressFile(filePathOriginal, filePathCompressed)
+{
+    try
+    {
+        await compressing.tgz.compressFile(filePathOriginal, filePathCompressed);
+        return true;
+    }
+    catch (e)
+    {
+        console.log(`compression failed: ${e}`);
+        return false;
+    }
+}
+
+async function decompressFile(filePathCompressed, filePathDecompressed)
+{
+    try
+    {
+        await compressing.tgz.uncompress(filePathCompressed, filePathDecompressed);
+        return true;
+    }
+    catch (e)
+    {
+        console.log(`compression failed: ${e}`);
+        return false;
+    }
+}
+
+module.exports = {
+    compressFile,
+    decompressFile
+};

--- a/js/encrypt-compress-json.js
+++ b/js/encrypt-compress-json.js
@@ -1,36 +1,40 @@
 'use strict';
-
+import Cryptify from 'cryptify';
 const compressing = require('compressing');
 
-async function compressFile(filePathOriginal, filePathCompressed)
+async function compressEncryptFile(filePathOriginal, filePathCompressed, passPhrase)
 {
     try
     {
         await compressing.tgz.compressFile(filePathOriginal, filePathCompressed);
+        const instance = new Cryptify(filePathCompressed, passPhrase);
+        await instance.encrypt();
         return true;
     }
     catch (e)
     {
-        console.log(`compression failed: ${e}`);
+        console.log(`compression and encryption failed: ${e}`);
         return false;
     }
 }
 
-async function decompressFile(filePathCompressed, filePathDecompressed)
+async function decryptDecompressFile(filePathCompressed, filePathDecompressed, passPhrase)
 {
     try
     {
+        const instance = new Cryptify(filePathCompressed, passPhrase);
+        await instance.decrypt();
         await compressing.tgz.uncompress(filePathCompressed, filePathDecompressed);
         return true;
     }
     catch (e)
     {
-        console.log(`compression failed: ${e}`);
+        console.log(`decryption and decompression failed: ${e}`);
         return false;
     }
 }
 
 module.exports = {
-    compressFile,
-    decompressFile
+    compressEncryptFile,
+    decryptDecompressFile
 };

--- a/js/encrypt-compress-json.js
+++ b/js/encrypt-compress-json.js
@@ -7,7 +7,7 @@ async function compressEncryptFile(filePathOriginal, filePathCompressed, passPhr
     try
     {
         await compressing.tgz.compressFile(filePathOriginal, filePathCompressed);
-        const instance = new Cryptify(filePathCompressed, passPhrase);
+        const instance = new Cryptify(filePathCompressed, passPhrase, 'aes-256-cbc', 'utf8', true);
         await instance.encrypt();
         return true;
     }
@@ -22,7 +22,7 @@ async function decryptDecompressFile(filePathCompressed, filePathDecompressed, p
 {
     try
     {
-        const instance = new Cryptify(filePathCompressed, passPhrase);
+        const instance = new Cryptify(filePathCompressed, passPhrase, 'aes-256-cbc', 'utf8', true);
         await instance.decrypt();
         await compressing.tgz.uncompress(filePathCompressed, filePathDecompressed);
         return true;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "bootstrap": "^5.1.1",
+    "compressing": "^1.7.0",
+    "cryptify": "^4.1.2",
     "date-holidays": "^3.9.1",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^6.0.1",


### PR DESCRIPTION
#### Related issue
Towards #932

#### Context / Background
We are currently developing the functionality of syncing the TTL data to Google Drive, related to #913.

When exporting the data, it would be good to encrypt it with a passphrase that the user enters into TTL (this will be optional, otherwise a TTL passphrase is used). If the user loads the data back into TTL, he has to enter the passphrase used before and then the data gets decrypted and imported into TTL (or the TTL passphrase is used for decryption).

#### What change is being introduced by this PR?
This PR introduces methods to de/encrypt and de/compress a file. This can be used during the exporting and importing of TTL data. 
During the export, the file is first compressed then encrypted with a passphrase. During the import the file is decrypted first then decompressed.

For compressing, I used the [compressing](https://www.npmjs.com/package/compressing) npm module. The file is compressed to .tgz. As the user is not supposed to decompress the file, I think the archive format does not matter that much.

For encryption, I used the [cryptify](https://www.npmjs.com/package/cryptify) npm module. I used the aes-256-cbc Cipher algorithm and utf8 encoding. The Cipher algorithm I choose was a rather arbitrary choice (the default algorithm used by cryptify) as I think we are using the encryption mostly to ensure the file is not changed (as discussed in #932). But cryptify offers a range of different cipher algorithms, so we could also change that.

#### How will this be tested?
I wrote unit tests for the new functions I implemented. But we definitely have to do more tests once the functionality is integrated with the sync-data-to-google-drive functionality.
