### PR TITLE
Fix #972: Preference window needs minimum width

### DIFF
--- a/js/menus.js
+++ b/js/menus.js
@@ -124,6 +124,7 @@ function getEditMenuTemplate(mainWindow)
                 const dialogCoordinates = getDialogCoordinates(500, 620, mainWindow);
                 prefWindow = new BrowserWindow({ width: 500,
                     height: 620,
+                    minWidth: 480,
                     x: dialogCoordinates.x,
                     y: dialogCoordinates.y,
                     parent: mainWindow,


### PR DESCRIPTION
#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->

I limited the width of preference window by adding 'minWidth' option to it.
I have checked for every languages and it works well with all of them without any breaking.

#### Before change:

![](https://user-images.githubusercontent.com/37311270/245334829-6a9e1ae9-6d9b-4b5d-8a47-f341c495227b.png)

#### After change
<img width="475" alt="Screenshot 2023-06-16 at 3 47 16 PM" src="https://github.com/thamara/time-to-leave/assets/63391638/e0755074-02e0-4346-a0d4-c63bfceaa02c">

Among every languages, Italian needs the longest minimum width of preference window.