### PR TITLE
<FEAT> : Fix close button on pop-up confirmation to remove waived day

### DIFF
--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -187,13 +187,12 @@ function deleteEntryOnClick(event)
         title: 'Time to Leave',
         message: `${deleteWaiverMessageStr} ${day} ?`,
         type: 'info',
-        buttons: ['yes', 'no'],
-        cancelId: -1
+        buttons: [getTranslation('$WorkdayWaiver.yes'), getTranslation('$WorkdayWaiver.no')]
     };
     showDialog(options, (result) =>
     {
         const buttonId = result.response;
-        if (buttonId !== 0)
+        if (buttonId === 1)
         {
             return;
         }

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -187,12 +187,13 @@ function deleteEntryOnClick(event)
         title: 'Time to Leave',
         message: `${deleteWaiverMessageStr} ${day} ?`,
         type: 'info',
-        buttons: [getTranslation('$WorkdayWaiver.yes'), getTranslation('$WorkdayWaiver.no')]
+        buttons: ['yes', 'no'],
+        cancelId: -1
     };
     showDialog(options, (result) =>
     {
         const buttonId = result.response;
-        if (buttonId === 1)
+        if (buttonId !== 0)
         {
             return;
         }


### PR DESCRIPTION
#### Related issue
- pop-up confirmation to remove waived day

#### What change is being introduced by this PR?
- Fix the issue where closing the message box does not cancel the deletion.
- Resolve the inconsistency in the layout of the 'Yes' and 'No' buttons when using a non-English language. This buttons now follow the language of the execution environment.


