### PR TITLE
Fix #1042: Removing extra space at bottom of workday waiver window

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -162,7 +162,6 @@ body {
 
 .container {
   font-family: 'Montserrat', sans-serif;
-  margin-bottom: 70px;
 }
 
 @media (max-width: 768px) {
@@ -219,6 +218,10 @@ body {
   margin-bottom: auto;
   font-size: 400%;
   float: left;
+}
+
+#calendar.container {
+  margin-bottom: 70px;
 }
 
 #calendar table {


### PR DESCRIPTION
#### Related issue
Closes #1042

#### What change is being introduced by this PR?
margin-bottom was added for the calendar only but had affected the workday waiver window. Now it's calendar-specific and doesn't add extra space to workday waiver window.