### PR TITLE
Fix #1008: Sourced conflicting holidays being imported by default

### DIFF
--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -476,7 +476,7 @@ describe('Test Workday Waiver Window', function()
             const secondCell = table.find('td')[1].innerHTML;
             const thirdCell = table.find('td')[2].innerHTML;
             const fourthCell = table.find('td')[4].innerHTML;
-            const fourthCellContent = `<label class="switch"><input type="checkbox" checked="${conflicts || workingDay === 'No' ? '' : 'checked'}" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
+            const fourthCellContent = `<label class="switch"><input type="checkbox" checked="" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
             expect(firstCell).toBe(day);
             expect(secondCell).toBe(reason);
             expect(thirdCell).toBe('undefined');
@@ -497,7 +497,7 @@ describe('Test Workday Waiver Window', function()
             const secondCell = table.find('td')[1].innerHTML;
             const thirdCell = table.find('td')[2].innerHTML;
             const fourthCell = table.find('td')[4].innerHTML;
-            const fourthCellContent = `<label class="switch"><input type="checkbox" checked="${conflicts || workingDay === 'No' ? '' : 'checked'}" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
+            const fourthCellContent = `<label class="switch"><input type="checkbox" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
             expect(firstCell).toBe(day);
             expect(secondCell).toBe(reason);
             expect(thirdCell).toBe(workingDay);
@@ -519,7 +519,7 @@ describe('Test Workday Waiver Window', function()
             const thirdCell = table.find('td')[2].innerHTML;
             const conflictsCell = table.find('td')[3].innerHTML;
             const fourthCell = table.find('td')[4].innerHTML;
-            const fourthCellContent = `<label class="switch"><input type="checkbox" checked="${conflicts || workingDay === 'No' ? '' : 'checked'}" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
+            const fourthCellContent = `<label class="switch"><input type="checkbox" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
             expect(firstCell).toBe(day);
             expect(secondCell).toBe(reason);
             expect(thirdCell).toBe(workingDay);

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -314,7 +314,7 @@ function addHolidayToList(day, reason, workingDay, conflicts)
     if (conflicts)
         $(row.cells[3]).addClass('text-danger');
     conflictsCell.innerHTML = conflicts;
-    importCell.innerHTML = `<label class="switch"><input type="checkbox" checked="${conflicts || workingDay === 'No' ? '' : 'checked'}" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
+    importCell.innerHTML = `<label class="switch"><input type="checkbox" ${conflicts || workingDay === 'No' ? ' ' : 'checked=""'} name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
 }
 
 function clearHolidayTable()


### PR DESCRIPTION
#### Related issue
Closes #1008

#### Context / Background
When sourcing holidays, the ones matching existing waivers were tagged as conflicts, but still picked to be added nonetheless

#### What change is being introduced by this PR?
Now when a conflict is detected, the checkbox will be unchecked by default and also disabled. Turns out that all we needed was to either set the `checked` attribute or not, but we were instead doing `checked=''` or `checked=checked` and it always thought it was checked.
- Do we really want to disable it? If the user wants to import conflicting waivers, then we might as well allow it.

![image](https://github.com/thamara/time-to-leave/assets/6443427/92161877-ec4a-4a00-9d44-48ac083a3b6d)

#### How will this be tested?
Test manually, but there are automatic tests for it that I hope still work