### PR TITLE
fix date picker localizations

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -668,6 +668,11 @@ input:disabled + .slider {
 }
 
 /* Styles for Right Alignment of input type date */
+#preferences-window input[type="text"].date-right {
+  text-align: right;
+  position: relative;
+}
+
 #preferences-window input[type="date"].date-right::-webkit-datetime-edit {
   text-align: right;
   position: relative;

--- a/js/date-to-string-util.js
+++ b/js/date-to-string-util.js
@@ -26,7 +26,20 @@ function getMonthName(languageData, monthIndex)
     return getTranslationInLanguageData(languageData, `$DateUtil.${monthNames[monthIndex]}`);
 }
 
+
+function getMonthNames(languageData)
+{
+    return monthNames.map(val => getTranslationInLanguageData(languageData, `$DateUtil.${val}`));
+}
+
+function getDay(languageData)
+{
+    return dayAbbrs.map(val => getTranslationInLanguageData(languageData, `$DateUtil.${val}`));
+}
+
 export {
     getDayAbbr,
-    getMonthName
+    getMonthName,
+    getMonthNames,
+    getDay
 };

--- a/js/date-to-string-util.js
+++ b/js/date-to-string-util.js
@@ -32,7 +32,7 @@ function getMonthNames(languageData)
     return monthNames.map(val => getTranslationInLanguageData(languageData, `$DateUtil.${val}`));
 }
 
-function getDay(languageData)
+function getDayAbbrvs(languageData)
 {
     return dayAbbrs.map(val => getTranslationInLanguageData(languageData, `$DateUtil.${val}`));
 }
@@ -41,5 +41,5 @@ export {
     getDayAbbr,
     getMonthName,
     getMonthNames,
-    getDay
+    getDayAbbrvs
 };

--- a/js/menus.js
+++ b/js/menus.js
@@ -154,6 +154,14 @@ function getEditMenuTemplate(mainWindow)
                         BrowserWindow.getFocusedWindow().webContents.toggleDevTools();
                     }
                 });
+                prefWindow.webContents.on('before-input-event', (event, input) =>
+                {
+                    if (input.control && input.shift && input.key.toLowerCase() === 'r')
+                    {
+                        BrowserWindow.getFocusedWindow().reload();
+                    }
+                });
+
             },
         },
         {type: 'separator'},

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "i18next-node-fs-backend": "^2.1.3",
     "is-online": "^9.0.1",
     "jquery": "^3.6.0",
-    "jquery-mousewheel": "^3.1.13"
+    "jquery-mousewheel": "^3.1.13",
+    "jquery-ui": "^1.13.2",
+    "jquery-ui-css": "^1.11.5"
   },
   "engines": {
     "node": ">=14.15.5",

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -5,7 +5,8 @@
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../node_modules/@fortawesome/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="../css/styles.css">
-    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+    <link rel="stylesheet" href="../node_modules/jquery-ui-css/jquery-ui.theme.min.css">
+    <link rel="stylesheet" href="../node_modules/jquery-ui-css/jquery-ui.structure.min.css">
 
     <!-- First we need to declare jQuery and $ globals with jquery -->
     <script src="../node_modules/jquery/dist/jquery.min.js" charset="utf-8"></script>
@@ -14,7 +15,7 @@
     </script>
 
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
-    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+    <script src="../node_modules/jquery-ui/dist/jquery-ui.min.js"></script>
     <script type="module" src="preferences.js"></script>
 </head>
 
@@ -107,7 +108,7 @@
             </div>
             <div class="flex-box">
                 <p><i class="fas fa-sign-in-alt"></i><span data-i18n="$Preferences.overallBalanceStart">Overall Balance Start Date</span></p>
-                <label id='overall-balance-start-date'><input id="datepicker" type="text" class="date-right" name="overall-balance-start-date">
+                <label id="overall-balance-start-date"><input id="datepicker" type="text" class="date-right" name="overall-balance-start-date">
                     <i class="fa fa-calendar" aria-hidden="true"></i>
                 </label>
             </div>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../node_modules/@fortawesome/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="../css/styles.css">
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 
     <!-- First we need to declare jQuery and $ globals with jquery -->
     <script src="../node_modules/jquery/dist/jquery.min.js" charset="utf-8"></script>
@@ -13,6 +14,7 @@
     </script>
 
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
     <script type="module" src="preferences.js"></script>
 </head>
 
@@ -105,7 +107,9 @@
             </div>
             <div class="flex-box">
                 <p><i class="fas fa-sign-in-alt"></i><span data-i18n="$Preferences.overallBalanceStart">Overall Balance Start Date</span></p>
-                <label id='overall-balance-start-date'><input type="date" class="date-right" name="overall-balance-start-date"></label>
+                <label id='overall-balance-start-date'><input id="datepicker" type="text" class="date-right" name="overall-balance-start-date">
+                    <i class="fa fa-calendar" aria-hidden="true"></i>
+                </label>
             </div>
             <div class="flex-box">
                 <p><i class="fas fa-eye"></i><span data-i18n="$Preferences.view">View</span></p>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -37,7 +37,7 @@ function listenerLanguage()
         window.mainApi.changeLanguagePromise(this.value).then((languageData) =>
         {
             translatePage(this.value, languageData, 'Preferences');
-            refreshDate(this.value,languageData);
+            refreshDate(this.value, languageData);
             window.mainApi.notifyNewPreferences(preferences);
         });
     });
