### PR TITLE
Fix #1027: Avoid update-changelog to generate an extra line when there are no changes

### DIFF
--- a/.github/workflows/ChangelogUpdater.yml
+++ b/.github/workflows/ChangelogUpdater.yml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - name: Check trigger
         id: check
-        uses: khan/pull-request-comment-trigger@master
+        uses: khan/pull-request-comment-trigger@v1.1.0
         with:
           trigger: '\changelog-update'
           reaction: rocket
           prefix_only: 'true'
         env:
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@v2
         id: generate-token
         with:
           app_id: ${{ secrets.APP_ID }}
@@ -39,7 +39,7 @@ jobs:
           echo "COMMENT_AUTHOR_ASSOCIATION: $COMMENT_AUTHOR_ASSOCIATION"
       - name: Clone git repo
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Configure Git Agent
         if: steps.check.outputs.triggered == 'true'
         run: |

--- a/scripts/update-changelog.py
+++ b/scripts/update-changelog.py
@@ -40,8 +40,9 @@ def get_updated_file_content(current_changelog_lines: str, new_change: any, new_
         if line == g_end_changes:
             is_sourcing_changes = False
             new_file_content.extend(get_sorted_unique_entries(changes))
-            # adds an extra item to avoid issues with the linter
-            new_file_content.append('')
+            # adds an extra item to avoid issues with the linter, but only if there is at least one entry
+            if new_file_content[-1] != '':
+                new_file_content.append('')
 
         if line == g_end_users:
             is_sourcing_users = False
@@ -68,6 +69,7 @@ def get_updated_file_content(current_changelog_lines: str, new_change: any, new_
 
     # Include on extra empty line to comply with markdown formatter
     new_file_content.append('')
+
     return new_file_content
 
 def update_changelog(changelog_filename: str, new_change: any, new_user: any):


### PR DESCRIPTION
#### Related issue
Closes #1027

#### Context / Background
update-changelog.py was adding an extra empty line to the section below every time the bot was called while there were no changes in the current release.

```
<!--- Begin changes - Do not remove -->

<!--- End changes - Do not remove -->
```

For example: https://github.com/thamara/time-to-leave/commit/322a4d3e218fb3a26577a9c65e177d8a995fa63f

This extra line gets a linter complaint every time and then causes problems for the next PR.

This is not a common problem because we don't often have no changes, though.
Just now we got the first change.

#### What change is being introduced by this PR?
- Updating the actions we use to the latest to avoid some warnings.
- No longer adding an extra line in the script when there's no change.

#### How will this be tested?
Ran it locally against an empty changelog.md and against a filled changelog.md.