### PR TITLE
Updating Release.yml

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,8 +11,10 @@ jobs:
   'MacOS':
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
     - name: ' Building...'
       run: |
         npm ci
@@ -41,8 +43,10 @@ jobs:
   'Linux':
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
     - name: ' Building...'
       run: |
         npm ci
@@ -89,8 +93,10 @@ jobs:
   'Windows':
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
     - name: 'Building...'
       run: |
         npm ci
@@ -132,8 +138,10 @@ jobs:
   'ReleaseNotes':
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
     - name: ' Building...'
       run: |
         npm ci
@@ -142,7 +150,7 @@ jobs:
         echo "APP_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         echo ${{ env.APP_VERSION }}
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Parse release information


### PR DESCRIPTION
#### Related issue
Closes #983

#### Context / Background
Attempted to run the release CI at https://github.com/thamara/time-to-leave/actions/runs/5285712756.
It failed when installing the puppeeter dependency, which needs a recent node version. The CI is using the device's inbox node, which seems to be older than needed.

```
> puppeteer@[19](https://github.com/thamara/time-to-leave/actions/runs/5285712756/jobs/9564455132#step:4:20).5.2 postinstall /Users/runner/work/time-to-leave/time-to-leave/node_modules/puppeteer
> node install.js

internal/modules/cjs/loader.js:638
    throw err;
```

#### What change is being introduced by this PR?
Updated node version on Release.yml to be the most recent one, 18.
Updated actions that had newer versions so we're using the most updated ones at once.

#### How will this be tested?
Running the release action later.