### PR TITLE
Adding an animation to the workday waiver holidays table when switching contents

### DIFF
--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -36,6 +36,10 @@ const {
     getRegions,
     getStates
 } = require('../../main/workday-waiver-aux.js');
+const {
+    defaultPreferences,
+    savePreferences,
+} = require('../../js/user-preferences.js');
 
 jest.mock('../../renderer/i18n-translator.js', () => ({
     translatePage: jest.fn().mockReturnThis(),
@@ -133,6 +137,12 @@ jest.mock('../../js/window-aux.js');
 describe('Test Workday Waiver Window', function()
 {
     process.env.NODE_ENV = 'test';
+
+    beforeAll(() =>
+    {
+        // Making sure the preferences are the default so the tests work as expected
+        savePreferences(defaultPreferences);
+    });
 
     describe('Adding new waivers update the db and the page', function()
     {

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -476,8 +476,6 @@ describe('Test Workday Waiver Window', function()
         {
             const day = 'test day';
             const reason = 'test reason';
-            const workingDay = undefined;
-            const conflicts = undefined;
             addHolidayToList(day, reason);
             const table = $('#holiday-list-table tbody');
             const rowsLength = table.find('tr').length;
@@ -498,7 +496,6 @@ describe('Test Workday Waiver Window', function()
             const day = 'test day';
             const reason = 'test reason';
             const workingDay = 'No';
-            const conflicts = undefined;
             addHolidayToList(day, reason, workingDay);
             const table = $('#holiday-list-table tbody');
             const rowsLength = table.find('tr').length;
@@ -548,12 +545,12 @@ describe('Test Workday Waiver Window', function()
             addHolidayToList('test day', 'no reason');
         });
 
-        test('Clear table by ID', () =>
+        test('Clear table by JQuery object', () =>
         {
             const tableId = 'waiver-list-table';
             let rowLength = $(`#${tableId} tbody tr`).length;
             expect(rowLength).toBe(2);
-            clearTable(tableId);
+            clearTable($(`#${tableId}`));
             rowLength = $(`#${tableId} tbody tr`).length;
             expect(rowLength).toBe(0);
         });

--- a/css/styles.css
+++ b/css/styles.css
@@ -739,6 +739,10 @@ input:disabled + .slider {
   width: 100%;
 }
 
+#workday-waiver-window .list-date-header {
+  min-width: 80px;
+}
+
 #workday-waiver-window a.nav-link:not(.active) {
   color: var(--page-color);
   border-bottom: 1px solid var(--tab-waiver-border);

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -94,7 +94,7 @@
                     <table id="holiday-list-table">
                         <thead>
                             <tr>
-                                <th data-i18n="$WorkdayWaiver.date">Date</th>
+                                <th class="list-date-header" data-i18n="$WorkdayWaiver.date">Date</th>
                                 <th data-i18n="$WorkdayWaiver.holiday">Holiday</th>
                                 <th data-i18n="$WorkdayWaiver.on-working-day">On working day</th>
                                 <th data-i18n="$WorkdayWaiver.conflicts">Conflicts?</th>
@@ -124,7 +124,7 @@
                 <thead>
                     <tr>
                         <th></th>
-                        <th data-i18n="$WorkdayWaiver.day">Day</th>
+                        <th class="list-date-header" data-i18n="$WorkdayWaiver.day">Day</th>
                         <th data-i18n="$WorkdayWaiver.waiver-reason">Waiver Reason</th>
                         <th data-i18n="$WorkdayWaiver.hours-waived">Hours Waived</th>
                     </tr>


### PR DESCRIPTION
#### Related issue
Closes #1009

Before:
![holidays](https://github.com/thamara/time-to-leave/assets/37311270/e12526c7-a0cb-4d8d-91e6-4b5c2d1471e1)

After:
![holidays2](https://github.com/thamara/time-to-leave/assets/37311270/ca1c5ada-99c0-429f-83dd-c9221f579d80)

Also limited the min width of the date column so it stops breaking when the holiday names are too big.