### PR TITLE
set verbose flag to false to enable console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "postinstall": "patch-package",
     "start": "electron .",
     "test": "npm-run-all test:*",
-    "test:jest": "jest --runInBand --detectOpenHandles --colors --transformIgnorePatterns 'node_modules/(?!astronomia)/' -- ",
+    "test:jest": "jest --runInBand --verbose=false --detectOpenHandles --colors --transformIgnorePatterns 'node_modules/(?!astronomia)/' -- ",
     "test:mocha": "nyc --reporter=lcov --reporter=json mocha tests/*",
     "setup:win": "node scripts/create_windows_installer.js"
   },


### PR DESCRIPTION
#### Related issue
Closes #886 
* this fix will work for running individual jest unit tests as well has running the script included in the `package.json` file

#### Context / Background
* the earlier fix merged worked for running the jest command collectively for all unit tests but not while running the same individually for a single unit test
* this fix ensures that the verbose flag is uniformly disabled across individual as well as script runs

#### What change is being introduced by this PR?
* set `--verbose=false` in the `package.json` file
* this will make consoles added in unit tests for jest to appear while running single or collective script for unit tests covered with jest

#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
-->
* tested locally, will reconfirm with repo owner whether this is the final expected behavior once PR gets merged
