### PR TITLE
Fixing missing IPC handlers in tests (and other issues)

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           export DISPLAY=:99
           # TODO: need to download driver according to electron's version
-          wget --directory-prefix=/tmp https://chromedriver.storage.googleapis.com/87.0.4280.88/chromedriver_linux64.zip
+          wget --directory-prefix=/tmp https://chromedriver.storage.googleapis.com/100.0.4896.20/chromedriver_linux64.zip
           unzip -d /tmp/chromedriver /tmp/chromedriver_linux64.zip
           sudo chmod +x /tmp/chromedriver/chromedriver
           /tmp/chromedriver/chromedriver &

--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -39,8 +39,20 @@ jobs:
       - name: '        Tests'
         shell: bash
         env:
-          DISPLAY: ':99'
+          OS: ${{ matrix.os }}
         run: |
+          if [[ $OS == 'ubuntu-20.04' ]]; then
+            # Avoid "failed to connect to the bus" errors on CI https://github.com/microsoft/WSL/issues/7915
+            export XDG_RUNTIME_DIR=/run/user/$(id -u)
+            sudo mkdir -p $XDG_RUNTIME_DIR
+            sudo chmod 700 $XDG_RUNTIME_DIR
+            sudo chown $(id -un):$(id -gn) $XDG_RUNTIME_DIR
+            export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+
+            # For ChromeDriver to work
+            export DISPLAY=':99'
+          fi
+
           npm run test:jest
       - name: '        Create COV_REPORT'
         run: |

--- a/__tests__/__main__/import-export.js
+++ b/__tests__/__main__/import-export.js
@@ -158,6 +158,6 @@ describe('Import export', function()
 
     afterAll(() =>
     {
-        fs.rmdirSync(folder, {recursive: true});
+        fs.rmSync(folder, {recursive: true});
     });
 });

--- a/__tests__/__main__/main-window.js
+++ b/__tests__/__main__/main-window.js
@@ -1,7 +1,7 @@
 const notification = require('../../js/notification.js');
 const userPreferences = require('../../js/user-preferences.js');
 const { savePreferences, defaultPreferences, resetPreferences } = userPreferences;
