### PR TITLE
Fix punch button and scroll bar styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -126,10 +126,6 @@ html[data-theme="cadent-star"] {
   background-color: var(--punch-bground);
 }
 
-::-webkit-scrollbar-track {
-  background-color: var(--page-bground);
-}
-
 *:focus {
   outline: var(--outline);
   z-index: 1;
@@ -158,6 +154,7 @@ html[data-theme="cadent-star"] body {
 body {
   background-color: var(--page-bground);
   color: var(--page-color);
+  overflow-y: overlay;
 }
 
 .container {
@@ -405,8 +402,8 @@ body {
 }
 
 .punch-button {
-  opacity: 0.9;
-  width: calc(100vw - 60px);
+  width: 100vw;
+  padding: 0px;
   height: 100%;
   border: none;
   color: var(--punch-color);


### PR DESCRIPTION
Set punch button width to fill screen and opaque. Scrollbar will not leave a gap anymore.

<img width="957" alt="TTL button fix" src="https://github.com/thamara/time-to-leave/assets/21368773/33b8cb8a-222b-4293-aca8-ec90ded8f4c5">


#### Context / Background
<!--
- Briefly explain the purpose of the PR by providing a summary of the context
-->

Originally the 'Punch time' button did not fill the entire screen, and it was also transparent.

#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->

The _css/styles.css_  file is modified to remove the background color of the webkit scroll track, and change the overflow behavior of the body so that the scroll bar now overlaps the punch button, instead of leaving a gap.

I believe this looks much cleaner. I'm not sure why the button was originally transparent and smaller than the width of the screen, but it was visually confusing. The scrollbar being visible indicates there is more content below, and the button occluding a small portion of the screen shouldn't be an issue. Also, having transparent texts on top of each just doesn't look legible.

#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
-->

I did not introduce any tests to this change.

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.

I've just begun contributing to open source, so please give me any and all critiques! :)