### PR TITLE
Fix #1038: Introduce Content Security Policies to app's pages

### DIFF
--- a/src/calendar.html
+++ b/src/calendar.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
 
     <title>Time to Leave</title>
 
@@ -11,11 +12,7 @@
     <link rel="stylesheet" href="../css/styles.css">
 
     <!-- Scripts -->
-    <!-- First we need to declare jQuery and $ globals with jquery -->
     <script src="../node_modules/jquery/dist/jquery.min.js" charset="utf-8"></script>
-    <script>
-        window.$ = window.jQuery;
-    </script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
     <script src="../node_modules/jquery-mousewheel/jquery.mousewheel.js"></script>
     <script type="module" src="./calendar.js" charset="utf-8"></script>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -2,16 +2,12 @@
 <html data-theme="" lang="en">
 
 <head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../node_modules/@fortawesome/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="../css/styles.css">
 
-    <!-- First we need to declare jQuery and $ globals with jquery -->
     <script src="../node_modules/jquery/dist/jquery.min.js" charset="utf-8"></script>
-    <script>
-        window.$ = window.jQuery;
-    </script>
-
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
     <script type="module" src="preferences.js"></script>
 </head>

--- a/src/workday-waiver.html
+++ b/src/workday-waiver.html
@@ -2,15 +2,11 @@
 <html data-theme="" lang="en">
 
 <head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../css/styles.css">
 
-    <!-- First we need to declare jQuery and $ globals with jquery -->
     <script src="../node_modules/jquery/dist/jquery.min.js" charset="utf-8"></script>
-    <script>
-        window.$ = window.jQuery;
-    </script>
-
     <script src="../node_modules/bootstrap/dist/js/bootstrap.bundle.js" charset="utf-8"></script>
     <script type="module" src="workday-waiver.js"></script>
 </head>


### PR DESCRIPTION
#### Related issue
Closes #1038

#### Context / Background
App was giving out security warnings on the JS console when fired, up as shown here:
![image](https://github.com/thamara/time-to-leave/assets/6443427/aeeb32c3-90fc-4193-9242-35b5dab7d0af)

#### What change is being introduced by this PR?
As far as I understood from [electron documentation](https://www.electronjs.org/docs/latest/tutorial/security#7-define-a-content-security-policy), the Content Security Policy (CSP) when defined prevents a malicious user from modifying/injecting stuff into our script calls. For when we have inline scripts, we could either use `unsafe-inline`, which would defeat the purpose of the CSP, `nonce` or a `hash`. When setting the CSP to just self, it would complain and already give the hash of the inline scripts, so I just used those hashes to not restrict it instead. If we ever change those inline scripts we'll need to update the hash, but I think that is ok.

#### How will this be tested?
The warnings are gone, I don't really think this was a big problem for us, but at least 
![image](https://github.com/thamara/time-to-leave/assets/6443427/092a151b-dec0-4b76-acdf-3a22c9feb56c)
