### PR TITLE
Fix #1040: Preferences window - date overflowing icon after electron …

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -671,7 +671,6 @@ input:disabled + .slider {
 #preferences-window input[type="date"].date-right::-webkit-datetime-edit {
   text-align: right;
   position: relative;
-  left: 25px;
 }
 
 #preferences-window #hours-per-day, #break-time-interval {


### PR DESCRIPTION
Closes #1040

Before:
![image](https://github.com/thamara/time-to-leave/assets/37311270/35366fcc-6050-43b2-a4e8-0f3c867f8a8e)

After:
![image](https://github.com/thamara/time-to-leave/assets/37311270/1ab7fc5e-2771-4df3-9554-ce308db7b07d)

Seems electron removed the overflow that was fixed with the `left` configuration.