### PR TITLE
Close #914: Enable more formats to input time in preferences

### DIFF
--- a/__tests__/__renderer__/preferences.js
+++ b/__tests__/__renderer__/preferences.js
@@ -21,6 +21,7 @@ window.mainApi = preferencesApi;
 window.mainApi.getUserPreferencesPromise = () => { return new Promise((resolve) => resolve(getUserPreferences())); };
 
 const {
+    convertTimeFormat,
     refreshContent,
     populateLanguages,
     listenerLanguage,
@@ -213,6 +214,49 @@ describe('Test Preferences Window', () =>
                 }
             });
             assert.notStrictEqual(lastValue, '');
+        });
+    });
+
+    describe('Check if configure hours per day conversion function', () =>
+    {
+        test('should convert single digit hour to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('6'), '06:00');
+        });
+
+        test('should convert double digit hour to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('12'), '12:00');
+        });
+
+        test('should convert H.M format to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('6.5'), '06:30');
+        });
+
+        test('should convert H.MM format to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('6.50'), '06:30');
+        });
+
+        test('should convert HH.M format to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('12.5'), '12:30');
+        });
+
+        test('should convert HH.MM format to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('12.50'), '12:30');
+        });
+
+        test('should convert H:MM format to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('6:30'), '06:30');
+        });
+
+        test('should convert HH:MM format to HH:MM format', () =>
+        {
+            assert.strictEqual(convertTimeFormat('12:30'), '12:30');
         });
     });
 });

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -42,7 +42,7 @@
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.hoursPerDay">Hours per day</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
+                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" title="X, XX, XX.X, X.XX, X:XX, XX.XX, XX:XX" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^((0|1)?[0-9]|2[0-3])(\.[0-9][0-9]?|:[0-5][0-9])?$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
             </div>
             <div class="flex-box">
                 <p><i class="fas fa-utensils"></i><span data-i18n="$Preferences.enablePrefillBreakTime">Enable prefilling of break time</span></p>
@@ -50,7 +50,7 @@
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.breakTimeInterval">Break time interval</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day" type="text" name="break-time-interval" id="break-time-interval" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="00:30" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '00:30'">
+                <input data-i18n="[placeholder]$Preferences.hours-per-day" title="X, XX, XX.X, X.XX, X:XX, XX.XX, XX:XX" type="text" name="break-time-interval" id="break-time-interval" maxlength=5 pattern="^((0|1)?[0-9]|2[0-3])(\.[0-9][0-9]?|:[0-5][0-9])?$" value="00:30" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '00:30'">
             </div>
             
         </section>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -238,6 +238,7 @@ $(() =>
 });
 
 export {
+    convertTimeFormat,
     refreshContent,
     populateLanguages,
     listenerLanguage,

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -69,6 +69,46 @@ function changeValue(type, newVal)
     window.mainApi.notifyNewPreferences(preferences);
 }
 
+function convertTimeFormat(entry)
+{
+    const colonIdx = entry.indexOf(':');
+    const containsColon = colonIdx !== -1;
+    const periodIdx = entry.indexOf('.');
+    const containsPeriod = periodIdx !== -1;
+    const singleStartDigit = (containsColon && colonIdx <= 1) || (containsPeriod && periodIdx <= 1);
+    if (containsColon)
+    {
+        /* istanbul ignore else */
+        if (singleStartDigit)
+        {
+            entry = '0'.concat(entry);
+        }
+    }
+    else if (containsPeriod)
+    {
+        let minutes = parseFloat('0'.concat(entry.substring(periodIdx)));
+        minutes *= 60;
+        minutes = Math.floor(minutes).toString();
+        minutes = minutes.length < 2 ? '0'.concat(minutes) : minutes.substring(0, 2);
+        entry = entry.substring(0, periodIdx).concat(':').concat(minutes);
+        /* istanbul ignore else */
+        if (singleStartDigit)
+        {
+            entry = '0'.concat(entry);
+        }
+    }
+    else
+    {
+        /* istanbul ignore else */
+        if (entry.length < 2)
+        {
+            entry = '0'.concat(entry);
+        }
+        entry = entry.concat(':00');
+    }
+    return entry;
+}
+
 function renderPreferencesWindow()
 {
     // Theme-handling should be towards the top. Applies theme early so it's more natural.
@@ -101,7 +141,9 @@ function renderPreferencesWindow()
         /* istanbul ignore else */
         if (this.checkValidity() === true)
         {
-            changeValue(this.name, this.value);
+            const entry = convertTimeFormat(this.value);
+            this.value = entry;
+            changeValue(this.name, entry);
         }
     });
 


### PR DESCRIPTION
#### Related issue
Closes #914 

#### Context / Background
- Previously the input of the "Hours per day" and "Break time interval" preferences sections were restricted to an XX:XX format, this PR introduces more formats that can be used.

#### What change is being introduced by this PR?
- You can now use X, XX, XX.X, X.XX, X:XX, and XX.XX in addition to the default XX:XX format when entering hours and minutes into the "Hours per day" and "Break time interval" sections in preferences.
- If the entered value matches one of these formats, it will be converted to match XX:XX before being saved as a preference.
- This involved changing the pattern regex for those fields in preferences.html, and performing some case checks and string manipulation in preferences.js.

#### Before change:
<img width="503" alt="Screen Shot 2023-10-18 at 5 37 00 pm" src="https://github.com/thamara/time-to-leave/assets/110021708/9f5d6fc9-5d9f-4206-8069-d86770217d24">

<img width="503" alt="Screen Shot 2023-10-18 at 5 36 51 pm" src="https://github.com/thamara/time-to-leave/assets/110021708/ebdc75f8-9c9c-46fd-96e3-ca16d1954a4f">

#### After change:
<img width="503" alt="Screen Shot 2023-10-18 at 5 37 17 pm" src="https://github.com/thamara/time-to-leave/assets/110021708/e01876aa-f189-4163-a97f-ece1f139c8c3">
<img width="503" alt="Screen Shot 2023-10-18 at 5 38 13 pm" src="https://github.com/thamara/time-to-leave/assets/110021708/f4f531f4-f390-4784-a04c-ae2236982290">

<img width="503" alt="Screen Shot 2023-10-18 at 5 37 13 pm" src="https://github.com/thamara/time-to-leave/assets/110021708/ee9aec9b-d94a-43fe-b23e-c8c9e38af88e">
<img width="503" alt="Screen Shot 2023-10-18 at 5 37 34 pm" src="https://github.com/thamara/time-to-leave/assets/110021708/294ab17a-94e7-40da-aa45-3cb9eda50e50">
