### PR TITLE
remove verbose flag from jest command

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "postinstall": "patch-package",
     "start": "electron .",
     "test": "npm-run-all test:*",
-    "test:jest": "jest --runInBand --detectOpenHandles --verbose --colors --transformIgnorePatterns 'node_modules/(?!astronomia)/' -- ",
+    "test:jest": "jest --runInBand --detectOpenHandles --colors --transformIgnorePatterns 'node_modules/(?!astronomia)/' -- ",
     "test:mocha": "nyc --reporter=lcov --reporter=json mocha tests/*",
     "setup:win": "node scripts/create_windows_installer.js"
   },


### PR DESCRIPTION
#### Related issue
Closes #886 

#### Context / Background
* Issue faced with printing `console.log()` statements when running `jest` command through scripts

#### What change is being introduced by this PR?
- Changes
    - removed verbose flag from jest command in `package.json`

#### How will this be tested?
- Running jest locally with `console.log()` statement present in one of the unit tests