@@ -50,14 +50,14 @@ function setupLanguages()
     window.mainApi.getLanguageDataPromise().then(languageData =>
     {
         translatePage(usersStyles['language'], languageData.data, 'Preferences');
-        refreshDate(usersStyles['language'],languageData.data);
+        refreshDate(usersStyles['language'], languageData.data);
     });
 }
 
 function refreshDate(language, languageData)
 {
-    var monthAbbrs = getMonthNames(languageData);
-    var dayAbbrs = getDayAbbrvs(languageData);
+    const monthAbbrs = getMonthNames(languageData);
+    const dayAbbrs = getDayAbbrvs(languageData);
     $.datepicker.regional[`${language}`] = {
         monthNames: monthAbbrs,
         monthNamesShort: monthAbbrs,
@@ -110,7 +110,7 @@ function renderPreferencesWindow()
         $('#view').val(usersStyles['view']);
     }
 
-    $( function()
+    $(()=>
     {
         $( '#datepicker' ).datepicker({
             dateFormat: 'yy-mm-dd',

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -2,7 +2,7 @@
 
 import { applyTheme } from '../renderer/themes.js';
 import { translatePage } from '../renderer/i18n-translator.js';
-import { getMonthNames, getDay } from '../js/date-to-string-util.js';
+import { getMonthNames, getDayAbbrvs } from '../js/date-to-string-util.js';
 
 
 // Global values for preferences page
@@ -56,13 +56,15 @@ function setupLanguages()
 
 function refreshDate(language, languageData)
 {
+    var monthAbbrs = getMonthNames(languageData);
+    var dayAbbrs = getDayAbbrvs(languageData);
     $.datepicker.regional[`${language}`] = {
-        monthNames: getMonthNames(languageData),
-        monthNamesShort: getMonthNames(languageData),
+        monthNames: monthAbbrs,
+        monthNamesShort: monthAbbrs,
         weekHeader: 'Sm',
-        dayNames: getDay(languageData),
-        dayNamesShort: getDay(languageData),
-        dayNamesMin: getDay(languageData),
+        dayNames: dayAbbrs,
+        dayNamesShort: dayAbbrs,
+        dayNamesMin: dayAbbrs,
         firstDay: 0};
     $.datepicker.setDefaults($.datepicker.regional[`${language}`]);
 }

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -2,6 +2,8 @@
 
 import { applyTheme } from '../renderer/themes.js';
 import { translatePage } from '../renderer/i18n-translator.js';
+import { getMonthNames, getDay } from '../js/date-to-string-util.js';
+
 
 // Global values for preferences page
 let usersStyles;
@@ -35,6 +37,7 @@ function listenerLanguage()
         window.mainApi.changeLanguagePromise(this.value).then((languageData) =>
         {
             translatePage(this.value, languageData, 'Preferences');
+            refreshDate(this.value,languageData);
             window.mainApi.notifyNewPreferences(preferences);
         });
     });
@@ -47,7 +50,21 @@ function setupLanguages()
     window.mainApi.getLanguageDataPromise().then(languageData =>
     {
         translatePage(usersStyles['language'], languageData.data, 'Preferences');
+        refreshDate(usersStyles['language'],languageData.data);
     });
+}
+
+function refreshDate(language, languageData)
+{
+    $.datepicker.regional[`${language}`] = {
+        monthNames: getMonthNames(languageData),
+        monthNamesShort: getMonthNames(languageData),
+        weekHeader: 'Sm',
+        dayNames: getDay(languageData),
+        dayNamesShort: getDay(languageData),
+        dayNamesMin: getDay(languageData),
+        firstDay: 0};
+    $.datepicker.setDefaults($.datepicker.regional[`${language}`]);
 }
 
 function refreshContent()
@@ -91,6 +108,15 @@ function renderPreferencesWindow()
         $('#view').val(usersStyles['view']);
     }
 
+    $( function()
+    {
+        $( '#datepicker' ).datepicker({
+            dateFormat: 'yy-mm-dd',
+            changeYear: true,
+            changeMonth: true
+        });
+    });
+
     $('input[type="checkbox"]').on('change', function()
     {
         changeValue(this.name, this.checked);
@@ -105,7 +131,7 @@ function renderPreferencesWindow()
         }
     });
 
-    $('input[type="number"], input[type="date"]').on('change', function()
+    $('input[type="number"], input[type="date"], input[type="text"]').on('change', function()
     {
         changeValue(this.name, this.value);
     });


### PR DESCRIPTION
#### Related issue
Closes #949

#### Context / Background
The date picker isn't localized, always sticking with language English.

#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->
This PR will introduce localized date picker in preferences window alone - Later this change will be incorporated to other date picker available across in the tool.
I'm using the existing translations available for Month names and week days name, so no new translations are needed, and also it cuts off our dependency on dealing with jquery-ui translation library.  

Changing the language preference to Espanol 

**Before change**

![image](https://github.com/thamara/time-to-leave/assets/27039899/37c5c098-cb5f-440d-b258-11da0a483080)

**After change**

![image](https://github.com/thamara/time-to-leave/assets/27039899/cb08baab-3fac-48c0-bb22-5ee67759ea43)


#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
-->
The language change in preference window should load their locale specific date picker.

