### PR TITLE
fix: make images and icons not draggable

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -175,6 +175,10 @@ body {
   text-align: center;
 }
 
+.th :only-child {
+  -webkit-user-drag: none;
+}
+
 .th-month-name {
   text-align: center;
   font-size: 120%;
@@ -198,6 +202,7 @@ body {
   margin-right: auto;
   margin-top: auto;
   margin-bottom: auto;
+  user-select: none;
 }
 
 .title-header-img {
@@ -208,6 +213,8 @@ body {
 
 .title-header-img img {
   float: right;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .error-tr {
@@ -416,6 +423,10 @@ body {
 .punch-button:disabled {
   opacity: 0.5;
   color: var(--punch-disable-bground);
+}
+
+.punch-button img {
+  -webkit-user-drag: none;
 }
 
 #punch-button-label {


### PR DESCRIPTION
Makes images and icons not draggable within the app

#### Related issue
Closes #1028 

#### Context / Background
Makes images and icons with class .th and logo not draggable within the app

#### What change is being introduced by this PR?
Slight UX improvement

#### How will this be tested?
No need for testing, has little impact on usability of the app, though I've tested it locally

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