-const { BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
 
 jest.mock('../../js/update-manager', () => ({
     checkForUpdates: jest.fn(),
@@ -11,6 +11,21 @@ jest.mock('../../js/update-manager', () => ({
 const mainWindowModule = require('../../js/main-window.js');
 const { getMainWindow, createWindow, resetMainWindow, getLeaveByInterval, getWindowTray, triggerStartupDialogs } = mainWindowModule;
 const updateManager = require('../../js/update-manager.js');
+
+// Mocking USER_DATA_PATH for tests below
+ipcMain.handle('USER_DATA_PATH', () =>
+{
+    return new Promise((resolve) =>
+    {
+        resolve(app.getPath('userData'));
+    });
+});
+
+ipcMain.removeHandler('GET_LANGUAGE_DATA');
+ipcMain.handle('GET_LANGUAGE_DATA', () => ({
+    'language': 'en',
+    'data': {}
+}));
 
 describe('main-window.js', () =>
 {
@@ -113,11 +128,6 @@ describe('main-window.js', () =>
                 {
                     ipcMain.emit('FINISH_TEST', event, savedPreferences);
                 });
-                ipcMain.removeHandler('GET_LANGUAGE_DATA');
-                ipcMain.handle('GET_LANGUAGE_DATA', () => ({
-                    'language': 'en',
-                    'data': {}
-                }));
                 ipcMain.on('FINISH_TEST', (event, savedPreferences) =>
                 {
                     expect(windowSpy).toBeCalledTimes(1);

--- a/__tests__/__main__/menus.js
+++ b/__tests__/__main__/menus.js
@@ -371,13 +371,21 @@ describe('menus.js', () =>
             expect(mocks.showMessageBox).toHaveBeenCalledTimes(1);
             expect(mocks.writeText).toHaveBeenCalledTimes(0);
         });
-        test('Should show about message box', () =>
+        test('Should show about message box', (done) =>
         {
+            mocks.consoleLog = jest.spyOn(console, 'log').mockImplementation();
             mocks.writeText = jest.spyOn(clipboard, 'writeText').mockImplementation(() => {});
             mocks.showMessageBox = jest.spyOn(dialog, 'showMessageBox').mockRejectedValue({response: 1});
             getHelpMenuTemplate({})[4].click();
             expect(mocks.showMessageBox).toHaveBeenCalledTimes(1);
             expect(mocks.writeText).toHaveBeenCalledTimes(0);
+
+            // When the rejection happens, we call console.log with the response
+            setTimeout(() =>
+            {
+                expect(mocks.consoleLog).toHaveBeenCalledWith({response: 1});
+                done();
+            }, 500);
         });
     });
 

--- a/__tests__/__main__/update-manager.js
+++ b/__tests__/__main__/update-manager.js
@@ -53,7 +53,13 @@ describe('js/update-manager.js', () =>
     {
         test('should not execute when is offline', () =>
         {
-            mocks.net = jest.spyOn(net, 'request').mockImplementation(() => {});
+            mocks.net = jest.spyOn(net, 'request').mockImplementation(() =>
+            {
+                return {
+                    on: () => {},
+                    end: () => {}
+                };
+            });
             checkForUpdates();
             expect(mocks.net).toBeCalledTimes(0);
         });
@@ -67,7 +73,8 @@ describe('js/update-manager.js', () =>
                     {
                         expect(mocks.net).toBeCalledTimes(1);
                         done();
-                    }
+                    },
+                    end: () => {}
                 };
             });
             checkForUpdates();

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -167,14 +167,22 @@ describe('BaseCalendar.js', () =>
             expect(mocks.compute).toHaveBeenCalledTimes(0);
         });
 
-        test('Should not update value because of rejection', async() =>
+        test('Should not update value because of rejection', async(done) =>
         {
+            mocks.consoleLog = jest.spyOn(console, 'log').mockImplementation();
             mocks.compute = jest.spyOn(timeBalance, 'computeAllTimeBalanceUntilAsync').mockImplementation(() => Promise.reject());
             const preferences = {view: 'day'};
             const languageData = {hello: 'hola'};
             const calendar = new ExtendedClass(preferences, languageData);
             calendar._updateAllTimeBalance();
             expect(mocks.compute).toHaveBeenCalledTimes(1);
+
+            // When the rejection happens, we call console.log, but it'll be undefined here
+            setTimeout(() =>
+            {
+                expect(mocks.consoleLog).toHaveBeenCalledWith(undefined);
+                done();
+            }, 500);
         });
 
         test('Should not update value because no overall-balance element', () =>

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -56,11 +56,25 @@ describe('BaseCalendar.js', () =>
 
         window.mainApi.getFlexibleStoreContents = () =>
         {
-            return flexibleStore.store;
+            return new Promise((resolve) =>
+            {
+                resolve(flexibleStore.store);
+            });
         };
         window.mainApi.getWaiverStoreContents = () =>
         {
-            return waivedWorkdays.store;
+            return new Promise((resolve) =>
+            {
+                resolve(waivedWorkdays.store);
+            });
+        };
+        window.mainApi.setFlexibleStoreData = (key, contents) =>
+        {
+            flexibleStore.set(key, contents);
+            return new Promise((resolve) =>
+            {
+                resolve(true);
+            });
         };
     });
 

--- a/__tests__/__renderer__/classes/FlexibleDayCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleDayCalendar.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 
 const Store = require('electron-store');
+import { computeAllTimeBalanceUntilAsync } from '../../../js/time-balance.js';
 import { defaultPreferences } from '../../../js/user-preferences.js';
 import { CalendarFactory } from '../../../renderer/classes/CalendarFactory.js';
 import { calendarApi } from '../../../renderer/preload-scripts/calendar-api.js';
@@ -48,6 +49,13 @@ window.mainApi.deleteFlexibleStoreData = (key) =>
     {
         flexibleStore.delete(key);
         resolve(true);
+    });
+};
+window.mainApi.computeAllTimeBalanceUntilPromise = (targetDate) =>
+{
+    return new Promise((resolve) =>
+    {
+        resolve(computeAllTimeBalanceUntilAsync(targetDate));
     });
 };
 

--- a/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const Store = require('electron-store');
+import { computeAllTimeBalanceUntilAsync } from '../../../js/time-balance.js';
 import { defaultPreferences } from '../../../js/user-preferences.js';
 import { CalendarFactory } from '../../../renderer/classes/CalendarFactory.js';
 import { calendarApi } from '../../../renderer/preload-scripts/calendar-api.js';
@@ -49,6 +50,13 @@ window.mainApi.deleteFlexibleStoreData = (key) =>
     {
         flexibleStore.delete(key);
         resolve(true);
+    });
+};
+window.mainApi.computeAllTimeBalanceUntilPromise = (targetDate) =>
+{
+    return new Promise((resolve) =>
+    {
+        resolve(computeAllTimeBalanceUntilAsync(targetDate));
     });
 };
 

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -28,7 +28,6 @@ const {
     initializeHolidayInfo,
     refreshDataForTest
 } = require('../../src/workday-waiver');
-import { showDialogSync } from '../../js/window-aux.js';
 const { workdayWaiverApi } = require('../../renderer/preload-scripts/workday-waiver-api.js');
 const {
     getAllHolidays,
@@ -38,6 +37,7 @@ const {
 } = require('../../main/workday-waiver-aux.js');
 const {
     defaultPreferences,
+    getUserPreferencesPromise,
     savePreferences,
 } = require('../../js/user-preferences.js');
 
@@ -101,6 +101,24 @@ window.mainApi.getRegions = (country, state) =>
     {
         resolve(getRegions(country, state));
     });
+};
+
+window.mainApi.showDialogSync = () =>
+{
+    return new Promise((resolve) =>
+    {
+        resolve({ response: 0 });
+    });
+};
+
+window.mainApi.getUserPreferences = () =>
+{
+    const preferencesFilePathPromise = new Promise((resolve) =>
+    {
+        const userDataPath = app.getPath('userData');
+        resolve(path.join(userDataPath, 'preferences.json'));
+    });
+    return getUserPreferencesPromise(preferencesFilePathPromise);
 };
 
 const languageData = {'language': 'en', 'data': {'dummy_string': 'dummy_string_translated'}};
@@ -273,10 +291,6 @@ describe('Test Workday Waiver Window', function()
             await prepareMockup();
             addTestWaiver('2020-07-16', 'some reason');
             const deleteBtn = document.querySelectorAll('#waiver-list-table .delete-btn')[0];
-            showDialogSync.mockImplementation((options, cb) =>
-            {
-                cb({ response: 0 });
-            });
             deleteEntryOnClick({target: deleteBtn});
             const length = document.querySelectorAll('#waiver-list-table .delete-btn').length;
             expect(length).toBe(0);

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -232,11 +232,16 @@ function getLoadedOrDerivedUserPreferences()
     return readPreferences();
 }
 
-function getUserPreferencesPromise()
+/**
+ * Returns a promise to the user preferences.
+ * @param preferencesFilePathPromise Optionally allows one to pass in a promise that resolves to the preferences file path
+ * @return {Promise<Object>}
+ */
+function getUserPreferencesPromise(preferencesFilePathPromise = getPreferencesFilePathPromise())
 {
     return new Promise((resolve) =>
     {
-        getPreferencesFilePathPromise().then((filePath) =>
+        preferencesFilePathPromise.then((filePath) =>
         {
             initPreferencesFileIfNotExistsOrInvalid(filePath);
             resolve(readPreferences(filePath));


### PR DESCRIPTION
#### Related issue
Closes #1036

#### Context / Background
There are a few issues that show up only on the CI for the PR Checks, indicating missing ipc handlers in our tests.
On Ubuntu specifically there were a lot of warnings caused by a misconfigured Chrome Driver.

#### What change is being introduced by this PR?

Some IPC handlers were missing for a few tests. Most of them were "invoke" calls made by handlers registered in `ipcMain`. In order to avoid registering those in the tests, I've instead mocked the places where the invoke calls are made and called directly what they were invoking.

For Ubuntu, there was an issue with "failed to connect to the bus" related to a dbus used by the chrome driver. To fix that I've followed a suggestion from another repo to properly set the `DBUS_SESSION_BUS_ADDRESS` env variable and the warning went away.
Also took the chance to update the version of ChromeDriver we use.

#### How will this be tested?
Checked the PR checks for further warnings. There are no more warnings that we can take care of. The Ubuntu one still has a few unavoidable chrome warnings, but much less than before.