### PR TITLE
Switching most expect calls to node assert

### DIFF
--- a/__tests__/__main__/date-aux.js
+++ b/__tests__/__main__/date-aux.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import { getDateStr, getCurrentDateTimeStr, getMonthLength } from '../../js/date-aux.js';
 
 describe('Date Functions', () =>
@@ -13,12 +14,12 @@ describe('Date Functions', () =>
     {
         test('Given a JS Date() object, should return YYYY-MM-DD', () =>
         {
-            expect(getDateStr(testDate)).toBe(expectedDate);
+            assert.strictEqual(getDateStr(testDate), expectedDate);
         });
 
         test('Given an insane object, should return an error', () =>
         {
-            expect(getDateStr(badDate)).not.toBe(expectedDate);
+            assert.notStrictEqual(getDateStr(badDate), expectedDate);
         });
     });
 
@@ -27,18 +28,18 @@ describe('Date Functions', () =>
         const testYear = 2024;
         test('Given for the Year(2024) and Months, should return number of days in month', () =>
         {
-            expect(getMonthLength(testYear, 0)).toBe(31);
-            expect(getMonthLength(testYear, 1)).toBe(29);
-            expect(getMonthLength(testYear, 2)).toBe(31);
-            expect(getMonthLength(testYear, 3)).toBe(30);
-            expect(getMonthLength(testYear, 4)).toBe(31);
-            expect(getMonthLength(testYear, 5)).toBe(30);
-            expect(getMonthLength(testYear, 6)).toBe(31);
-            expect(getMonthLength(testYear, 7)).toBe(31);
-            expect(getMonthLength(testYear, 8)).toBe(30);
-            expect(getMonthLength(testYear, 9)).toBe(31);
-            expect(getMonthLength(testYear, 10)).toBe(30);
-            expect(getMonthLength(testYear, 11)).toBe(31);
+            assert.strictEqual(getMonthLength(testYear, 0), 31);
+            assert.strictEqual(getMonthLength(testYear, 1), 29);
+            assert.strictEqual(getMonthLength(testYear, 2), 31);
+            assert.strictEqual(getMonthLength(testYear, 3), 30);
+            assert.strictEqual(getMonthLength(testYear, 4), 31);
+            assert.strictEqual(getMonthLength(testYear, 5), 30);
+            assert.strictEqual(getMonthLength(testYear, 6), 31);
+            assert.strictEqual(getMonthLength(testYear, 7), 31);
+            assert.strictEqual(getMonthLength(testYear, 8), 30);
+            assert.strictEqual(getMonthLength(testYear, 9), 31);
+            assert.strictEqual(getMonthLength(testYear, 10), 30);
+            assert.strictEqual(getMonthLength(testYear, 11), 31);
         });
     });
 
@@ -49,12 +50,12 @@ describe('Date Functions', () =>
 
         test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters making sure it accepts digits', () =>
         {
-            expect(looseRegexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);
+            assert.strictEqual(looseRegexCurrentDateTime.test(getCurrentDateTimeStr()), true);
         });
 
         test('Should return Current Date Time string in YYYY_MM_DD_HH_MM_SS format with no spaces or unexpected characters', () =>
         {
-            expect(regexCurrentDateTime.test(getCurrentDateTimeStr())).toBe(true);
+            assert.strictEqual(regexCurrentDateTime.test(getCurrentDateTimeStr()), true);
         });
     });
 });

--- a/__tests__/__main__/import-export.js
+++ b/__tests__/__main__/import-export.js
@@ -29,17 +29,17 @@ describe('Import export', function()
         const badWaivedEntry = {'type': 'regular', 'date': '2020-06-03', 'data': 'day-begin', 'hours': 'not-an-hour'};
         test('should be valid', () =>
         {
-            assert.notStrictEqual(validEntry(goodRegularEntry), undefined);
-            assert.notStrictEqual(validEntry(goodWaivedEntry), undefined);
-            assert.notStrictEqual(validEntry(goodFlexibleEntry), undefined);
+            assert.strictEqual(validEntry(goodRegularEntry), true);
+            assert.strictEqual(validEntry(goodWaivedEntry), true);
+            assert.strictEqual(validEntry(goodFlexibleEntry), true);
         });
 
         test('should not be valid', () =>
         {
-            assert.notStrictEqual(validEntry(badRegularEntry), undefined);
-            assert.notStrictEqual(validEntry(badWaivedEntry), undefined);
-            assert.notStrictEqual(validEntry(badFlexibleEntry), undefined);
-            assert.notStrictEqual(validEntry(badFlexibleEntry2), undefined);
+            assert.strictEqual(validEntry(badRegularEntry), false);
+            assert.strictEqual(validEntry(badWaivedEntry), false);
+            assert.strictEqual(validEntry(badFlexibleEntry), false);
+            assert.strictEqual(validEntry(badFlexibleEntry2), false);
         });
     });
 
@@ -83,8 +83,8 @@ describe('Import export', function()
     {
         test('Check that export works', () =>
         {
-            assert.notStrictEqual(exportDatabaseToFile(path.join(folder, 'exported_file.ttldb')), undefined);
-            assert.notStrictEqual(exportDatabaseToFile('/not/a/valid/path'), undefined);
+            assert.strictEqual(exportDatabaseToFile(path.join(folder, 'exported_file.ttldb')), true);
+            assert.strictEqual(exportDatabaseToFile('/not/a/valid/path'), false);
         });
     });
 
@@ -102,10 +102,10 @@ describe('Import export', function()
     {
         test('Check that import works', () =>
         {
-            assert.notStrictEqual(importDatabaseFromFile([path.join(folder, 'exported_file.ttldb')])['result'], undefined);
-            assert.notStrictEqual(importDatabaseFromFile(['/not/a/valid/path'])['result'], undefined);
+            assert.strictEqual(importDatabaseFromFile([path.join(folder, 'exported_file.ttldb')])['result'], true);
+            assert.strictEqual(importDatabaseFromFile(['/not/a/valid/path'])['result'], false);
             assert.strictEqual(importDatabaseFromFile(['/not/a/valid/path'])['failed'], 0);
-            assert.notStrictEqual(importDatabaseFromFile([invalidEntriesFile])['result'], undefined);
+            assert.strictEqual(importDatabaseFromFile([invalidEntriesFile])['result'], false);
             assert.strictEqual(importDatabaseFromFile([invalidEntriesFile])['failed'], 5);
         });
     });
@@ -150,7 +150,7 @@ describe('Import export', function()
         {
             flexibleStore.clear();
             assert.strictEqual(flexibleStore.size, 0);
-            assert.notStrictEqual(importDatabaseFromFile([mixedEntriesFile])['result'], undefined);
+            assert.strictEqual(importDatabaseFromFile([mixedEntriesFile])['result'], true);
             assert.strictEqual(flexibleStore.size, 2);
             expect(flexibleStore.get('2020-2-1')).toStrictEqual(expectedMixedEntries['2020-2-1']);
             expect(flexibleStore.get('2020-5-3')).toStrictEqual(expectedMixedEntries['2020-5-3']);

--- a/__tests__/__main__/import-export.js
+++ b/__tests__/__main__/import-export.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 const {
     exportDatabaseToFile,
     importDatabaseFromFile,
@@ -28,17 +29,17 @@ describe('Import export', function()
         const badWaivedEntry = {'type': 'regular', 'date': '2020-06-03', 'data': 'day-begin', 'hours': 'not-an-hour'};
         test('should be valid', () =>
         {
-            expect(validEntry(goodRegularEntry)).toBeTruthy();
-            expect(validEntry(goodWaivedEntry)).toBeTruthy();
-            expect(validEntry(goodFlexibleEntry)).toBeTruthy();
+            assert.notStrictEqual(validEntry(goodRegularEntry), undefined);
+            assert.notStrictEqual(validEntry(goodWaivedEntry), undefined);
+            assert.notStrictEqual(validEntry(goodFlexibleEntry), undefined);
         });
 
         test('should not be valid', () =>
         {
-            expect(validEntry(badRegularEntry)).not.toBeTruthy();
-            expect(validEntry(badWaivedEntry)).not.toBeTruthy();
-            expect(validEntry(badFlexibleEntry)).not.toBeTruthy();
-            expect(validEntry(badFlexibleEntry2)).not.toBeTruthy();
+            assert.notStrictEqual(validEntry(badRegularEntry), undefined);
+            assert.notStrictEqual(validEntry(badWaivedEntry), undefined);
+            assert.notStrictEqual(validEntry(badFlexibleEntry), undefined);
+            assert.notStrictEqual(validEntry(badFlexibleEntry2), undefined);
         });
     });
 
@@ -82,8 +83,8 @@ describe('Import export', function()
     {
         test('Check that export works', () =>
         {
-            expect(exportDatabaseToFile(path.join(folder, 'exported_file.ttldb'))).toBeTruthy();
-            expect(exportDatabaseToFile('/not/a/valid/path')).not.toBeTruthy();
+            assert.notStrictEqual(exportDatabaseToFile(path.join(folder, 'exported_file.ttldb')), undefined);
+            assert.notStrictEqual(exportDatabaseToFile('/not/a/valid/path'), undefined);
         });
     });
 
@@ -101,11 +102,11 @@ describe('Import export', function()
     {
         test('Check that import works', () =>
         {
-            expect(importDatabaseFromFile([path.join(folder, 'exported_file.ttldb')])['result']).toBeTruthy();
-            expect(importDatabaseFromFile(['/not/a/valid/path'])['result']).not.toBeTruthy();
-            expect(importDatabaseFromFile(['/not/a/valid/path'])['failed']).toBe(0);
-            expect(importDatabaseFromFile([invalidEntriesFile])['result']).not.toBeTruthy();
-            expect(importDatabaseFromFile([invalidEntriesFile])['failed']).toBe(5);
+            assert.notStrictEqual(importDatabaseFromFile([path.join(folder, 'exported_file.ttldb')])['result'], undefined);
+            assert.notStrictEqual(importDatabaseFromFile(['/not/a/valid/path'])['result'], undefined);
+            assert.strictEqual(importDatabaseFromFile(['/not/a/valid/path'])['failed'], 0);
+            assert.notStrictEqual(importDatabaseFromFile([invalidEntriesFile])['result'], undefined);
+            assert.strictEqual(importDatabaseFromFile([invalidEntriesFile])['failed'], 5);
         });
     });
 
@@ -118,11 +119,11 @@ describe('Import export', function()
     {
         test('Check that migration works', () =>
         {
-            expect(flexibleStore.size).toBe(2);
+            assert.strictEqual(flexibleStore.size, 2);
             flexibleStore.clear();
-            expect(flexibleStore.size).toBe(0);
+            assert.strictEqual(flexibleStore.size, 0);
             migrateFixedDbToFlexible();
-            expect(flexibleStore.size).toBe(2);
+            assert.strictEqual(flexibleStore.size, 2);
             expect(flexibleStore.get('2020-3-1')).toStrictEqual(migratedFlexibleEntries['2020-3-1']);
             expect(flexibleStore.get('2020-3-2')).toStrictEqual(migratedFlexibleEntries['2020-3-2']);
         });
@@ -148,9 +149,9 @@ describe('Import export', function()
         test('Check that import works', () =>
         {
             flexibleStore.clear();
-            expect(flexibleStore.size).toBe(0);
-            expect(importDatabaseFromFile([mixedEntriesFile])['result']).toBeTruthy();
-            expect(flexibleStore.size).toBe(2);
+            assert.strictEqual(flexibleStore.size, 0);
+            assert.notStrictEqual(importDatabaseFromFile([mixedEntriesFile])['result'], undefined);
+            assert.strictEqual(flexibleStore.size, 2);
             expect(flexibleStore.get('2020-2-1')).toStrictEqual(expectedMixedEntries['2020-2-1']);
             expect(flexibleStore.get('2020-5-3')).toStrictEqual(expectedMixedEntries['2020-5-3']);
         });

--- a/__tests__/__main__/main-window.js
+++ b/__tests__/__main__/main-window.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const notification = require('../../js/notification.js');
 const userPreferences = require('../../js/user-preferences.js');
 const { savePreferences, defaultPreferences, resetPreferences } = userPreferences;
@@ -42,16 +43,16 @@ describe('main-window.js', () =>
     {
         test('Should be null if it has not been started', () =>
         {
-            expect(getWindowTray()).toBe(null);
-            expect(getMainWindow()).toBe(null);
-            expect(getLeaveByInterval()).toBe(null);
+            assert.strictEqual(getWindowTray(), null);
+            assert.strictEqual(getMainWindow(), null);
+            assert.strictEqual(getLeaveByInterval(), null);
         });
 
         test('Should get window', () =>
         {
             createWindow();
             expect(showSpy).toHaveBeenCalledTimes(1);
-            expect(getMainWindow()).toBeInstanceOf(BrowserWindow);
+            assert.strictEqual(getMainWindow() instanceof BrowserWindow, true);
         });
     });
 
@@ -65,17 +66,17 @@ describe('main-window.js', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            expect(mainWindow).toBeInstanceOf(BrowserWindow);
-            expect(ipcMain.listenerCount('TOGGLE_TRAY_PUNCH_TIME')).toBe(1);
-            expect(ipcMain.listenerCount('RESIZE_MAIN_WINDOW')).toBe(1);
-            expect(ipcMain.listenerCount('SWITCH_VIEW')).toBe(1);
-            expect(ipcMain.listenerCount('RECEIVE_LEAVE_BY')).toBe(1);
-            expect(mainWindow.listenerCount('minimize')).toBe(2);
-            expect(mainWindow.listenerCount('close')).toBe(1);
+            assert.strictEqual(mainWindow instanceof BrowserWindow, true);
+            assert.strictEqual(ipcMain.listenerCount('TOGGLE_TRAY_PUNCH_TIME'), 1);
+            assert.strictEqual(ipcMain.listenerCount('RESIZE_MAIN_WINDOW'), 1);
+            assert.strictEqual(ipcMain.listenerCount('SWITCH_VIEW'), 1);
+            assert.strictEqual(ipcMain.listenerCount('RECEIVE_LEAVE_BY'), 1);
+            assert.strictEqual(mainWindow.listenerCount('minimize'), 2);
+            assert.strictEqual(mainWindow.listenerCount('close'), 1);
             expect(loadFileSpy).toHaveBeenCalledTimes(1);
             expect(showSpy).toHaveBeenCalledTimes(1);
-            expect(getLeaveByInterval()).not.toBe(null);
-            expect(getLeaveByInterval()._idleNext.expiry).toBeGreaterThan(0);
+            assert.notStrictEqual(getLeaveByInterval(), null);
+            assert.strictEqual(getLeaveByInterval()._idleNext.expiry > 0, true);
         });
     });
 
@@ -264,7 +265,7 @@ describe('main-window.js', () =>
                 mainWindow.emit('minimize', {
                     preventDefault: () => {}
                 });
-                expect(mainWindow.isVisible()).toBe(false);
+                assert.strictEqual(mainWindow.isVisible(), false);
                 done();
             });
         });
@@ -309,8 +310,8 @@ describe('main-window.js', () =>
                 mainWindow.emit('close', {
                     preventDefault: () => {}
                 });
-                expect(mainWindow.isDestroyed()).toBe(false);
-                expect(mainWindow.isVisible()).toBe(false);
+                assert.strictEqual(mainWindow.isDestroyed(), false);
+                assert.strictEqual(mainWindow.isVisible(), false);
                 done();
             });
         });
@@ -337,7 +338,7 @@ describe('main-window.js', () =>
                 mainWindow.emit('close', {
                     preventDefault: () => {}
                 });
-                expect(mainWindow.isDestroyed()).toBe(true);
+                assert.strictEqual(mainWindow.isDestroyed(), true);
                 done();
             });
         });

--- a/__tests__/__main__/menus.js
+++ b/__tests__/__main__/menus.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const { getContextMenuTemplate, getDockMenuTemplate, getEditMenuTemplate, getHelpMenuTemplate, getMainMenuTemplate, getViewMenuTemplate} = require('../../js/menus.js');
 
 jest.mock('../../src/configs/i18next.config.js', () => ({
@@ -92,7 +93,7 @@ describe('menus.js', () =>
     {
         test('Should have 3 options', () =>
         {
-            expect(getMainMenuTemplate().length).toBe(3);
+            assert.strictEqual(getMainMenuTemplate().length, 3);
         });
 
         getMainMenuTemplate().forEach((menu) =>
@@ -105,22 +106,22 @@ describe('menus.js', () =>
                 ];
                 if ('type' in menu)
                 {
-                    expect(menu.type).toBe('separator');
+                    assert.strictEqual(menu.type, 'separator');
                 }
                 else
                 {
                     for (const t of tests)
                     {
-                        expect(menu[t.field]).toBeTruthy();
-                        expect(typeof menu[t.field]).toBe(t.type);
+                        assert.notStrictEqual(menu[t.field], undefined);
+                        assert.strictEqual(typeof menu[t.field], t.type);
                     }
                     if ('id' in menu)
                     {
-                        expect(typeof menu.id).toBe('string');
+                        assert.strictEqual(typeof menu.id, 'string');
                     }
                     if ('accelerator' in menu)
                     {
-                        expect(typeof menu.accelerator).toBe('string');
+                        assert.strictEqual(typeof menu.accelerator, 'string');
                     }
                 }
             });
@@ -149,7 +150,7 @@ describe('menus.js', () =>
     {
         test('Should have 3 options', () =>
         {
-            expect(getContextMenuTemplate().length).toBe(3);
+            assert.strictEqual(getContextMenuTemplate().length, 3);
         });
 
         getContextMenuTemplate().forEach((menu) =>
@@ -162,8 +163,8 @@ describe('menus.js', () =>
                 ];
                 for (const t of tests)
                 {
-                    expect(menu[t.field]).toBeTruthy();
-                    expect(typeof menu[t.field]).toBe(t.type);
+                    assert.notStrictEqual(menu[t.field], undefined);
+                    assert.strictEqual(typeof menu[t.field], t.type);
                 }
             });
 
@@ -175,7 +176,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        expect(key).toBe('PUNCH_DATE');
+                        assert.strictEqual(key, 'PUNCH_DATE');
                     }
                 }
             };
@@ -207,7 +208,7 @@ describe('menus.js', () =>
     {
         test('Should have 1 option', () =>
         {
-            expect(getDockMenuTemplate().length).toBe(1);
+            assert.strictEqual(getDockMenuTemplate().length, 1);
         });
 
         getDockMenuTemplate().forEach((menu) =>
@@ -220,8 +221,8 @@ describe('menus.js', () =>
                 ];
                 for (const t of tests)
                 {
-                    expect(menu[t.field]).toBeTruthy();
-                    expect(typeof menu[t.field]).toBe(t.type);
+                    assert.notStrictEqual(menu[t.field], undefined);
+                    assert.strictEqual(typeof menu[t.field], t.type);
                 }
             });
         });
@@ -232,7 +233,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        expect(key).toBe('PUNCH_DATE');
+                        assert.strictEqual(key, 'PUNCH_DATE');
                     }
                 }
             };
@@ -248,7 +249,7 @@ describe('menus.js', () =>
     {
         test('Should have 2 option', () =>
         {
-            expect(getViewMenuTemplate().length).toBe(2);
+            assert.strictEqual(getViewMenuTemplate().length, 2);
         });
 
         getViewMenuTemplate().forEach((menu) =>
@@ -261,8 +262,8 @@ describe('menus.js', () =>
                 ];
                 for (const t of tests)
                 {
-                    expect(menu[t.field]).toBeTruthy();
-                    expect(typeof menu[t.field]).toBe(t.type);
+                    assert.notStrictEqual(menu[t.field], undefined);
+                    assert.strictEqual(typeof menu[t.field], t.type);
                 }
             });
         });
@@ -298,7 +299,7 @@ describe('menus.js', () =>
     {
         test('Should have 5 option', () =>
         {
-            expect(getHelpMenuTemplate().length).toBe(5);
+            assert.strictEqual(getHelpMenuTemplate().length, 5);
         });
 
         getHelpMenuTemplate().forEach((menu) =>
@@ -311,14 +312,14 @@ describe('menus.js', () =>
                 ];
                 if ('type' in menu)
                 {
-                    expect(menu.type).toBe('separator');
+                    assert.strictEqual(menu.type, 'separator');
                 }
                 else
                 {
                     for (const t of tests)
                     {
-                        expect(menu[t.field]).toBeTruthy();
-                        expect(typeof menu[t.field]).toBe(t.type);
+                        assert.notStrictEqual(menu[t.field], undefined);
+                        assert.strictEqual(typeof menu[t.field], t.type);
                     }
                 }
             });
@@ -328,7 +329,7 @@ describe('menus.js', () =>
         {
             mocks.window = jest.spyOn(shell, 'openExternal').mockImplementation((key) =>
             {
-                expect(key).toBe('https://github.com/thamara/time-to-leave');
+                assert.strictEqual(key, 'https://github.com/thamara/time-to-leave');
                 done();
             });
             getHelpMenuTemplate()[0].click();
@@ -338,7 +339,7 @@ describe('menus.js', () =>
         {
             mocks.window = jest.spyOn(updateManager, 'checkForUpdates').mockImplementation((key) =>
             {
-                expect(key).toBe(true);
+                assert.strictEqual(key, true);
                 done();
             });
             getHelpMenuTemplate()[1].click();
@@ -348,7 +349,7 @@ describe('menus.js', () =>
         {
             mocks.window = jest.spyOn(shell, 'openExternal').mockImplementation((key) =>
             {
-                expect(key).toBe('https://github.com/thamara/time-to-leave/issues/new');
+                assert.strictEqual(key, 'https://github.com/thamara/time-to-leave/issues/new');
                 done();
             });
             getHelpMenuTemplate()[2].click();
@@ -395,7 +396,7 @@ describe('menus.js', () =>
     {
         test('Should have 10 options', () =>
         {
-            expect(getEditMenuTemplate().length).toBe(10);
+            assert.strictEqual(getEditMenuTemplate().length, 10);
         });
 
         getEditMenuTemplate().forEach((menu) =>
@@ -407,30 +408,30 @@ describe('menus.js', () =>
                 ];
                 if ('type' in menu)
                 {
-                    expect(menu.type).toBe('separator');
+                    assert.strictEqual(menu.type, 'separator');
                 }
                 else
                 {
                     for (const t of tests)
                     {
-                        expect(menu[t.field]).toBeTruthy();
-                        expect(typeof menu[t.field]).toBe(t.type);
+                        assert.notStrictEqual(menu[t.field], undefined);
+                        assert.strictEqual(typeof menu[t.field], t.type);
                     }
                     if ('id' in menu)
                     {
-                        expect(typeof menu.id).toBe('string');
+                        assert.strictEqual(typeof menu.id, 'string');
                     }
                     if ('accelerator' in menu)
                     {
-                        expect(typeof menu.accelerator).toBe('string');
+                        assert.strictEqual(typeof menu.accelerator, 'string');
                     }
                     if ('selector' in menu)
                     {
-                        expect(typeof menu.selector).toBe('string');
+                        assert.strictEqual(typeof menu.selector, 'string');
                     }
                     if ('click' in menu)
                     {
-                        expect(typeof menu.click).toBe('function');
+                        assert.strictEqual(typeof menu.click, 'function');
                     }
                 }
             });
@@ -460,12 +461,11 @@ describe('menus.js', () =>
 
         test('Should show dialog for importing db', () =>
         {
-            expect.assertions(5);
             const mainWindow = {
                 webContents: {
                     send: (key) =>
                     {
-                        expect(key).toBe('RELOAD_CALENDAR');
+                        assert.strictEqual(key, 'RELOAD_CALENDAR');
                     }
                 }
             };
@@ -485,12 +485,11 @@ describe('menus.js', () =>
 
         test('Should show fail dialog for importing db', () =>
         {
-            expect.assertions(5);
             const mainWindow = {
                 webContents: {
                     send: (key) =>
                     {
-                        expect(key).toBe('RELOAD_CALENDAR');
+                        assert.strictEqual(key, 'RELOAD_CALENDAR');
                     }
                 }
             };
@@ -510,12 +509,11 @@ describe('menus.js', () =>
 
         test('Should show fail dialog for importing db', () =>
         {
-            expect.assertions(5);
             const mainWindow = {
                 webContents: {
                     send: (key) =>
                     {
-                        expect(key).toBe('RELOAD_CALENDAR');
+                        assert.strictEqual(key, 'RELOAD_CALENDAR');
                     }
                 }
             };
@@ -574,7 +572,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        expect(key).toBe('RELOAD_CALENDAR');
+                        assert.strictEqual(key, 'RELOAD_CALENDAR');
                     }
                 }
             };

--- a/__tests__/__main__/notification.js
+++ b/__tests__/__main__/notification.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 const { createNotification, createLeaveNotification, updateDismiss, getDismiss } = require('../../js/notification.js');
 const { getUserPreferences, savePreferences, resetPreferences } = require('../../js/user-preferences.js');
 const { getDateStr } = require('../../js/date-aux.js');
@@ -33,12 +34,12 @@ describe('Notifications', function()
             }
             else
             {
-                expect(notification.body).toBe('test');
-                expect(notification.title).toBe('Time to Leave');
+                assert.strictEqual(notification.body, 'test');
+                assert.strictEqual(notification.title, 'Time to Leave');
             }
             notification.on('show', (event) =>
             {
-                expect(event).toBeTruthy();
+                assert.notStrictEqual(event, undefined);
                 // In Electron 25 the definition of Event changed and we can no longer
                 // check information about the event sender
                 notification.close();
@@ -73,12 +74,12 @@ describe('Notifications', function()
             }
             else
             {
-                expect(notification.body).toBe('production');
-                expect(notification.title).toBe('Time to Leave');
+                assert.strictEqual(notification.body, 'production');
+                assert.strictEqual(notification.title, 'Time to Leave');
             }
             notification.on('show', (event) =>
             {
-                expect(event).toBeTruthy();
+                assert.notStrictEqual(event, undefined);
                 // In Electron 25 the definition of Event changed and we can no longer
                 // check information about the event sender
                 notification.close();
@@ -111,13 +112,13 @@ describe('Notifications', function()
             preferences['notification'] = false;
             savePreferences(preferences);
             const notify = createLeaveNotification(true);
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should fail when leaveByElement is not found', () =>
         {
             const notify = createLeaveNotification(undefined);
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should fail when notifications have been dismissed', () =>
@@ -126,13 +127,13 @@ describe('Notifications', function()
             const dateToday = getDateStr(now);
             updateDismiss(dateToday);
             const notify = createLeaveNotification(true);
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should fail when time is not valid', () =>
         {
             const notify = createLeaveNotification('33:90');
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should fail when time is in the future', () =>
@@ -141,7 +142,7 @@ describe('Notifications', function()
             const now = new Date();
             now.setMinutes(now.getMinutes() + 1);
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should fail when time is in the past', () =>
@@ -149,7 +150,7 @@ describe('Notifications', function()
             const now = new Date();
             now.setMinutes(now.getMinutes() - 9);
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should fail when repetition is disabled', () =>
@@ -160,61 +161,61 @@ describe('Notifications', function()
             const now = new Date();
             now.setHours(now.getHours() - 1);
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBe(false);
+            assert.strictEqual(notify, false);
         });
 
         test('Should pass when time is correct and dismiss action is pressed', () =>
         {
             const now = new Date();
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBeTruthy();
-            expect(getDismiss()).toBe(null);
-            expect(notify.listenerCount('action')).toBe(1);
-            expect(notify.listenerCount('close')).toBe(1);
-            expect(notify.listenerCount('click')).toBe(1);
+            assert.notStrictEqual(notify, undefined);
+            assert.strictEqual(getDismiss(), null);
+            assert.strictEqual(notify.listenerCount('action'), 1);
+            assert.strictEqual(notify.listenerCount('close'), 1);
+            assert.strictEqual(notify.listenerCount('click'), 1);
             notify.emit('action', 'dismiss');
-            expect(getDismiss()).toBe(getDateStr(now));
+            assert.strictEqual(getDismiss(), getDateStr(now));
         });
 
         test('Should pass when time is correct and other action is pressed', () =>
         {
             const now = new Date();
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBeTruthy();
-            expect(getDismiss()).toBe(null);
-            expect(notify.listenerCount('action')).toBe(1);
-            expect(notify.listenerCount('close')).toBe(1);
-            expect(notify.listenerCount('click')).toBe(1);
+            assert.notStrictEqual(notify, undefined);
+            assert.strictEqual(getDismiss(), null);
+            assert.strictEqual(notify.listenerCount('action'), 1);
+            assert.strictEqual(notify.listenerCount('close'), 1);
+            assert.strictEqual(notify.listenerCount('click'), 1);
             notify.emit('action', '');
-            expect(getDismiss()).toBe(null);
+            assert.strictEqual(getDismiss(), null);
         });
 
         test('Should pass when time is correct and close is pressed', () =>
         {
             const now = new Date();
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBeTruthy();
-            expect(getDismiss()).toBe(null);
-            expect(notify.listenerCount('action')).toBe(1);
-            expect(notify.listenerCount('close')).toBe(1);
-            expect(notify.listenerCount('click')).toBe(1);
+            assert.notStrictEqual(notify, undefined);
+            assert.strictEqual(getDismiss(), null);
+            assert.strictEqual(notify.listenerCount('action'), 1);
+            assert.strictEqual(notify.listenerCount('close'), 1);
+            assert.strictEqual(notify.listenerCount('click'), 1);
             notify.emit('close');
-            expect(getDismiss()).toBe(getDateStr(now));
+            assert.strictEqual(getDismiss(), getDateStr(now));
         });
 
         test('Should pass when time is correct and close is pressed', (done) =>
         {
             jest.spyOn(app, 'emit').mockImplementation((key) =>
             {
-                expect(key).toBe('activate');
+                assert.strictEqual(key, 'activate');
                 done();
             });
             const now = new Date();
             const notify = createLeaveNotification(buildTimeString(now));
-            expect(notify).toBeTruthy();
-            expect(notify.listenerCount('action')).toBe(1);
-            expect(notify.listenerCount('close')).toBe(1);
-            expect(notify.listenerCount('click')).toBe(1);
+            assert.notStrictEqual(notify, undefined);
+            assert.strictEqual(notify.listenerCount('action'), 1);
+            assert.strictEqual(notify.listenerCount('close'), 1);
+            assert.strictEqual(notify.listenerCount('click'), 1);
             notify.emit('click', 'Clicked on notification');
         });
     });

--- a/__tests__/__main__/time-balance.js
+++ b/__tests__/__main__/time-balance.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import Store from 'electron-store';
 import {
     computeAllTimeBalanceUntil,
@@ -23,7 +24,7 @@ describe('Time Balance', () =>
 
     test('getFirstInputInDb: no input', () =>
     {
-        expect(getFirstInputInDb()).toBe('');
+        assert.strictEqual(getFirstInputInDb(), '');
     });
 
     test('getFirstInputInDb: input 1', () =>
@@ -32,7 +33,7 @@ describe('Time Balance', () =>
             '2020-3-1': {'values': ['08:00']}
         };
         flexibleStore.set(entryEx);
-        expect(getFirstInputInDb()).toBe('2020-3-1');
+        assert.strictEqual(getFirstInputInDb(), '2020-3-1');
     });
 
     test('getFirstInputInDb: input 2', () =>
@@ -42,7 +43,7 @@ describe('Time Balance', () =>
             '2020-3-3': {'values': ['08:00']}
         };
         flexibleStore.set(entryEx);
-        expect(getFirstInputInDb()).toBe('2020-3-1');
+        assert.strictEqual(getFirstInputInDb(), '2020-3-1');
     });
 
     test('getFirstInputInDb: input 3', () =>
@@ -53,7 +54,7 @@ describe('Time Balance', () =>
             '2020-2-1': {'values': ['08:00']}
         };
         flexibleStore.set(entryEx);
-        expect(getFirstInputInDb()).toBe('2020-2-1');
+        assert.strictEqual(getFirstInputInDb(), '2020-2-1');
     });
 
     test('getFirstInputInDb: input 4', () =>
@@ -66,7 +67,7 @@ describe('Time Balance', () =>
             '2020-6-10': {'values': ['08:00', '12:00', '13:00', '19:00']}
         };
         flexibleStore.set(entryEx);
-        expect(getFirstInputInDb()).toBe('2020-6-6');
+        assert.strictEqual(getFirstInputInDb(), '2020-6-6');
     });
 
     test('computeAllTimeBalanceUntil: no input', async() =>

--- a/__tests__/__main__/time-math.js
+++ b/__tests__/__main__/time-math.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
+
 import {
     isNegative,
     multiplyTime,
@@ -24,12 +26,12 @@ describe('Time Math Functions', () =>
     {
         test('expect diffDays 22350', () =>
         {
-            expect(diffDays(date1, date2)).toBe(22350);
+            assert.strictEqual(diffDays(date1, date2), 22350);
         });
 
         test('expect diffDays greater than 0', () =>
         {
-            expect(diffDays(date1, date3)).toBeGreaterThan(0);
+            assert.strictEqual(diffDays(date1, date3) > 0, true);
         });
 
     });
@@ -38,12 +40,12 @@ describe('Time Math Functions', () =>
     {
         test('date1 Should not be negative', () =>
         {
-            expect(isNegative(date2)).not.toBeTruthy();
+            assert.notStrictEqual(isNegative(date2), undefined);
         });
 
         test('-date2 Should be negative', () =>
         {
-            expect(isNegative('-' + date2)).toBeTruthy();
+            assert.notStrictEqual(isNegative('-' + date2), undefined);
         });
 
     });
@@ -52,32 +54,32 @@ describe('Time Math Functions', () =>
     {
         test('0 should return 00:00', () =>
         {
-            expect(minutesToHourFormatted(0)).toBe('00:00');
-            expect(minutesToHourFormatted(-0)).toBe('00:00');
+            assert.strictEqual(minutesToHourFormatted(0), '00:00');
+            assert.strictEqual(minutesToHourFormatted(-0), '00:00');
         });
 
         test('1 should return 00:01', () =>
         {
-            expect(minutesToHourFormatted(1)).toBe('00:01');
-            expect(minutesToHourFormatted(-1)).toBe('-00:01');
+            assert.strictEqual(minutesToHourFormatted(1), '00:01');
+            assert.strictEqual(minutesToHourFormatted(-1), '-00:01');
         });
 
         test('59 should return 00:59', () =>
         {
-            expect(minutesToHourFormatted(59)).toBe('00:59');
-            expect(minutesToHourFormatted(-59)).toBe('-00:59');
+            assert.strictEqual(minutesToHourFormatted(59), '00:59');
+            assert.strictEqual(minutesToHourFormatted(-59), '-00:59');
         });
 
         test('60 should return 01:00', () =>
         {
-            expect(minutesToHourFormatted(60)).toBe('01:00');
-            expect(minutesToHourFormatted(-60)).toBe('-01:00');
+            assert.strictEqual(minutesToHourFormatted(60), '01:00');
+            assert.strictEqual(minutesToHourFormatted(-60), '-01:00');
         });
 
         test('61 should return 01:01', () =>
         {
-            expect(minutesToHourFormatted(61)).toBe('01:01');
-            expect(minutesToHourFormatted(-61)).toBe('-01:01');
+            assert.strictEqual(minutesToHourFormatted(61), '01:01');
+            assert.strictEqual(minutesToHourFormatted(-61), '-01:01');
         });
     });
 
@@ -87,29 +89,29 @@ describe('Time Math Functions', () =>
 
         test('00:00 should return 0', () =>
         {
-            expect(hourToMinutes('00:00')).toBe(0);
-            expect(hourToMinutes('-00:00')).toBeLessThan(1);
+            assert.strictEqual(hourToMinutes('00:00'), 0);
+            assert.strictEqual(hourToMinutes('-00:00') < 1, true);
         });
 
         test('01:01 should return 61', () =>
         {
-            expect(hourToMinutes('01:01')).toBe(61);
-            expect(hourToMinutes('-01:01')).toBe(-61);
+            assert.strictEqual(hourToMinutes('01:01'), 61);
+            assert.strictEqual(hourToMinutes('-01:01'), -61);
         });
         test('00:01 should return 1', () =>
         {
-            expect(hourToMinutes('00:01')).toBe(1);
-            expect(hourToMinutes('-00:01')).toBe(-1);
+            assert.strictEqual(hourToMinutes('00:01'), 1);
+            assert.strictEqual(hourToMinutes('-00:01'), -1);
         });
         test('00:59 should return 59', () =>
         {
-            expect(hourToMinutes('00:59')).toBe(59);
-            expect(hourToMinutes('-00:59')).toBe(-59);
+            assert.strictEqual(hourToMinutes('00:59'), 59);
+            assert.strictEqual(hourToMinutes('-00:59'), -59);
         });
         test('01:00 should return 60', () =>
         {
-            expect(hourToMinutes('01:00')).toBe(60);
-            expect(hourToMinutes('-01:00')).toBe(-60);
+            assert.strictEqual(hourToMinutes('01:00'), 60);
+            assert.strictEqual(hourToMinutes('-01:00'), -60);
         });
     });
 
@@ -118,59 +120,59 @@ describe('Time Math Functions', () =>
     {
         test('01:00 * 10 should be 10:00', () =>
         {
-            expect(multiplyTime('01:00', 10)).toBe('10:00');
-            expect(multiplyTime('-01:00', 10)).toBe('-10:00');
-            expect(multiplyTime('01:00', -10)).toBe('-10:00');
+            assert.strictEqual(multiplyTime('01:00', 10), '10:00');
+            assert.strictEqual(multiplyTime('-01:00', 10), '-10:00');
+            assert.strictEqual(multiplyTime('01:00', -10), '-10:00');
         });
 
         test('00:60 * 1 should be 01:00', () =>
         {
-            expect(multiplyTime('00:60', 1)).toBe('01:00');
-            expect(multiplyTime('-00:60', 1)).toBe('-01:00');
-            expect(multiplyTime('00:60', -1)).toBe('-01:00');
+            assert.strictEqual(multiplyTime('00:60', 1), '01:00');
+            assert.strictEqual(multiplyTime('-00:60', 1), '-01:00');
+            assert.strictEqual(multiplyTime('00:60', -1), '-01:00');
         });
     });
 
     // Subtract time
     test('subtractTime(HH:MM, HH:MM)', () =>
     {
-        expect(subtractTime('1:00', '1:00')).toBe('00:00');
-        expect(subtractTime('00:00', '00:00')).toBe('00:00');
-        expect(subtractTime('00:01', '01:00')).toBe('00:59');
-        expect(subtractTime('13:00', '12:00')).toBe('-01:00');
-        expect(subtractTime('48:00', '24:00')).toBe('-24:00');
-        expect(subtractTime('00:01', '12:00')).toBe('11:59');
-        expect(subtractTime('12:00', '13:00')).toBe('01:00');
-        expect(subtractTime('13:00', '00:00')).toBe('-13:00');
+        assert.strictEqual(subtractTime('1:00', '1:00'), '00:00');
+        assert.strictEqual(subtractTime('00:00', '00:00'), '00:00');
+        assert.strictEqual(subtractTime('00:01', '01:00'), '00:59');
+        assert.strictEqual(subtractTime('13:00', '12:00'), '-01:00');
+        assert.strictEqual(subtractTime('48:00', '24:00'), '-24:00');
+        assert.strictEqual(subtractTime('00:01', '12:00'), '11:59');
+        assert.strictEqual(subtractTime('12:00', '13:00'), '01:00');
+        assert.strictEqual(subtractTime('13:00', '00:00'), '-13:00');
     });
 
     // Sum time
     test('sumTime(HH:MM, HH:MM)', () =>
     {
-        expect(sumTime('01:00', '01:00')).toBe('02:00');
-        expect(sumTime('00:00', '00:00')).toBe('00:00');
-        expect(sumTime('00:00', '00:01')).toBe('00:01');
-        expect(sumTime('00:59', '00:01')).toBe('01:00');
-        expect(sumTime('12:00', '12:00')).toBe('24:00');
-        expect(sumTime('12:00', '-12:00')).toBe('00:00');
+        assert.strictEqual(sumTime('01:00', '01:00'), '02:00');
+        assert.strictEqual(sumTime('00:00', '00:00'), '00:00');
+        assert.strictEqual(sumTime('00:00', '00:01'), '00:01');
+        assert.strictEqual(sumTime('00:59', '00:01'), '01:00');
+        assert.strictEqual(sumTime('12:00', '12:00'), '24:00');
+        assert.strictEqual(sumTime('12:00', '-12:00'), '00:00');
     });
 
     // Time Validation
     test('validateTime(HH:MM)', () =>
     {
-        expect(validateTime('00:00')).toBeTruthy();
-        expect(validateTime('00:01')).toBeTruthy();
-        expect(validateTime('00:11')).toBeTruthy();
-        expect(validateTime('01:11')).toBeTruthy();
-        expect(validateTime('11:11')).toBeTruthy();
-        expect(validateTime('23:59')).toBeTruthy();
-        expect(validateTime('-04:00')).toBeTruthy();
-        expect(validateTime('24:00')).not.toBeTruthy();
-        expect(validateTime('34:00')).not.toBeTruthy();
-        expect(validateTime('4:00')).not.toBeTruthy();
-        expect(validateTime('00:1')).not.toBeTruthy();
-        expect(validateTime('--:--')).not.toBeTruthy();
-        expect(validateTime('')).not.toBeTruthy();
+        assert.notStrictEqual(validateTime('00:00'), undefined);
+        assert.notStrictEqual(validateTime('00:01'), undefined);
+        assert.notStrictEqual(validateTime('00:11'), undefined);
+        assert.notStrictEqual(validateTime('01:11'), undefined);
+        assert.notStrictEqual(validateTime('11:11'), undefined);
+        assert.notStrictEqual(validateTime('23:59'), undefined);
+        assert.notStrictEqual(validateTime('-04:00'), undefined);
+        assert.notStrictEqual(validateTime('24:00'), undefined);
+        assert.notStrictEqual(validateTime('34:00'), undefined);
+        assert.notStrictEqual(validateTime('4:00'), undefined);
+        assert.notStrictEqual(validateTime('00:1'), undefined);
+        assert.notStrictEqual(validateTime('--:--'), undefined);
+        assert.notStrictEqual(validateTime(''), undefined);
     });
 
     test('validateDate(date)', () =>
@@ -213,7 +215,7 @@ describe('Time Math Functions', () =>
         ];
         for (const test of tests)
         {
-            expect(validateDate(test.date)).toBe(test.valid);
+            assert.strictEqual(validateDate(test.date), test.valid);
         }
     });
 });

--- a/__tests__/__main__/time-math.js
+++ b/__tests__/__main__/time-math.js
@@ -40,12 +40,12 @@ describe('Time Math Functions', () =>
     {
         test('date1 Should not be negative', () =>
         {
-            assert.notStrictEqual(isNegative(date2), undefined);
+            assert.strictEqual(isNegative(date2), false);
         });
 
         test('-date2 Should be negative', () =>
         {
-            assert.notStrictEqual(isNegative('-' + date2), undefined);
+            assert.strictEqual(isNegative('-' + date2), true);
         });
 
     });
@@ -160,34 +160,34 @@ describe('Time Math Functions', () =>
     // Time Validation
     test('validateTime(HH:MM)', () =>
     {
-        assert.notStrictEqual(validateTime('00:00'), undefined);
-        assert.notStrictEqual(validateTime('00:01'), undefined);
-        assert.notStrictEqual(validateTime('00:11'), undefined);
-        assert.notStrictEqual(validateTime('01:11'), undefined);
-        assert.notStrictEqual(validateTime('11:11'), undefined);
-        assert.notStrictEqual(validateTime('23:59'), undefined);
-        assert.notStrictEqual(validateTime('-04:00'), undefined);
-        assert.notStrictEqual(validateTime('24:00'), undefined);
-        assert.notStrictEqual(validateTime('34:00'), undefined);
-        assert.notStrictEqual(validateTime('4:00'), undefined);
-        assert.notStrictEqual(validateTime('00:1'), undefined);
-        assert.notStrictEqual(validateTime('--:--'), undefined);
-        assert.notStrictEqual(validateTime(''), undefined);
+        assert.strictEqual(validateTime('00:00'), true);
+        assert.strictEqual(validateTime('00:01'), true);
+        assert.strictEqual(validateTime('00:11'), true);
+        assert.strictEqual(validateTime('01:11'), true);
+        assert.strictEqual(validateTime('11:11'), true);
+        assert.strictEqual(validateTime('23:59'), true);
+        assert.strictEqual(validateTime('-04:00'), true);
+        assert.strictEqual(validateTime('24:00'), false);
+        assert.strictEqual(validateTime('34:00'), false);
+        assert.strictEqual(validateTime('4:00'), false);
+        assert.strictEqual(validateTime('00:1'), false);
+        assert.strictEqual(validateTime('--:--'), false);
+        assert.strictEqual(validateTime(''), false);
     });
 
     test('validateDate(date)', () =>
     {
         const tests = [
-            {date: '0001-00-00',valid: false},
-            {date: '1-00-00',valid: false},
-            {date: '1996-13-00',valid: false},
-            {date: '1996-1-00',valid: false},
-            {date: '1996-01-1',valid: false},
-            {date: '1996-01-40',valid: false},
-            {date: '1996-01-31',valid: false},
-            {date: 'I\'m a date!',valid: false},
-            {date: '1996-01-29',valid: true},
-            {date: '1996-01-30',valid: false},
+            {date: '0001-00-00', valid: false},
+            {date: '1-00-00', valid: false},
+            {date: '1996-13-00', valid: false},
+            {date: '1996-1-00', valid: false},
+            {date: '1996-01-1', valid: false},
+            {date: '1996-01-40', valid: false},
+            {date: '1996-01-31', valid: false},
+            {date: 'I\'m a date!', valid: false},
+            {date: '1996-01-29', valid: true},
+            {date: '1996-01-30', valid: false},
             {date: '1996-00-01', valid: true},
             {date: '1996-01-01', valid: true},
             {date: '1996-02-01', valid: true},

--- a/__tests__/__main__/update-manager.js
+++ b/__tests__/__main__/update-manager.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 import Store from 'electron-store';
 const { getDateStr } = require('../../js/date-aux');
 const {shouldCheckForUpdates, checkForUpdates} = require('../../js/update-manager');
@@ -30,7 +31,7 @@ describe('js/update-manager.js', () =>
         {
             const store = new Store();
             store.set('update-remind-me-after', false);
-            expect(shouldCheckForUpdates()).toBe(true);
+            assert.strictEqual(shouldCheckForUpdates(), true);
         });
 
         test('Should return true when was checked before today', () =>
@@ -39,7 +40,7 @@ describe('js/update-manager.js', () =>
             now.setDate(now.getDate() - 1);
             const store = new Store();
             store.set('update-remind-me-after', getDateStr(now));
-            expect(shouldCheckForUpdates()).toBe(true);
+            assert.strictEqual(shouldCheckForUpdates(), true);
         });
 
         test('Should return false when was checked today', () =>
@@ -47,7 +48,7 @@ describe('js/update-manager.js', () =>
             const now = new Date();
             const store = new Store();
             store.set('update-remind-me-after', getDateStr(now));
-            expect(shouldCheckForUpdates()).toBe(false);
+            assert.strictEqual(shouldCheckForUpdates(), false);
         });
     });
 

--- a/__tests__/__main__/user-preferences.js
+++ b/__tests__/__main__/user-preferences.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 const { booleanInputs, defaultPreferences, getDefaultWidthHeight, getPreferencesFilePath, getUserPreferences, savePreferences, showDay, switchCalendarView, notificationIsEnabled, getUserLanguage, getNotificationsInterval, repetitionIsEnabled, getUserPreferencesPromise, resetPreferences } = require('../../js/user-preferences');
 import fs from 'fs';
 const { themeOptions } = require('../../renderer/themes');
@@ -41,14 +42,14 @@ describe('Preferences Main', () =>
 
     test('showDay(year, month, day)', () =>
     {
-        expect(showDay(2020, 1, 1)).toBe(days['working-days-saturday']);
-        expect(showDay(2020, 1, 2)).toBe(days['working-days-sunday']);
-        expect(showDay(2020, 1, 3)).toBe(days['working-days-monday']);
-        expect(showDay(2020, 1, 4)).toBe(days['working-days-tuesday']);
-        expect(showDay(2020, 1, 5)).toBe(days['working-days-wednesday']);
-        expect(showDay(2020, 1, 6)).toBe(days['working-days-thursday']);
-        expect(showDay(2020, 1, 7)).toBe(days['working-days-friday']);
-        expect(showDay(2020, 1, 7, defaultPreferences)).toBe(days['working-days-friday']);
+        assert.strictEqual(showDay(2020, 1, 1), days['working-days-saturday']);
+        assert.strictEqual(showDay(2020, 1, 2), days['working-days-sunday']);
+        assert.strictEqual(showDay(2020, 1, 3), days['working-days-monday']);
+        assert.strictEqual(showDay(2020, 1, 4), days['working-days-tuesday']);
+        assert.strictEqual(showDay(2020, 1, 5), days['working-days-wednesday']);
+        assert.strictEqual(showDay(2020, 1, 6), days['working-days-thursday']);
+        assert.strictEqual(showDay(2020, 1, 7), days['working-days-friday']);
+        assert.strictEqual(showDay(2020, 1, 7, defaultPreferences), days['working-days-friday']);
     });
 
     describe('getDefaultWidthHeight()', () =>
@@ -56,7 +57,7 @@ describe('Preferences Main', () =>
 
         test('Month view', () =>
         {
-            expect(defaultPreferences['view']).toBe('month');
+            assert.strictEqual(defaultPreferences['view'], 'month');
             savePreferences(defaultPreferences);
 
             expect(getDefaultWidthHeight()).toStrictEqual({ width: 1010, height: 800 });
@@ -78,14 +79,14 @@ describe('Preferences Main', () =>
 
         test('Month to Day', () =>
         {
-            expect(defaultPreferences['view']).toBe('month');
+            assert.strictEqual(defaultPreferences['view'], 'month');
             savePreferences(defaultPreferences);
 
-            expect(getUserPreferences()['view']).toBe('month');
+            assert.strictEqual(getUserPreferences()['view'], 'month');
             switchCalendarView();
 
             const preferences = getUserPreferences();
-            expect(preferences['view']).toBe('day');
+            assert.strictEqual(preferences['view'], 'day');
         });
 
         test('Day to Month', () =>
@@ -95,11 +96,11 @@ describe('Preferences Main', () =>
             preferences['view'] = 'day';
             savePreferences(preferences);
 
-            expect(getUserPreferences()['view']).toBe('day');
+            assert.strictEqual(getUserPreferences()['view'], 'day');
             switchCalendarView();
 
             preferences = getUserPreferences();
-            expect(preferences['view']).toBe('month');
+            assert.strictEqual(preferences['view'], 'month');
         });
     });
 
@@ -107,32 +108,32 @@ describe('Preferences Main', () =>
     {
         beforeEach(() =>
         {
-            expect(defaultPreferences['notifications-interval']).toBe('5');
+            assert.strictEqual(defaultPreferences['notifications-interval'], '5');
             savePreferences(defaultPreferences);
 
-            expect(getUserPreferences()['notifications-interval']).toBe('5');
-            expect(getNotificationsInterval()).toBe('5');
+            assert.strictEqual(getUserPreferences()['notifications-interval'], '5');
+            assert.strictEqual(getNotificationsInterval(), '5');
         });
 
         test('Saving valid number as notifications-interval', () =>
         {
             setNewPreference('notifications-interval', '6');
-            expect(getUserPreferences()['notifications-interval']).toBe('6');
-            expect(getNotificationsInterval()).toBe('6');
+            assert.strictEqual(getUserPreferences()['notifications-interval'], '6');
+            assert.strictEqual(getNotificationsInterval(), '6');
         });
 
         test('Saving invalid number as notifications-interval', () =>
         {
             setNewPreference('notifications-interval', '0');
-            expect(getUserPreferences()['notifications-interval']).toBe('5');
-            expect(getNotificationsInterval()).toBe('5');
+            assert.strictEqual(getUserPreferences()['notifications-interval'], '5');
+            assert.strictEqual(getNotificationsInterval(), '5');
         });
 
         test('Saving invalid text as notifications-interval', () =>
         {
             setNewPreference('notifications-interval', 'ab');
-            expect(getUserPreferences()['notifications-interval']).toBe('5');
-            expect(getNotificationsInterval()).toBe('5');
+            assert.strictEqual(getUserPreferences()['notifications-interval'], '5');
+            assert.strictEqual(getNotificationsInterval(), '5');
         });
     });
 
@@ -141,22 +142,22 @@ describe('Preferences Main', () =>
         test('Saving valid language', () =>
         {
             setNewPreference('language', 'es');
-            expect(getUserPreferences()['language']).toBe('es');
-            expect(getUserLanguage()).toBe('es');
+            assert.strictEqual(getUserPreferences()['language'], 'es');
+            assert.strictEqual(getUserLanguage(), 'es');
         });
 
         test('Saving invalid number as language', () =>
         {
             setNewPreference('language', 5);
-            expect(getUserPreferences()['language']).toBe('en');
-            expect(getUserLanguage()).toBe('en');
+            assert.strictEqual(getUserPreferences()['language'], 'en');
+            assert.strictEqual(getUserLanguage(), 'en');
         });
 
         test('Saving invalid string language', () =>
         {
             setNewPreference('language', 'es-AR');
-            expect(getUserPreferences()['language']).toBe('en');
-            expect(getUserLanguage()).toBe('en');
+            assert.strictEqual(getUserPreferences()['language'], 'en');
+            assert.strictEqual(getUserLanguage(), 'en');
         });
 
     });
@@ -166,19 +167,19 @@ describe('Preferences Main', () =>
         test('Saving invalid string as notification preference', () =>
         {
             setNewPreference('notification', 'true');
-            expect(notificationIsEnabled()).toBe(true);
+            assert.strictEqual(notificationIsEnabled(), true);
         });
 
         test('Saving invalid number as notification preference', () =>
         {
             setNewPreference('notification', 8);
-            expect(notificationIsEnabled()).toBe(true);
+            assert.strictEqual(notificationIsEnabled(), true);
         });
 
         test('Saving valid boolean as notification preference', () =>
         {
             setNewPreference('notification', false);
-            expect(notificationIsEnabled()).toBe(false);
+            assert.strictEqual(notificationIsEnabled(), false);
         });
     });
 
@@ -187,19 +188,19 @@ describe('Preferences Main', () =>
         test('Saving invalid string as repetition preference', () =>
         {
             setNewPreference('repetition', 'true');
-            expect(repetitionIsEnabled()).toBe(true);
+            assert.strictEqual(repetitionIsEnabled(), true);
         });
 
         test('Saving invalid number as repetition preference', () =>
         {
             setNewPreference('repetition', 15);
-            expect(repetitionIsEnabled()).toBe(true);
+            assert.strictEqual(repetitionIsEnabled(), true);
         });
 
         test('Saving valid boolean as repetition preference', () =>
         {
             setNewPreference('repetition', false);
-            expect(repetitionIsEnabled()).toBe(false);
+            assert.strictEqual(repetitionIsEnabled(), false);
         });
     });
 
@@ -215,25 +216,25 @@ describe('Preferences Main', () =>
             test(`Saving invalid string as ${pref} preference`, () =>
             {
                 setNewPreference(pref, 'true');
-                expect(getUserPreferences()[pref]).toBe(defaultPreferences[pref]);
+                assert.strictEqual(getUserPreferences()[pref], defaultPreferences[pref]);
             });
 
             test(`Saving invalid number as ${pref} preference`, () =>
             {
                 setNewPreference(pref, 20);
-                expect(getUserPreferences()[pref]).toBe(defaultPreferences[pref]);
+                assert.strictEqual(getUserPreferences()[pref], defaultPreferences[pref]);
             });
 
             test(`Saving valid boolean as ${pref} preference`, () =>
             {
                 setNewPreference(pref, false);
-                expect(getUserPreferences()[pref]).toBe(false);
+                assert.strictEqual(getUserPreferences()[pref], false);
             });
 
             test(`Saving valid boolean as ${pref} preference`, () =>
             {
                 setNewPreference(pref, true);
-                expect(getUserPreferences()[pref]).toBe(true);
+                assert.strictEqual(getUserPreferences()[pref], true);
             });
         }
     });
@@ -245,20 +246,20 @@ describe('Preferences Main', () =>
             test(`Saving valid theme ${theme}`, () =>
             {
                 setNewPreference('theme', theme);
-                expect(getUserPreferences()['theme']).toBe(theme);
+                assert.strictEqual(getUserPreferences()['theme'], theme);
             });
         }
 
         test('Saving invalid string as theme', () =>
         {
             setNewPreference('theme', 'DARKKKK');
-            expect(getUserPreferences()['theme']).toBe(defaultPreferences.theme);
+            assert.strictEqual(getUserPreferences()['theme'], defaultPreferences.theme);
         });
 
         test('Saving invalid number as theme', () =>
         {
             setNewPreference('theme', 5);
-            expect(getUserPreferences()['theme']).toBe(defaultPreferences.theme);
+            assert.strictEqual(getUserPreferences()['theme'], defaultPreferences.theme);
         });
     });
     describe('Hours Per Day', () =>
@@ -266,37 +267,37 @@ describe('Preferences Main', () =>
         test('Saving invalid number as hours per day', () =>
         {
             setNewPreference('hours-per-day', 1223);
-            expect(getUserPreferences()['hours-per-day']).toBe(defaultPreferences['hours-per-day']);
+            assert.strictEqual(getUserPreferences()['hours-per-day'], defaultPreferences['hours-per-day']);
         });
 
         test('Saving invalid amount of hours per day', () =>
         {
             setNewPreference('hours-per-day', '30:00');
-            expect(getUserPreferences()['hours-per-day']).toBe(defaultPreferences['hours-per-day']);
+            assert.strictEqual(getUserPreferences()['hours-per-day'], defaultPreferences['hours-per-day']);
         });
 
         test('Saving invalid minutes in hours per day', () =>
         {
             setNewPreference('hours-per-day', '20:99');
-            expect(getUserPreferences()['hours-per-day']).toBe(defaultPreferences['hours-per-day']);
+            assert.strictEqual(getUserPreferences()['hours-per-day'], defaultPreferences['hours-per-day']);
         });
 
         test('Saving invalid boolean as hours per day', () =>
         {
             setNewPreference('hours-per-day', true);
-            expect(getUserPreferences()['hours-per-day']).toBe(defaultPreferences['hours-per-day']);
+            assert.strictEqual(getUserPreferences()['hours-per-day'], defaultPreferences['hours-per-day']);
         });
 
         test('Saving valid hours per day', () =>
         {
             setNewPreference('hours-per-day', '06:00');
-            expect(getUserPreferences()['hours-per-day']).toBe('06:00');
+            assert.strictEqual(getUserPreferences()['hours-per-day'], '06:00');
         });
 
         test('Saving valid hours per day', () =>
         {
             setNewPreference('hours-per-day', '01:30');
-            expect(getUserPreferences()['hours-per-day']).toBe('01:30');
+            assert.strictEqual(getUserPreferences()['hours-per-day'], '01:30');
         });
     });
     describe('Break Time Interval', () =>
@@ -304,37 +305,37 @@ describe('Preferences Main', () =>
         test('Saving invalid number as break-time-interval', () =>
         {
             setNewPreference('break-time-interval', 1223);
-            expect(getUserPreferences()['break-time-interval']).toBe(defaultPreferences['break-time-interval']);
+            assert.strictEqual(getUserPreferences()['break-time-interval'], defaultPreferences['break-time-interval']);
         });
 
         test('Saving invalid hours in break-time-interval', () =>
         {
             setNewPreference('break-time-interval', '30:00');
-            expect(getUserPreferences()['break-time-interval']).toBe(defaultPreferences['break-time-interval']);
+            assert.strictEqual(getUserPreferences()['break-time-interval'], defaultPreferences['break-time-interval']);
         });
 
         test('Saving invalid mintes in break-time-interval', () =>
         {
             setNewPreference('break-time-interval', '20:99');
-            expect(getUserPreferences()['break-time-interval']).toBe(defaultPreferences['break-time-interval']);
+            assert.strictEqual(getUserPreferences()['break-time-interval'], defaultPreferences['break-time-interval']);
         });
 
         test('Saving invalid boolean as break-time-interval', () =>
         {
             setNewPreference('break-time-interval', true);
-            expect(getUserPreferences()['break-time-interval']).toBe(defaultPreferences['break-time-interval']);
+            assert.strictEqual(getUserPreferences()['break-time-interval'], defaultPreferences['break-time-interval']);
         });
 
         test('Saving valid break-time-interval', () =>
         {
             setNewPreference('break-time-interval', '00:30');
-            expect(getUserPreferences()['break-time-interval']).toBe('00:30');
+            assert.strictEqual(getUserPreferences()['break-time-interval'], '00:30');
         });
 
         test('Saving valid break-time-interval', () =>
         {
             setNewPreference('break-time-interval', '00:15');
-            expect(getUserPreferences()['break-time-interval']).toBe('00:15');
+            assert.strictEqual(getUserPreferences()['break-time-interval'], '00:15');
         });
     });
     describe('Overall balance start date', () =>
@@ -342,19 +343,19 @@ describe('Preferences Main', () =>
         test('Saving invalid month in overall-balance-start-date', () =>
         {
             setNewPreference( 'overall-balance-start-date', '2022-13-01');
-            expect(getUserPreferences()['overall-balance-start-date']).toBe(defaultPreferences['overall-balance-start-date']);
+            assert.strictEqual(getUserPreferences()['overall-balance-start-date'], defaultPreferences['overall-balance-start-date']);
         });
 
         test('Saving invalid day in overall-balance-start-date', () =>
         {
             setNewPreference( 'overall-balance-start-date', '2022-10-32');
-            expect(getUserPreferences()['overall-balance-start-date']).toBe(defaultPreferences['overall-balance-start-date']);
+            assert.strictEqual(getUserPreferences()['overall-balance-start-date'], defaultPreferences['overall-balance-start-date']);
         });
 
         test('Saving valid date', () =>
         {
             setNewPreference( 'overall-balance-start-date', '2022-10-02');
-            expect(getUserPreferences()['overall-balance-start-date']).toBe('2022-10-02');
+            assert.strictEqual(getUserPreferences()['overall-balance-start-date'], '2022-10-02');
         });
     });
     describe('Update remind me after', () =>
@@ -362,37 +363,37 @@ describe('Preferences Main', () =>
         test('Saving invalid numner as update-remind-me-after', () =>
         {
             setNewPreference( 'update-remind-me-after', new Date('2022-13-01').getTime());
-            expect(getUserPreferences()['update-remind-me-after']).toBe(defaultPreferences['update-remind-me-after']);
+            assert.strictEqual(getUserPreferences()['update-remind-me-after'], defaultPreferences['update-remind-me-after']);
         });
 
         test('Saving invalid month in update-remind-me-after', () =>
         {
             setNewPreference( 'update-remind-me-after', '2022-13-01');
-            expect(getUserPreferences()['update-remind-me-after']).toBe(defaultPreferences['update-remind-me-after']);
+            assert.strictEqual(getUserPreferences()['update-remind-me-after'], defaultPreferences['update-remind-me-after']);
         });
 
         test('Saving invalid date in update-remind-me-after', () =>
         {
             setNewPreference( 'update-remind-me-after', '2022-10-32');
-            expect(getUserPreferences()['update-remind-me-after']).toBe(defaultPreferences['update-remind-me-after']);
+            assert.strictEqual(getUserPreferences()['update-remind-me-after'], defaultPreferences['update-remind-me-after']);
         });
 
         test('Saving valid date', () =>
         {
             setNewPreference( 'update-remind-me-after', '2022-10-02');
-            expect(getUserPreferences()['update-remind-me-after']).toBe('2022-10-02');
+            assert.strictEqual(getUserPreferences()['update-remind-me-after'], '2022-10-02');
         });
     });
     describe('savePreferences()', () =>
     {
         test('Save to wrong path', () =>
         {
-            expect(savePreferences(defaultPreferences, './not/existing/folder')).toBeInstanceOf(Error);
+            assert.strictEqual(savePreferences(defaultPreferences, './not/existing/folder') instanceof Error, true);
         });
 
         test('Save to default path', () =>
         {
-            expect(savePreferences(defaultPreferences)).toBe(true);
+            assert.strictEqual(savePreferences(defaultPreferences), true);
         });
     });
     describe('resetPreferences()', () =>
@@ -433,7 +434,7 @@ describe('Preferences Main', () =>
 
         test('Should return a promise', () =>
         {
-            expect(getUserPreferencesPromise()).toBeInstanceOf(Promise);
+            assert.strictEqual(getUserPreferencesPromise() instanceof Promise, true);
         });
 
         test('Should resolve promise', async() =>
@@ -451,7 +452,7 @@ describe('Preferences Main', () =>
     {
         test('getLanguageMap() should have language code keys', () =>
         {
-            expect(Object.keys(getLanguageMap()).length).toBeGreaterThan(0);
+            assert.strictEqual(Object.keys(getLanguageMap()).length > 0, true);
         });
 
         test('getLanguageMap() keys should be sorted', () =>
@@ -462,11 +463,11 @@ describe('Preferences Main', () =>
                 if (lastLanguage === '') lastLanguage = language;
                 else
                 {
-                    expect(language.localeCompare(lastLanguage)).toBeGreaterThan(0);
+                    assert.strictEqual(language.localeCompare(lastLanguage) > 0, true);
                     lastLanguage = language;
                 }
             });
-            expect(lastLanguage).not.toBe('');
+            assert.notStrictEqual(lastLanguage, '');
 
         });
 
@@ -477,33 +478,33 @@ describe('Preferences Main', () =>
 
         test('getLanguageName() should return correct language', () =>
         {
-            expect(getLanguageName('bn')).toBe('বাংলা');
-            expect(getLanguageName('ca')).toBe('Catalàn');
-            expect(getLanguageName('de-DE')).toBe('Deutsch');
-            expect(getLanguageName('el')).toBe('Ελληνικά');
-            expect(getLanguageName('en')).toBe('English');
-            expect(getLanguageName('es')).toBe('Español');
-            expect(getLanguageName('fr-FR')).toBe('Français - France');
-            expect(getLanguageName('gu')).toBe('ગુજરાતી');
-            expect(getLanguageName('he')).toBe('עברית');
-            expect(getLanguageName('hi')).toBe('हिंदी');
-            expect(getLanguageName('id')).toBe('Bahasa Indonesia');
-            expect(getLanguageName('it')).toBe('Italiano');
-            expect(getLanguageName('ja')).toBe('日本語');
-            expect(getLanguageName('ko')).toBe('한국어');
-            expect(getLanguageName('mr')).toBe('मराठी');
-            expect(getLanguageName('nl')).toBe('Nederlands');
-            expect(getLanguageName('pl')).toBe('Polski');
-            expect(getLanguageName('pt-BR')).toBe('Português - Brasil');
-            expect(getLanguageName('pt-MI')).toBe('Português - Minerês');
-            expect(getLanguageName('pt-PT')).toBe('Português - Portugal');
-            expect(getLanguageName('ru-RU')).toBe('Русский');
-            expect(getLanguageName('sv-SE')).toBe('Svenska');
-            expect(getLanguageName('ta')).toBe('தமிழ்');
-            expect(getLanguageName('th-TH')).toBe('ไทย');
-            expect(getLanguageName('tr-TR')).toBe('Türkçe');
-            expect(getLanguageName('uk-UA')).toBe('Українська');
-            expect(getLanguageName('zh-TW')).toBe('繁體中文');
+            assert.strictEqual(getLanguageName('bn'), 'বাংলা');
+            assert.strictEqual(getLanguageName('ca'), 'Catalàn');
+            assert.strictEqual(getLanguageName('de-DE'), 'Deutsch');
+            assert.strictEqual(getLanguageName('el'), 'Ελληνικά');
+            assert.strictEqual(getLanguageName('en'), 'English');
+            assert.strictEqual(getLanguageName('es'), 'Español');
+            assert.strictEqual(getLanguageName('fr-FR'), 'Français - France');
+            assert.strictEqual(getLanguageName('gu'), 'ગુજરાતી');
+            assert.strictEqual(getLanguageName('he'), 'עברית');
+            assert.strictEqual(getLanguageName('hi'), 'हिंदी');
+            assert.strictEqual(getLanguageName('id'), 'Bahasa Indonesia');
+            assert.strictEqual(getLanguageName('it'), 'Italiano');
+            assert.strictEqual(getLanguageName('ja'), '日本語');
+            assert.strictEqual(getLanguageName('ko'), '한국어');
+            assert.strictEqual(getLanguageName('mr'), 'मराठी');
+            assert.strictEqual(getLanguageName('nl'), 'Nederlands');
+            assert.strictEqual(getLanguageName('pl'), 'Polski');
+            assert.strictEqual(getLanguageName('pt-BR'), 'Português - Brasil');
+            assert.strictEqual(getLanguageName('pt-MI'), 'Português - Minerês');
+            assert.strictEqual(getLanguageName('pt-PT'), 'Português - Portugal');
+            assert.strictEqual(getLanguageName('ru-RU'), 'Русский');
+            assert.strictEqual(getLanguageName('sv-SE'), 'Svenska');
+            assert.strictEqual(getLanguageName('ta'), 'தமிழ்');
+            assert.strictEqual(getLanguageName('th-TH'), 'ไทย');
+            assert.strictEqual(getLanguageName('tr-TR'), 'Türkçe');
+            assert.strictEqual(getLanguageName('uk-UA'), 'Українська');
+            assert.strictEqual(getLanguageName('zh-TW'), '繁體中文');
         });
     });
 

--- a/__tests__/__main__/validate-json.js
+++ b/__tests__/__main__/validate-json.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import { validateJSON } from '../../js/validate-json.js';
 
 describe('Validate json', function()
@@ -17,13 +18,13 @@ describe('Validate json', function()
 
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validWaivedType)).toBeTruthy();
-                expect(validateJSON(validFlexibleType)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validWaivedType), undefined);
+                assert.notStrictEqual(validateJSON(validFlexibleType), undefined);
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidTypeValue)).not.toBeTruthy();
-                expect(validateJSON(invalidTypeType)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidTypeValue), undefined);
+                assert.notStrictEqual(validateJSON(invalidTypeType), undefined);
             });
         });
 
@@ -35,10 +36,10 @@ describe('Validate json', function()
             const validWaivedDate2 = [{ 'type': 'waived', 'date': '2020-6-3', 'data': 'waived', 'hours': '08:00' }];
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validFlexibleDate1)).toBeTruthy();
-                expect(validateJSON(validFlexibleDate2)).toBeTruthy();
-                expect(validateJSON(validWaivedDate1)).toBeTruthy();
-                expect(validateJSON(validWaivedDate2)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validFlexibleDate1), undefined);
+                assert.notStrictEqual(validateJSON(validFlexibleDate2), undefined);
+                assert.notStrictEqual(validateJSON(validWaivedDate1), undefined);
+                assert.notStrictEqual(validateJSON(validWaivedDate2), undefined);
             });
         });
 
@@ -52,15 +53,15 @@ describe('Validate json', function()
             const invalidDayInMonth = [{ 'type': 'flexible', 'date': '2020-04-31', 'values': ['08:00', '12:00', '13:00', '14:00'] }];
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validWaivedDate)).toBeTruthy();
-                expect(validateJSON(validFlexibleDate)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validWaivedDate), undefined);
+                assert.notStrictEqual(validateJSON(validFlexibleDate), undefined);
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidDateFormat)).not.toBeTruthy();
-                expect(validateJSON(invalidDateType)).not.toBeTruthy();
-                expect(validateJSON(invalidDateValue)).not.toBeTruthy();
-                expect(validateJSON(invalidDayInMonth)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidDateFormat), undefined);
+                assert.notStrictEqual(validateJSON(invalidDateType), undefined);
+                assert.notStrictEqual(validateJSON(invalidDateValue), undefined);
+                assert.notStrictEqual(validateJSON(invalidDayInMonth), undefined);
             });
         });
 
@@ -70,11 +71,11 @@ describe('Validate json', function()
             const invalidDataType = [{ 'type': 'waived', 'date': '2020-06-03', 'data': ['waived'], 'hours': '08:00' }];
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validData)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validData), undefined);
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidDataType)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidDataType), undefined);
             });
         });
 
@@ -88,15 +89,15 @@ describe('Validate json', function()
             const invalidHoursValueNegative = [{ 'type': 'waived', 'date': '2020-06-03', 'data': 'waived', 'hours': '-01:00' }];
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validHours)).toBeTruthy();
-                expect(validateJSON(validHours2)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validHours), undefined);
+                assert.notStrictEqual(validateJSON(validHours2), undefined);
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidHoursFormat)).not.toBeTruthy();
-                expect(validateJSON(invalidHoursType)).not.toBeTruthy();
-                expect(validateJSON(invalidHoursValue)).not.toBeTruthy();
-                expect(validateJSON(invalidHoursValueNegative)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidHoursFormat), undefined);
+                assert.notStrictEqual(validateJSON(invalidHoursType), undefined);
+                assert.notStrictEqual(validateJSON(invalidHoursValue), undefined);
+                assert.notStrictEqual(validateJSON(invalidHoursValueNegative), undefined);
             });
         });
 
@@ -112,17 +113,17 @@ describe('Validate json', function()
             const invalidPointsInTime = [{ 'type': 'flexible', 'date': '2020-02-01', 'values': ['08:00', '07:00', '13:00', '14:00'] }];
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validValues)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validValues), undefined);
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidValuesFormat1)).not.toBeTruthy();
-                expect(validateJSON(invalidValuesFormat2)).not.toBeTruthy();
-                expect(validateJSON(invalidValuesFormat3)).not.toBeTruthy();
-                expect(validateJSON(invalidValuesFormat4)).not.toBeTruthy();
-                expect(validateJSON(invalidValuesType)).not.toBeTruthy();
-                expect(validateJSON(invalidValuesValue)).not.toBeTruthy();
-                expect(validateJSON(invalidPointsInTime)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidValuesFormat1), undefined);
+                assert.notStrictEqual(validateJSON(invalidValuesFormat2), undefined);
+                assert.notStrictEqual(validateJSON(invalidValuesFormat3), undefined);
+                assert.notStrictEqual(validateJSON(invalidValuesFormat4), undefined);
+                assert.notStrictEqual(validateJSON(invalidValuesType), undefined);
+                assert.notStrictEqual(validateJSON(invalidValuesValue), undefined);
+                assert.notStrictEqual(validateJSON(invalidPointsInTime), undefined);
             });
         });
 
@@ -136,18 +137,18 @@ describe('Validate json', function()
                 for (let i = 1; i <= 9; i++)
                 {
                     const firstNineDays = [{ 'type': 'flexible', 'date': `2020-12-0${i}`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    expect(validateJSON(firstNineDays)).toBeTruthy();
+                    assert.notStrictEqual(validateJSON(firstNineDays), undefined);
                 }
                 for (let i = 10; i <= 31; i++)
                 {
                     const restDays = [{ 'type': 'flexible', 'date': `2020-12-${i}`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    expect(validateJSON(restDays)).toBeTruthy();
+                    assert.notStrictEqual(validateJSON(restDays), undefined);
                 }
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidDay)).not.toBeTruthy();
-                expect(validateJSON(invalidDay2)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidDay), undefined);
+                assert.notStrictEqual(validateJSON(invalidDay2), undefined);
             });
         });
 
@@ -161,18 +162,18 @@ describe('Validate json', function()
                 for (let i = 1; i <= 9; i++)
                 {
                     const firstNineMonths = [{ 'type': 'flexible', 'date': `2020-0${i}-13`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    expect(validateJSON(firstNineMonths)).toBeTruthy();
+                    assert.notStrictEqual(validateJSON(firstNineMonths), undefined);
                 }
                 for (let i = 10; i <= 12; i++)
                 {
                     const restMonths = [{ 'type': 'flexible', 'date': `2020-${i}-13`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    expect(validateJSON(restMonths)).toBeTruthy();
+                    assert.notStrictEqual(validateJSON(restMonths), undefined);
                 }
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidMonth)).not.toBeTruthy();
-                expect(validateJSON(invalidMonth2)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidMonth), undefined);
+                assert.notStrictEqual(validateJSON(invalidMonth2), undefined);
             });
         });
 
@@ -183,12 +184,12 @@ describe('Validate json', function()
 
             test('should be valid JSON', () =>
             {
-                expect(validateJSON(validLeapYear)).toBeTruthy();
+                assert.notStrictEqual(validateJSON(validLeapYear), undefined);
 
             });
             test('should not be valid JSON', () =>
             {
-                expect(validateJSON(invalidLeapYear)).not.toBeTruthy();
+                assert.notStrictEqual(validateJSON(invalidLeapYear), undefined);
             });
         });
     });

--- a/__tests__/__main__/validate-json.js
+++ b/__tests__/__main__/validate-json.js
@@ -18,13 +18,13 @@ describe('Validate json', function()
 
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validWaivedType), undefined);
-                assert.notStrictEqual(validateJSON(validFlexibleType), undefined);
+                assert.strictEqual(validateJSON(validWaivedType), true);
+                assert.strictEqual(validateJSON(validFlexibleType), true);
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidTypeValue), undefined);
-                assert.notStrictEqual(validateJSON(invalidTypeType), undefined);
+                assert.strictEqual(validateJSON(invalidTypeValue), false);
+                assert.strictEqual(validateJSON(invalidTypeType), false);
             });
         });
 
@@ -36,10 +36,10 @@ describe('Validate json', function()
             const validWaivedDate2 = [{ 'type': 'waived', 'date': '2020-6-3', 'data': 'waived', 'hours': '08:00' }];
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validFlexibleDate1), undefined);
-                assert.notStrictEqual(validateJSON(validFlexibleDate2), undefined);
-                assert.notStrictEqual(validateJSON(validWaivedDate1), undefined);
-                assert.notStrictEqual(validateJSON(validWaivedDate2), undefined);
+                assert.strictEqual(validateJSON(validFlexibleDate1), true);
+                assert.strictEqual(validateJSON(validFlexibleDate2), true);
+                assert.strictEqual(validateJSON(validWaivedDate1), true);
+                assert.strictEqual(validateJSON(validWaivedDate2), true);
             });
         });
 
@@ -53,15 +53,15 @@ describe('Validate json', function()
             const invalidDayInMonth = [{ 'type': 'flexible', 'date': '2020-04-31', 'values': ['08:00', '12:00', '13:00', '14:00'] }];
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validWaivedDate), undefined);
-                assert.notStrictEqual(validateJSON(validFlexibleDate), undefined);
+                assert.strictEqual(validateJSON(validWaivedDate), true);
+                assert.strictEqual(validateJSON(validFlexibleDate), true);
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidDateFormat), undefined);
-                assert.notStrictEqual(validateJSON(invalidDateType), undefined);
-                assert.notStrictEqual(validateJSON(invalidDateValue), undefined);
-                assert.notStrictEqual(validateJSON(invalidDayInMonth), undefined);
+                assert.strictEqual(validateJSON(invalidDateFormat), false);
+                assert.strictEqual(validateJSON(invalidDateType), false);
+                assert.strictEqual(validateJSON(invalidDateValue), false);
+                assert.strictEqual(validateJSON(invalidDayInMonth), false);
             });
         });
 
@@ -71,11 +71,11 @@ describe('Validate json', function()
             const invalidDataType = [{ 'type': 'waived', 'date': '2020-06-03', 'data': ['waived'], 'hours': '08:00' }];
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validData), undefined);
+                assert.strictEqual(validateJSON(validData), true);
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidDataType), undefined);
+                assert.strictEqual(validateJSON(invalidDataType), false);
             });
         });
 
@@ -89,15 +89,15 @@ describe('Validate json', function()
             const invalidHoursValueNegative = [{ 'type': 'waived', 'date': '2020-06-03', 'data': 'waived', 'hours': '-01:00' }];
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validHours), undefined);
-                assert.notStrictEqual(validateJSON(validHours2), undefined);
+                assert.strictEqual(validateJSON(validHours), true);
+                assert.strictEqual(validateJSON(validHours2), true);
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidHoursFormat), undefined);
-                assert.notStrictEqual(validateJSON(invalidHoursType), undefined);
-                assert.notStrictEqual(validateJSON(invalidHoursValue), undefined);
-                assert.notStrictEqual(validateJSON(invalidHoursValueNegative), undefined);
+                assert.strictEqual(validateJSON(invalidHoursFormat), false);
+                assert.strictEqual(validateJSON(invalidHoursType), false);
+                assert.strictEqual(validateJSON(invalidHoursValue), false);
+                assert.strictEqual(validateJSON(invalidHoursValueNegative), false);
             });
         });
 
@@ -113,17 +113,17 @@ describe('Validate json', function()
             const invalidPointsInTime = [{ 'type': 'flexible', 'date': '2020-02-01', 'values': ['08:00', '07:00', '13:00', '14:00'] }];
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validValues), undefined);
+                assert.strictEqual(validateJSON(validValues), true);
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidValuesFormat1), undefined);
-                assert.notStrictEqual(validateJSON(invalidValuesFormat2), undefined);
-                assert.notStrictEqual(validateJSON(invalidValuesFormat3), undefined);
-                assert.notStrictEqual(validateJSON(invalidValuesFormat4), undefined);
-                assert.notStrictEqual(validateJSON(invalidValuesType), undefined);
-                assert.notStrictEqual(validateJSON(invalidValuesValue), undefined);
-                assert.notStrictEqual(validateJSON(invalidPointsInTime), undefined);
+                assert.strictEqual(validateJSON(invalidValuesFormat1), false);
+                assert.strictEqual(validateJSON(invalidValuesFormat2), false);
+                assert.strictEqual(validateJSON(invalidValuesFormat3), false);
+                assert.strictEqual(validateJSON(invalidValuesFormat4), false);
+                assert.strictEqual(validateJSON(invalidValuesType), false);
+                assert.strictEqual(validateJSON(invalidValuesValue), false);
+                assert.strictEqual(validateJSON(invalidPointsInTime), false);
             });
         });
 
@@ -137,18 +137,18 @@ describe('Validate json', function()
                 for (let i = 1; i <= 9; i++)
                 {
                     const firstNineDays = [{ 'type': 'flexible', 'date': `2020-12-0${i}`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    assert.notStrictEqual(validateJSON(firstNineDays), undefined);
+                    assert.strictEqual(validateJSON(firstNineDays), true);
                 }
                 for (let i = 10; i <= 31; i++)
                 {
                     const restDays = [{ 'type': 'flexible', 'date': `2020-12-${i}`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    assert.notStrictEqual(validateJSON(restDays), undefined);
+                    assert.strictEqual(validateJSON(restDays), true);
                 }
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidDay), undefined);
-                assert.notStrictEqual(validateJSON(invalidDay2), undefined);
+                assert.strictEqual(validateJSON(invalidDay), false);
+                assert.strictEqual(validateJSON(invalidDay2), false);
             });
         });
 
@@ -162,18 +162,18 @@ describe('Validate json', function()
                 for (let i = 1; i <= 9; i++)
                 {
                     const firstNineMonths = [{ 'type': 'flexible', 'date': `2020-0${i}-13`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    assert.notStrictEqual(validateJSON(firstNineMonths), undefined);
+                    assert.strictEqual(validateJSON(firstNineMonths), true);
                 }
                 for (let i = 10; i <= 12; i++)
                 {
                     const restMonths = [{ 'type': 'flexible', 'date': `2020-${i}-13`, 'values': ['08:00', '12:00', '13:00', '14:00'] }];
-                    assert.notStrictEqual(validateJSON(restMonths), undefined);
+                    assert.strictEqual(validateJSON(restMonths), true);
                 }
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidMonth), undefined);
-                assert.notStrictEqual(validateJSON(invalidMonth2), undefined);
+                assert.strictEqual(validateJSON(invalidMonth), false);
+                assert.strictEqual(validateJSON(invalidMonth2), false);
             });
         });
 
@@ -184,12 +184,12 @@ describe('Validate json', function()
 
             test('should be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(validLeapYear), undefined);
+                assert.strictEqual(validateJSON(validLeapYear), true);
 
             });
             test('should not be valid JSON', () =>
             {
-                assert.notStrictEqual(validateJSON(invalidLeapYear), undefined);
+                assert.strictEqual(validateJSON(invalidLeapYear), false);
             });
         });
     });

--- a/__tests__/__main__/windows.js
+++ b/__tests__/__main__/windows.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 import { BrowserWindow } from 'electron';
 const { getDateStr } = require('../../js/date-aux.js');
 const windows = require('../../js/windows.js');
@@ -19,10 +20,10 @@ describe('windows.js', () =>
 
     test('Elements should be null on starting', () =>
     {
-        expect(getWaiverWindow()).toBe(null);
-        expect(tray).toBe(null);
-        expect(contextMenu).toBe(null);
-        expect(prefWindow).toBe(null);
+        assert.strictEqual(getWaiverWindow(), null);
+        assert.strictEqual(tray, null);
+        assert.strictEqual(contextMenu, null);
+        assert.strictEqual(prefWindow, null);
     });
 
     test('Should create waiver window', (done) =>
@@ -31,9 +32,9 @@ describe('windows.js', () =>
             show: false
         });
         openWaiverManagerWindow(mainWindow);
-        expect(getWaiverWindow()).not.toBe(null);
-        expect(getWaiverWindow()).toBeInstanceOf(BrowserWindow);
-        expect(getWaiverWindow().getSize()).toEqual([600, 500]);
+        assert.notStrictEqual(getWaiverWindow(), null);
+        assert.strictEqual(getWaiverWindow() instanceof BrowserWindow, true);
+        assert.deepEqual(getWaiverWindow().getSize(), [600, 500]);
         done();
     });
 
@@ -44,7 +45,7 @@ describe('windows.js', () =>
         });
         openWaiverManagerWindow(mainWindow);
         openWaiverManagerWindow(mainWindow);
-        expect(getWaiverWindow()).not.toBe(null);
+        assert.notStrictEqual(getWaiverWindow(), null);
         // It should only load once the URL because it already exists
         expect(showSpy).toHaveBeenCalledTimes(2);
         expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -57,8 +58,8 @@ describe('windows.js', () =>
             show: false
         });
         openWaiverManagerWindow(mainWindow, true);
-        expect(getWaiverWindow()).not.toBe(null);
-        expect(global.waiverDay).toBe(getDateStr(new Date()));
+        assert.notStrictEqual(getWaiverWindow(), null);
+        assert.strictEqual(global.waiverDay, getDateStr(new Date()));
         done();
     });
 
@@ -69,7 +70,7 @@ describe('windows.js', () =>
         });
         openWaiverManagerWindow(mainWindow, true);
         getWaiverWindow().emit('close');
-        expect(getWaiverWindow()).toBe(null);
+        assert.strictEqual(getWaiverWindow(), null);
     });
 
     test('Should get dialog coordinates', () =>
@@ -82,7 +83,7 @@ describe('windows.js', () =>
                 height: 600
             })
         });
-        expect(coordinates).toEqual({
+        assert.deepStrictEqual(coordinates, {
             x: 150,
             y: 475
         });

--- a/__tests__/__renderer__/classes/BaseCalendar.js
+++ b/__tests__/__renderer__/classes/BaseCalendar.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 import Store from 'electron-store';
 import { BaseCalendar } from '../../../renderer/classes/BaseCalendar.js';
 import { generateKey } from '../../../js/date-db-formatter.js';
@@ -104,7 +105,7 @@ describe('BaseCalendar.js', () =>
             const preferences = {view: 'day'};
             const languageData = {hello: 'hola'};
             const calendar = new ExtendedClass(preferences, languageData);
-            expect(calendar._calendarDate).toBeInstanceOf(Date);
+            assert.strictEqual(calendar._calendarDate instanceof Date, true);
             expect(calendar._languageData).toEqual(languageData);
             expect(calendar._preferences).toEqual(preferences);
 
@@ -133,7 +134,7 @@ describe('BaseCalendar.js', () =>
             const preferences = {view: 'day'};
             const languageData = {hello: 'hola'};
             const calendar = new ExtendedClass(preferences, languageData);
-            expect(calendar._calendarDate).toBeInstanceOf(Date);
+            assert.strictEqual(calendar._calendarDate instanceof Date, true);
             expect(calendar._languageData).toEqual(languageData);
             expect(calendar._preferences).toEqual(preferences);
 
@@ -212,9 +213,9 @@ describe('BaseCalendar.js', () =>
             setTimeout(() =>
             {
                 expect(mocks.compute).toHaveBeenCalledTimes(1);
-                expect($('#overall-balance').val()).toBe('2022-02-31');
-                expect($('#overall-balance').hasClass('text-danger')).toBe(true);
-                expect($('#overall-balance').hasClass('text-success')).toBe(false);
+                assert.strictEqual($('#overall-balance').val(), '2022-02-31');
+                assert.strictEqual($('#overall-balance').hasClass('text-danger'), true);
+                assert.strictEqual($('#overall-balance').hasClass('text-success'), false);
                 done();
             }, 500);
         });
@@ -232,9 +233,9 @@ describe('BaseCalendar.js', () =>
             setTimeout(() =>
             {
                 expect(mocks.compute).toHaveBeenCalledTimes(1);
-                expect($('#overall-balance').val()).toBe('2022-02-31');
-                expect($('#overall-balance').hasClass('text-danger')).toBe(false);
-                expect($('#overall-balance').hasClass('text-success')).toBe(true);
+                assert.strictEqual($('#overall-balance').val(), '2022-02-31');
+                assert.strictEqual($('#overall-balance').hasClass('text-danger'), false);
+                assert.strictEqual($('#overall-balance').hasClass('text-success'), true);
                 done();
             }, 500);
         });
@@ -459,7 +460,7 @@ describe('BaseCalendar.js', () =>
             calendar._updateDayTotal(key);
             const dayTotalSpan = $('#' + key).parent().find('.day-total-cell span');
             $(`#${key}`).remove();
-            expect(dayTotalSpan.text()).toBe('');
+            assert.strictEqual(dayTotalSpan.text(), '');
         });
 
         test('Should update when day has ended', async() =>
@@ -479,7 +480,7 @@ describe('BaseCalendar.js', () =>
             calendar._updateDayTotal(key);
             const dayTotalSpan = $('#' + key).parent().find('.day-total-cell span');
             $(`#${key}`).remove();
-            expect(dayTotalSpan.html()).toBe('08:30');
+            assert.strictEqual(dayTotalSpan.html(), '08:30');
         });
     });
 

--- a/__tests__/__renderer__/classes/CalendarFactory.js
+++ b/__tests__/__renderer__/classes/CalendarFactory.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 import { CalendarFactory } from '../../../renderer/classes/CalendarFactory.js';
 import { FlexibleDayCalendar } from '../../../renderer/classes/FlexibleDayCalendar.js';
 import { FlexibleMonthCalendar } from '../../../renderer/classes/FlexibleMonthCalendar.js';
@@ -43,10 +44,10 @@ describe('CalendarFactory', () =>
         const promise = CalendarFactory.getInstance({
             view: 'not_supported'
         }, {});
-        expect(promise).toBeInstanceOf(Promise);
+        assert.strictEqual(promise instanceof Promise, true);
         promise.then(() => {}).catch((reason) =>
         {
-            expect(reason).toBe('Could not instantiate not_supported');
+            assert.strictEqual(reason, 'Could not instantiate not_supported');
         });
     });
 
@@ -67,7 +68,7 @@ describe('CalendarFactory', () =>
                 view: 'day',
             }, {}, testCalendar);
             expect(calendar).toEqual(testCalendar);
-            expect(calls).toBe(3);
+            assert.strictEqual(calls, 3);
         });
 
         test('Should return new calendar without resizing', async() =>
@@ -84,8 +85,8 @@ describe('CalendarFactory', () =>
             const calendar = await CalendarFactory.getInstance({
                 view: 'day',
             }, {}, testCalendar);
-            expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
-            expect(calls).toBe(0);
+            assert.strictEqual(calendar instanceof FlexibleDayCalendar, true);
+            assert.strictEqual(calls, 0);
         });
 
         test('Should return new calendar without resizing', async() =>
@@ -98,8 +99,8 @@ describe('CalendarFactory', () =>
             const calendar = await CalendarFactory.getInstance({
                 view: 'day',
             }, {}, undefined);
-            expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
-            expect(calls).toBe(0);
+            assert.strictEqual(calendar instanceof FlexibleDayCalendar, true);
+            assert.strictEqual(calls, 0);
         });
 
         test('Should return new calendar with resizing', async() =>
@@ -120,8 +121,8 @@ describe('CalendarFactory', () =>
             const calendar = await CalendarFactory.getInstance({
                 view: 'day',
             }, {}, testCalendar);
-            expect(calendar).toBeInstanceOf(FlexibleDayCalendar);
-            expect(calls).toBe(1);
+            assert.strictEqual(calendar instanceof FlexibleDayCalendar, true);
+            assert.strictEqual(calls, 1);
         });
     });
 
@@ -142,7 +143,7 @@ describe('CalendarFactory', () =>
                 view: 'month',
             }, {}, testCalendar);
             expect(calendar).toEqual(testCalendar);
-            expect(calls).toBe(3);
+            assert.strictEqual(calls, 3);
         });
 
         test('Should return new calendar without resizing', async() =>
@@ -155,8 +156,8 @@ describe('CalendarFactory', () =>
             const calendar = await CalendarFactory.getInstance({
                 view: 'month',
             }, {}, undefined);
-            expect(calendar).toBeInstanceOf(FlexibleMonthCalendar);
-            expect(calls).toBe(0);
+            assert.strictEqual(calendar instanceof FlexibleMonthCalendar, true);
+            assert.strictEqual(calls, 0);
         });
 
         test('Should return new calendar with resizing', async() =>
@@ -177,8 +178,8 @@ describe('CalendarFactory', () =>
             const calendar = await CalendarFactory.getInstance({
                 view: 'month',
             }, {}, testCalendar);
-            expect(calendar).toBeInstanceOf(FlexibleMonthCalendar);
-            expect(calls).toBe(1);
+            assert.strictEqual(calendar instanceof FlexibleMonthCalendar, true);
+            assert.strictEqual(calls, 1);
         });
     });
 });

--- a/__tests__/__renderer__/classes/FlexibleDayCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleDayCalendar.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import Store from 'electron-store';
 import { computeAllTimeBalanceUntilAsync } from '../../../js/time-balance.js';
 import { defaultPreferences } from '../../../js/user-preferences.js';
@@ -91,24 +92,24 @@ describe('FlexibleDayCalendar class Tests', () =>
 
     test('FlexibleDayCalendar starts with today\'s date', () =>
     {
-        expect(calendar.constructor.name).toBe('FlexibleDayCalendar');
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar.constructor.name, 'FlexibleDayCalendar');
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
     });
 
     test('FlexibleDayCalendar "today" methods return today\'s date', () =>
     {
-        expect(calendar._getTodayDate()).toBe(today.getDate());
-        expect(calendar._getTodayYear()).toBe(today.getFullYear());
-        expect(calendar._getTodayMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getTodayDate(), today.getDate());
+        assert.strictEqual(calendar._getTodayYear(), today.getFullYear());
+        assert.strictEqual(calendar._getTodayMonth(), today.getMonth());
     });
 
     test('FlexibleDayCalendar internal storage correct loading', () =>
     {
         expect(calendar._internalStore['2020-3-1']).toStrictEqual(regularEntries['2020-3-1']);
         expect(calendar._getStore('2020-3-1')).toStrictEqual(regularEntries['2020-3-1']['values']);
-        expect(calendar._internalStore['2010-3-1']).toBe(undefined);
+        assert.strictEqual(calendar._internalStore['2010-3-1'], undefined);
         expect(calendar._getStore('2010-3-1')).toStrictEqual([]);
 
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(2);
@@ -122,7 +123,7 @@ describe('FlexibleDayCalendar class Tests', () =>
         expect(flexibleStore.size).toStrictEqual(3);
 
         calendar._removeStore('2010-3-1');
-        expect(calendar._internalStore['2010-3-1']).toBe(undefined);
+        assert.strictEqual(calendar._internalStore['2010-3-1'], undefined);
         expect(calendar._getStore('2010-3-1')).toStrictEqual([]);
 
         // remove just sets the value as undefined in internal store, if it existed
@@ -208,7 +209,7 @@ describe('FlexibleDayCalendar class Tests', () =>
 
     test('FlexibleDayCalendar Day Changes', () =>
     {
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
 
         const expectedNextDay = new Date(today);
         expectedNextDay.setDate(expectedNextDay.getDate() + 1);
@@ -216,31 +217,31 @@ describe('FlexibleDayCalendar class Tests', () =>
         expectedPrevDay.setDate(expectedPrevDay.getDate() - 1);
 
         calendar._nextDay();
-        expect(calendar._getCalendarDate()).toBe(expectedNextDay.getDate());
-        expect(calendar._isCalendarOnDate(expectedNextDay)).toBeTruthy();
-        expect(calendar._isCalendarOnDate(expectedPrevDay)).not.toBeTruthy();
+        assert.strictEqual(calendar._getCalendarDate(), expectedNextDay.getDate());
+        assert.notStrictEqual(calendar._isCalendarOnDate(expectedNextDay), undefined);
+        assert.notStrictEqual(calendar._isCalendarOnDate(expectedPrevDay), undefined);
 
         calendar._prevDay();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
 
         calendar._prevDay();
-        expect(calendar._getCalendarDate()).toBe(expectedPrevDay.getDate());
-        expect(calendar._isCalendarOnDate(expectedNextDay)).not.toBeTruthy();
-        expect(calendar._isCalendarOnDate(expectedPrevDay)).toBeTruthy();
+        assert.strictEqual(calendar._getCalendarDate(), expectedPrevDay.getDate());
+        assert.notStrictEqual(calendar._isCalendarOnDate(expectedNextDay), undefined);
+        assert.notStrictEqual(calendar._isCalendarOnDate(expectedPrevDay), undefined);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
 
         calendar._changeDay(1);
-        expect(calendar._getCalendarDate()).toBe(expectedNextDay.getDate());
+        assert.strictEqual(calendar._getCalendarDate(), expectedNextDay.getDate());
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
     });
 
     test('FlexibleDayCalendar Month Changes', () =>
     {
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
         const expectedNextMonth = today.getMonth() + 1 === 12 ? 0 : (today.getMonth() + 1);
         const expectedPrevMonth = today.getMonth() === 0 ? 11 : (today.getMonth() - 1);
 
@@ -256,27 +257,27 @@ describe('FlexibleDayCalendar class Tests', () =>
             calendar._nextDay();
         }
 
-        expect(calendar._getCalendarMonth()).toBe(expectedNextMonth);
+        assert.strictEqual(calendar._getCalendarMonth(), expectedNextMonth);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
 
         for (let i = 0; i < distToPrevMonth; i++)
         {
             calendar._prevDay();
         }
 
-        expect(calendar._getCalendarMonth()).toBe(expectedPrevMonth);
+        assert.strictEqual(calendar._getCalendarMonth(), expectedPrevMonth);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
     });
 
     test('FlexibleDayCalendar Year Changes', () =>
     {
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
         const expectedNextYear = today.getFullYear() + 1;
         const expectedPrevYear = today.getFullYear() - 1;
 
@@ -285,24 +286,24 @@ describe('FlexibleDayCalendar class Tests', () =>
             calendar._nextDay();
         }
 
-        expect(calendar._getCalendarYear()).toBe(expectedNextYear);
+        assert.strictEqual(calendar._getCalendarYear(), expectedNextYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
 
         for (let i = 0; i < 365; i++)
         {
             calendar._prevDay();
         }
 
-        expect(calendar._getCalendarYear()).toBe(expectedPrevYear);
+        assert.strictEqual(calendar._getCalendarYear(), expectedPrevYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
     });
 
     describe('FlexibleDayCalendar RefreshOnDayChange', () =>
@@ -316,9 +317,9 @@ describe('FlexibleDayCalendar class Tests', () =>
             // Refreshing with the date being looked at should push it to today
             calendar.refreshOnDayChange(prevDayDate.getDate(), prevDayDate.getMonth(), prevDayDate.getFullYear());
 
-            expect(calendar._getCalendarDate()).toBe(today.getDate());
-            expect(calendar._getCalendarYear()).toBe(today.getFullYear());
-            expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+            assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+            assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
+            assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
         });
 
         test('FlexibleDayCalendar refresh set to another day', () =>
@@ -329,7 +330,7 @@ describe('FlexibleDayCalendar class Tests', () =>
             // Refreshing with a date not being looked at should not push it to today
             calendar.refreshOnDayChange(today.getDate(), today.getMonth(), today.getFullYear());
 
-            expect(calendar._getCalendarDate()).not.toBe(today.getDate());
+            assert.notStrictEqual(calendar._getCalendarDate(), today.getDate());
         });
     });
 
@@ -338,11 +339,11 @@ describe('FlexibleDayCalendar class Tests', () =>
         const testPreferences = defaultPreferences;
         testPreferences['view'] = 'month';
         let calendar = await CalendarFactory.getInstance(testPreferences, languageData);
-        expect(calendar.constructor.name).toBe('FlexibleMonthCalendar');
+        assert.strictEqual(calendar.constructor.name, 'FlexibleMonthCalendar');
 
         testPreferences['view'] = 'day';
         calendar = await CalendarFactory.getInstance(testPreferences, languageData, calendar);
-        expect(calendar.constructor.name).toBe('FlexibleDayCalendar');
+        assert.strictEqual(calendar.constructor.name, 'FlexibleDayCalendar');
     });
 
 });

--- a/__tests__/__renderer__/classes/FlexibleDayCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleDayCalendar.js
@@ -218,16 +218,16 @@ describe('FlexibleDayCalendar class Tests', () =>
 
         calendar._nextDay();
         assert.strictEqual(calendar._getCalendarDate(), expectedNextDay.getDate());
-        assert.notStrictEqual(calendar._isCalendarOnDate(expectedNextDay), undefined);
-        assert.notStrictEqual(calendar._isCalendarOnDate(expectedPrevDay), undefined);
+        assert.strictEqual(calendar._isCalendarOnDate(expectedNextDay), true);
+        assert.strictEqual(calendar._isCalendarOnDate(expectedPrevDay), false);
 
         calendar._prevDay();
         assert.strictEqual(calendar._getCalendarDate(), today.getDate());
 
         calendar._prevDay();
         assert.strictEqual(calendar._getCalendarDate(), expectedPrevDay.getDate());
-        assert.notStrictEqual(calendar._isCalendarOnDate(expectedNextDay), undefined);
-        assert.notStrictEqual(calendar._isCalendarOnDate(expectedPrevDay), undefined);
+        assert.strictEqual(calendar._isCalendarOnDate(expectedNextDay), false);
+        assert.strictEqual(calendar._isCalendarOnDate(expectedPrevDay), true);
 
         calendar._goToCurrentDate();
         assert.strictEqual(calendar._getCalendarDate(), today.getDate());

--- a/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
+++ b/__tests__/__renderer__/classes/FlexibleMonthCalendar.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import Store from 'electron-store';
 import { computeAllTimeBalanceUntilAsync } from '../../../js/time-balance.js';
 import { defaultPreferences } from '../../../js/user-preferences.js';
@@ -90,24 +91,24 @@ describe('FlexibleMonthCalendar class Tests', () =>
 
     test('FlexibleMonthCalendar starts with today\'s date', () =>
     {
-        expect(calendar.constructor.name).toBe('FlexibleMonthCalendar');
-        expect(calendar._getCalendarDate()).toBe(today.getDate());
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar.constructor.name, 'FlexibleMonthCalendar');
+        assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
     });
 
     test('FlexibleMonthCalendar "today" methods return today\'s date', () =>
     {
-        expect(calendar._getTodayDate()).toBe(today.getDate());
-        expect(calendar._getTodayYear()).toBe(today.getFullYear());
-        expect(calendar._getTodayMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getTodayDate(), today.getDate());
+        assert.strictEqual(calendar._getTodayYear(), today.getFullYear());
+        assert.strictEqual(calendar._getTodayMonth(), today.getMonth());
     });
 
     test('FlexibleMonthCalendar internal storage correct loading', () =>
     {
         expect(calendar._internalStore['2020-3-1']).toStrictEqual(regularEntries['2020-3-1']);
         expect(calendar._getStore('2020-3-1')).toStrictEqual(regularEntries['2020-3-1']['values']);
-        expect(calendar._internalStore['2010-3-1']).toBe(undefined);
+        assert.strictEqual(calendar._internalStore['2010-3-1'], undefined);
         expect(calendar._getStore('2010-3-1')).toStrictEqual([]);
 
         expect(Object.keys(calendar._internalStore).length).toStrictEqual(2);
@@ -121,7 +122,7 @@ describe('FlexibleMonthCalendar class Tests', () =>
         expect(flexibleStore.size).toStrictEqual(3);
 
         calendar._removeStore('2010-3-1');
-        expect(calendar._internalStore['2010-3-1']).toBe(undefined);
+        assert.strictEqual(calendar._internalStore['2010-3-1'], undefined);
         expect(calendar._getStore('2010-3-1')).toStrictEqual([]);
 
         // remove just sets the value as undefined in internal store, if it existed
@@ -158,26 +159,26 @@ describe('FlexibleMonthCalendar class Tests', () =>
 
     test('FlexibleMonthCalendar Month Changes', () =>
     {
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
         const expectedNextMonth = today.getMonth() + 1 === 12 ? 0 : (today.getMonth() + 1);
         const expectedPrevMonth = today.getMonth() === 0 ? 11 : (today.getMonth() - 1);
 
         calendar._nextMonth();
-        expect(calendar._getCalendarMonth()).toBe(expectedNextMonth);
+        assert.strictEqual(calendar._getCalendarMonth(), expectedNextMonth);
 
         calendar._prevMonth();
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
 
         calendar._prevMonth();
-        expect(calendar._getCalendarMonth()).toBe(expectedPrevMonth);
+        assert.strictEqual(calendar._getCalendarMonth(), expectedPrevMonth);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
     });
 
     test('FlexibleMonthCalendar Year Changes', () =>
     {
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
         const expectedNextYear = today.getFullYear() + 1;
         const expectedPrevYear = today.getFullYear() - 1;
 
@@ -186,22 +187,22 @@ describe('FlexibleMonthCalendar class Tests', () =>
             calendar._nextMonth();
         }
 
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
-        expect(calendar._getCalendarYear()).toBe(expectedNextYear);
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
+        assert.strictEqual(calendar._getCalendarYear(), expectedNextYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
 
         for (let i = 0; i < 12; i++)
         {
             calendar._prevMonth();
         }
 
-        expect(calendar._getCalendarMonth()).toBe(today.getMonth());
-        expect(calendar._getCalendarYear()).toBe(expectedPrevYear);
+        assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
+        assert.strictEqual(calendar._getCalendarYear(), expectedPrevYear);
 
         calendar._goToCurrentDate();
-        expect(calendar._getCalendarYear()).toBe(today.getFullYear());
+        assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
     });
 
     describe('FlexibleMonthCalendar RefreshOnDayChange', () =>
@@ -215,9 +216,9 @@ describe('FlexibleMonthCalendar class Tests', () =>
             // Refreshing with the date being looked at should push it to today
             calendar.refreshOnDayChange(prevMonthDate.getDate(), prevMonthDate.getMonth(), prevMonthDate.getFullYear());
 
-            expect(calendar._getCalendarDate()).toBe(today.getDate());
-            expect(calendar._getCalendarYear()).toBe(today.getFullYear());
-            expect(calendar._getCalendarMonth()).toBe(today.getMonth());
+            assert.strictEqual(calendar._getCalendarDate(), today.getDate());
+            assert.strictEqual(calendar._getCalendarYear(), today.getFullYear());
+            assert.strictEqual(calendar._getCalendarMonth(), today.getMonth());
         });
 
         test('FlexibleMonthCalendar refresh set to another month', () =>
@@ -228,7 +229,7 @@ describe('FlexibleMonthCalendar class Tests', () =>
             // Refreshing with a date not being looked at should not push it to today
             calendar.refreshOnDayChange(today.getDate(), today.getMonth(), today.getFullYear());
 
-            expect(calendar._getCalendarMonth()).not.toBe(today.getMonth());
+            assert.notStrictEqual(calendar._getCalendarMonth(), today.getMonth());
         });
     });
 
@@ -237,10 +238,10 @@ describe('FlexibleMonthCalendar class Tests', () =>
         const testPreferences = defaultPreferences;
         testPreferences['view'] = 'day';
         let calendar = await CalendarFactory.getInstance(testPreferences, languageData);
-        expect(calendar.constructor.name).toBe('FlexibleDayCalendar');
+        assert.strictEqual(calendar.constructor.name, 'FlexibleDayCalendar');
 
         testPreferences['view'] = 'month';
         calendar = await CalendarFactory.getInstance(testPreferences, languageData, calendar);
-        expect(calendar.constructor.name).toBe('FlexibleMonthCalendar');
+        assert.strictEqual(calendar.constructor.name, 'FlexibleMonthCalendar');
     });
 });

--- a/__tests__/__renderer__/notification-channel.js
+++ b/__tests__/__renderer__/notification-channel.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assert = require('assert');
+
 const notificationChannel = require('../../renderer/notification-channel.js');
 
 describe('Notifications channel',  () =>
@@ -13,8 +15,8 @@ describe('Notifications channel',  () =>
             sender: {
                 send: (channel, value) =>
                 {
-                    expect(channel).toBe('RECEIVE_LEAVE_BY');
-                    expect(value).toBe('12:12');
+                    assert.strictEqual(channel, 'RECEIVE_LEAVE_BY');
+                    assert.strictEqual(value, '12:12');
                     done();
                 }
             }

--- a/__tests__/__renderer__/preferences.js
+++ b/__tests__/__renderer__/preferences.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import fs from 'fs';
 import path from 'path';
 const {
@@ -69,12 +70,12 @@ function checkRenderedItem(item, isCheckbox = false)
     {
         $(`input[name*='${item}']`).prop('checked', (i, val) =>
         {
-            expect(val).toBe(testPreferences[item]);
+            assert.strictEqual(val, testPreferences[item]);
         });
     }
     else
     {
-        expect($(`#${item}`).val()).toBe(testPreferences[item]);
+        assert.strictEqual($(`#${item}`).val(), testPreferences[item]);
     }
 }
 
@@ -207,11 +208,11 @@ describe('Test Preferences Window', () =>
                 if (lastValue === '') lastValue = this.value;
                 else
                 {
-                    expect(lastValue.localeCompare(this.value)).toBeLessThan(0);
+                    assert.strictEqual(lastValue.localeCompare(this.value) < 0, true);
                     lastValue = this.value;
                 }
             });
-            expect(lastValue).not.toBe('');
+            assert.notStrictEqual(lastValue, '');
         });
     });
 });

--- a/__tests__/__renderer__/themes.js
+++ b/__tests__/__renderer__/themes.js
@@ -15,10 +15,10 @@ describe('Theme Functions', function()
     {
         test('should validate', () =>
         {
-            assert.notStrictEqual(isValidTheme('system-default'), undefined);
-            assert.notStrictEqual(isValidTheme('light'), undefined);
-            assert.notStrictEqual(isValidTheme('dark'), undefined);
-            assert.notStrictEqual(isValidTheme('cadent-star'), undefined);
+            assert.strictEqual(isValidTheme('system-default'), true);
+            assert.strictEqual(isValidTheme('light'), true);
+            assert.strictEqual(isValidTheme('dark'), true);
+            assert.strictEqual(isValidTheme('cadent-star'), true);
         });
     });
 
@@ -26,8 +26,8 @@ describe('Theme Functions', function()
     {
         test('should not validate', () =>
         {
-            assert.notStrictEqual(isValidTheme('foo'), undefined);
-            assert.notStrictEqual(isValidTheme('bar'), undefined);
+            assert.strictEqual(isValidTheme('foo'), false);
+            assert.strictEqual(isValidTheme('bar'), false);
         });
     });
 
@@ -35,16 +35,16 @@ describe('Theme Functions', function()
     {
         test('should apply', () =>
         {
-            assert.notStrictEqual(applyTheme('system-default'), undefined);
-            assert.notStrictEqual(applyTheme('light'), undefined);
-            assert.notStrictEqual(applyTheme('dark'), undefined);
-            assert.notStrictEqual(applyTheme('cadent-star'), undefined);
+            assert.strictEqual(applyTheme('system-default'), true);
+            assert.strictEqual(applyTheme('light'), true);
+            assert.strictEqual(applyTheme('dark'), true);
+            assert.strictEqual(applyTheme('cadent-star'), true);
         });
 
         test('should not apply', function()
         {
-            assert.notStrictEqual(applyTheme('foo'), undefined);
-            assert.notStrictEqual(applyTheme('bar'), undefined);
+            assert.strictEqual(applyTheme('foo'), false);
+            assert.strictEqual(applyTheme('bar'), false);
         });
     });
 });

--- a/__tests__/__renderer__/themes.js
+++ b/__tests__/__renderer__/themes.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
+
 import {
     applyTheme,
     isValidTheme
@@ -13,10 +15,10 @@ describe('Theme Functions', function()
     {
         test('should validate', () =>
         {
-            expect(isValidTheme('system-default')).toBeTruthy();
-            expect(isValidTheme('light')).toBeTruthy();
-            expect(isValidTheme('dark')).toBeTruthy();
-            expect(isValidTheme('cadent-star')).toBeTruthy();
+            assert.notStrictEqual(isValidTheme('system-default'), undefined);
+            assert.notStrictEqual(isValidTheme('light'), undefined);
+            assert.notStrictEqual(isValidTheme('dark'), undefined);
+            assert.notStrictEqual(isValidTheme('cadent-star'), undefined);
         });
     });
 
@@ -24,8 +26,8 @@ describe('Theme Functions', function()
     {
         test('should not validate', () =>
         {
-            expect(isValidTheme('foo')).not.toBeTruthy();
-            expect(isValidTheme('bar')).not.toBeTruthy();
+            assert.notStrictEqual(isValidTheme('foo'), undefined);
+            assert.notStrictEqual(isValidTheme('bar'), undefined);
         });
     });
 
@@ -33,16 +35,16 @@ describe('Theme Functions', function()
     {
         test('should apply', () =>
         {
-            expect(applyTheme('system-default')).toBeTruthy();
-            expect(applyTheme('light')).toBeTruthy();
-            expect(applyTheme('dark')).toBeTruthy();
-            expect(applyTheme('cadent-star')).toBeTruthy();
+            assert.notStrictEqual(applyTheme('system-default'), undefined);
+            assert.notStrictEqual(applyTheme('light'), undefined);
+            assert.notStrictEqual(applyTheme('dark'), undefined);
+            assert.notStrictEqual(applyTheme('cadent-star'), undefined);
         });
 
         test('should not apply', function()
         {
-            expect(applyTheme('foo')).not.toBeTruthy();
-            expect(applyTheme('bar')).not.toBeTruthy();
+            assert.notStrictEqual(applyTheme('foo'), undefined);
+            assert.notStrictEqual(applyTheme('bar'), undefined);
         });
     });
 });

--- a/__tests__/__renderer__/user-preferences.js
+++ b/__tests__/__renderer__/user-preferences.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
+
 const {
     defaultPreferences,
     getPreferencesFilePath,
@@ -15,11 +17,11 @@ describe('Should return false if the value is not boolean type', () =>
 {
     test('Value as boolean type', () =>
     {
-        expect(isNotBoolean(true)).toBe(false);
+        assert.strictEqual(isNotBoolean(true), false);
     });
     test('Value as string type', () =>
     {
-        expect(isNotBoolean('string')).toBe(true);
+        assert.strictEqual(isNotBoolean('string'), true);
     });
 });
 
@@ -27,27 +29,27 @@ describe('Should return true if the value is a valid notification interval', () 
 {
     test('Value as number (val >= 1 || val <= 30)', () =>
     {
-        expect(isNotificationInterval(1)).toBe(true);
-        expect(isNotificationInterval(15)).toBe(true);
-        expect(isNotificationInterval(30)).toBe(true);
-        expect(isNotificationInterval(-5)).not.toBe(true);
-        expect(isNotificationInterval(0)).not.toBe(true);
-        expect(isNotificationInterval(31)).not.toBe(true);
-        expect(isNotificationInterval(60)).not.toBe(true);
+        assert.strictEqual(isNotificationInterval(1), true);
+        assert.strictEqual(isNotificationInterval(15), true);
+        assert.strictEqual(isNotificationInterval(30), true);
+        assert.notStrictEqual(isNotificationInterval(-5), true);
+        assert.notStrictEqual(isNotificationInterval(0), true);
+        assert.notStrictEqual(isNotificationInterval(31), true);
+        assert.notStrictEqual(isNotificationInterval(60), true);
     });
     test('Value as string (val >= 1 || val <= 30)', () =>
     {
-        expect(isNotificationInterval('1')).toBe(true);
-        expect(isNotificationInterval('30')).toBe(true);
-        expect(isNotificationInterval('-5')).not.toBe(true);
-        expect(isNotificationInterval('31')).not.toBe(true);
-        expect(isNotificationInterval('A')).not.toBe(true);
-        expect(isNotificationInterval('abc')).not.toBe(true);
+        assert.strictEqual(isNotificationInterval('1'), true);
+        assert.strictEqual(isNotificationInterval('30'), true);
+        assert.notStrictEqual(isNotificationInterval('-5'), true);
+        assert.notStrictEqual(isNotificationInterval('31'), true);
+        assert.notStrictEqual(isNotificationInterval('A'), true);
+        assert.notStrictEqual(isNotificationInterval('abc'), true);
     });
     test('Value as boolean type', () =>
     {
-        expect(isNotificationInterval(true)).not.toBe(true);
-        expect(isNotificationInterval(false)).not.toBe(true);
+        assert.notStrictEqual(isNotificationInterval(true), true);
+        assert.notStrictEqual(isNotificationInterval(false), true);
     });
 });
 
@@ -70,20 +72,20 @@ describe('User Preferences save/load', () =>
 
         test('getUserPreferences() before saving any', () =>
         {
-            expect(savePreferences(defaultPreferences)).toBeDefined();
+            assert.notStrictEqual(savePreferences(defaultPreferences), undefined);
             expect(getUserPreferences()).not.toStrictEqual(empty);
             expect(getUserPreferences()).toStrictEqual(defaultPreferences);
         });
 
         test('savePreferences()', () =>
         {
-            expect(savePreferences(testPreferences)).toBeDefined();
+            assert.notStrictEqual(savePreferences(testPreferences), undefined);
         });
 
         test('getUserPreferences() to check that it saved', () =>
         {
             expect(getUserPreferences()).toStrictEqual(testPreferences);
-            expect(savePreferences(defaultPreferences)).toBeDefined();
+            assert.notStrictEqual(savePreferences(defaultPreferences), undefined);
         });
     });
 

--- a/__tests__/__renderer__/window-aux.js
+++ b/__tests__/__renderer__/window-aux.js
@@ -23,7 +23,7 @@ describe('window-aux.cjs Testing', function()
     const timeoutValue = 1500;
 
     // Testcase no longer being used since the move to electron without remote
-    // but we should make use of it for a mocha testcase to still be sure the proferences window
+    // but we should make use of it for a mocha testcase to still be sure the preferences window
     // and workday waiver have the shortcut working
 
     // describe('bindDevToolsShortcut(window)', function()
@@ -33,7 +33,7 @@ describe('window-aux.cjs Testing', function()
     //     {
     //         const testWindow = new BrowserWindow(browserWindowOptions);
     //         testWindow.loadURL(mockHtmlPath);
-    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
+    //         assert.strictEqual(testWindow.webContents.isDevToolsOpened(), false);
 
     //         testWindow.webContents.on('dom-ready', () =>
     //         {
@@ -45,7 +45,7 @@ describe('window-aux.cjs Testing', function()
     //         });
 
     //         await new Promise(r => setTimeout(r, timeoutValue));
-    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
+    //         assert.strictEqual(testWindow.webContents.isDevToolsOpened(), false);
     //     });
 
     //     test('Bind: should open devTools', async() =>

--- a/__tests__/__renderer__/window-aux.js
+++ b/__tests__/__renderer__/window-aux.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import path from 'path';
 const BrowserWindow = require('@electron/remote').BrowserWindow;
 import * as windowAux from '../../js/window-aux.cjs';
@@ -32,7 +33,7 @@ describe('window-aux.cjs Testing', function()
     //     {
     //         const testWindow = new BrowserWindow(browserWindowOptions);
     //         testWindow.loadURL(mockHtmlPath);
-    //         expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
 
     //         testWindow.webContents.on('dom-ready', () =>
     //         {
@@ -44,14 +45,14 @@ describe('window-aux.cjs Testing', function()
     //         });
 
     //         await new Promise(r => setTimeout(r, timeoutValue));
-    //         expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
     //     });
 
     //     test('Bind: should open devTools', async() =>
     //     {
     //         const testWindow = new BrowserWindow(browserWindowOptions);
     //         testWindow.loadURL(mockHtmlPath);
-    //         expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
 
     //         testWindow.webContents.on('dom-ready', () =>
     //         {
@@ -64,14 +65,14 @@ describe('window-aux.cjs Testing', function()
     //         });
 
     //         await new Promise(r => setTimeout(r, timeoutValue));
-    //         expect(testWindow.webContents.isDevToolsOpened()).toBeTruthy();
+    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
     //     });
 
     //     test('Bind: bad shortcut, should not open devTools', async() =>
     //     {
     //         const testWindow = new BrowserWindow(browserWindowOptions);
     //         testWindow.loadURL(mockHtmlPath);
-    //         expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
 
     //         testWindow.webContents.on('dom-ready', () =>
     //         {
@@ -84,7 +85,7 @@ describe('window-aux.cjs Testing', function()
     //         });
 
     //         await new Promise(r => setTimeout(r, timeoutValue));
-    //         expect(testWindow.webContents.isDevToolsOpened()).not.toBeTruthy();
+    //         assert.notStrictEqual(testWindow.webContents.isDevToolsOpened(), undefined);
     //     });
     // });
 
@@ -114,7 +115,7 @@ describe('window-aux.cjs Testing', function()
             });
 
             await new Promise(r => setTimeout(r, timeoutValue));
-            expect(testWindow).toBeDefined();
+            assert.notStrictEqual(testWindow, undefined);
             expect(spy).toHaveBeenCalled();
 
             spy.mockRestore();
@@ -140,7 +141,7 @@ describe('window-aux.cjs Testing', function()
             });
 
             await new Promise(r => setTimeout(r, timeoutValue));
-            expect(testWindow).toBeDefined();
+            assert.notStrictEqual(testWindow, undefined);
             expect(spy).toHaveBeenCalled();
 
             spy.mockRestore();

--- a/__tests__/__renderer__/workday-waiver-aux.js
+++ b/__tests__/__renderer__/workday-waiver-aux.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
+
 import { formatDayId, displayWaiverWindow } from '../../renderer/workday-waiver-aux.js';
 
 // Mocking call
@@ -22,14 +24,14 @@ describe('Workday Waiver Aux', function()
     {
         test('should be valid', () =>
         {
-            expect(formatDayId(validJSDay)).toBe('2020-04-10');
-            expect(formatDayId(validJSDay2)).toBe('2020-01-10');
+            assert.strictEqual(formatDayId(validJSDay), '2020-04-10');
+            assert.strictEqual(formatDayId(validJSDay2), '2020-01-10');
         });
 
         test('should not be valid', () =>
         {
-            expect(formatDayId(garbageString)).toBeNaN();
-            expect(formatDayId(incompleteDate)).toBeNaN();
+            assert.strictEqual(formatDayId(garbageString), NaN);
+            assert.strictEqual(formatDayId(incompleteDate), NaN);
         });
     });
 

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+const assert = require('assert');
 import Store from 'electron-store';
 import fs from 'fs';
 import path from 'path';
@@ -146,8 +147,8 @@ async function addTestWaiver(day, reason)
 async function testWaiverCount(expected)
 {
     const waivedWorkdays = await window.mainApi.getWaiverStoreContents();
-    expect(waivedWorkdays.size).toBe(expected);
-    expect($('#waiver-list-table tbody')[0].rows.length).toBe(expected);
+    assert.strictEqual(waivedWorkdays.size, expected);
+    assert.strictEqual($('#waiver-list-table tbody')[0].rows.length, expected);
 }
 
 jest.mock('../../js/window-aux.cjs');
@@ -214,14 +215,14 @@ describe('Test Workday Waiver Window', function()
                     break;
                 }
             }
-            expect(isSorted).toBe(true);
+            assert.strictEqual(isSorted, true);
 
         });
         test('Time is not valid', async() =>
         {
             $('#hours').val('not a time');
             const waiver = await addWaiver();
-            expect(waiver).toBeFalsy();
+            assert.strictEqual(waiver, false);
         });
 
         test('End date less than start date', async() =>
@@ -230,20 +231,20 @@ describe('Test Workday Waiver Window', function()
             $('#start-date').val('2020-07-20');
             $('#end-date').val('2020-07-19');
             const waiver = await addWaiver();
-            expect(waiver).toBeFalsy();
+            assert.strictEqual(waiver, false);
         });
 
         test('Add waiver with the same date', async() =>
         {
             addTestWaiver('2020-07-16', 'some reason');
             const waiver = await addTestWaiver('2020-07-16', 'some reason');
-            expect(waiver).toBeFalsy();
+            assert.strictEqual(waiver, undefined);
         });
 
         test('Range does not contain any working day', async() =>
         {
             const waiver = await addTestWaiver('2020-13-01', 'some reason');
-            expect(waiver).toBeFalsy();
+            assert.strictEqual(waiver, false);
         });
     });
 
@@ -261,21 +262,21 @@ describe('Test Workday Waiver Window', function()
         test('Testing button is exist', () =>
         {
             const exists = document.querySelectorAll(`#${btnId}`).length;
-            expect(exists).toBeTruthy();
+            assert.notStrictEqual(exists, undefined);
         });
 
         test('Make disabled', () =>
         {
             toggleAddButton(btnId, false);
             const disabled = btn.getAttribute('disabled');
-            expect(disabled).toBe('disabled');
+            assert.strictEqual(disabled, 'disabled');
         });
 
         test('Make not disabled', () =>
         {
             toggleAddButton(btnId, true);
             const notDisabled = btn.getAttribute('disabled');
-            expect(notDisabled).toBeNull();
+            assert.strictEqual(notDisabled, null);
         });
 
         afterAll(() =>
@@ -293,7 +294,7 @@ describe('Test Workday Waiver Window', function()
             const deleteBtn = document.querySelectorAll('#waiver-list-table .delete-btn')[0];
             deleteEntryOnClick({target: deleteBtn});
             const length = document.querySelectorAll('#waiver-list-table .delete-btn').length;
-            expect(length).toBe(0);
+            assert.strictEqual(length, 0);
         });
     });
 
@@ -309,47 +310,47 @@ describe('Test Workday Waiver Window', function()
         test('Country was populated', async() =>
         {
             const countriesLength = Object.keys(hd.getCountries()).length;
-            expect($('#country option').length).toBe(0);
+            assert.strictEqual($('#country option').length, 0);
             await populateCountry();
-            expect($('#country option').length).toBe(countriesLength + 1);
+            assert.strictEqual($('#country option').length, countriesLength + 1);
         });
 
         test('States was populated', async() =>
         {
             const statesLength = Object.keys(hd.getStates('US')).length;
-            expect($('#state option').length).toBe(0);
+            assert.strictEqual($('#state option').length, 0);
             await populateState('US');
-            expect($('#state option').length).toBe(statesLength + 1);
-            expect($('#state').css('display')).toBe('inline-block');
-            expect($('#holiday-state').css('display')).toBe('table-row');
+            assert.strictEqual($('#state option').length, statesLength + 1);
+            assert.strictEqual($('#state').css('display'), 'inline-block');
+            assert.strictEqual($('#holiday-state').css('display'), 'table-row');
         });
 
         test('States was not populated', async() =>
         {
-            expect($('#state option').length).toBe(0);
+            assert.strictEqual($('#state option').length, 0);
             await populateState('CN');
-            expect($('#state option').length).toBe(0);
-            expect($('#state').css('display')).toBe('none');
-            expect($('#holiday-state').css('display')).toBe('none');
+            assert.strictEqual($('#state option').length, 0);
+            assert.strictEqual($('#state').css('display'), 'none');
+            assert.strictEqual($('#holiday-state').css('display'), 'none');
         });
 
         test('City was populated', async() =>
         {
             const regionsLength = Object.keys(hd.getRegions('US', 'CA')).length;
-            expect($('#city option').length).toBe(0);
+            assert.strictEqual($('#city option').length, 0);
             await populateCity('US', 'CA');
-            expect($('#city option').length).toBe(regionsLength + 1);
-            expect($('#city').css('display')).toBe('inline-block');
-            expect($('#holiday-city').css('display')).toBe('table-row');
+            assert.strictEqual($('#city option').length, regionsLength + 1);
+            assert.strictEqual($('#city').css('display'), 'inline-block');
+            assert.strictEqual($('#holiday-city').css('display'), 'table-row');
         });
 
         test('City was not populated', async() =>
         {
-            expect($('#city option').length).toBe(0);
+            assert.strictEqual($('#city option').length, 0);
             await populateCity('US', 'AL');
-            expect($('#city option').length).toBe(0);
-            expect($('#city').css('display')).toBe('none');
-            expect($('#holiday-city').css('display')).toBe('none');
+            assert.strictEqual($('#city option').length, 0);
+            assert.strictEqual($('#city').css('display'), 'none');
+            assert.strictEqual($('#holiday-city').css('display'), 'none');
         });
 
         test('Year was populated', () =>
@@ -357,10 +358,10 @@ describe('Test Workday Waiver Window', function()
             populateYear();
             const thisYear = new Date().getFullYear();
             const values = document.querySelectorAll('#year option');
-            expect($('#year option').length).toBe(10);
+            assert.strictEqual($('#year option').length, 10);
             for (let i = 0; i < 10; i++)
             {
-                expect(values[i].value).toBe(`${thisYear + i}`);
+                assert.strictEqual(values[i].value, `${thisYear + i}`);
             }
         });
     });
@@ -381,7 +382,7 @@ describe('Test Workday Waiver Window', function()
         test('Get holidays with no country', async() =>
         {
             $('#year').append($('<option selected></option>').val(year).html(year));
-            expect($('#year option').length).toBe(1);
+            assert.strictEqual($('#year option').length, 1);
             const holidays = await getHolidays();
             expect(holidays).toEqual([]);
         });
@@ -390,7 +391,7 @@ describe('Test Workday Waiver Window', function()
         {
             $('#year').append($('<option selected></option>').val(year).html(year));
             $('#country').append($('<option selected></option>').val(country).html(country));
-            expect($('#country option').length).toBe(1);
+            assert.strictEqual($('#country option').length, 1);
             hd.init(country);
             const holidays = await getHolidays();
             expect(holidays).toEqual(hd.getHolidays(year));
@@ -401,7 +402,7 @@ describe('Test Workday Waiver Window', function()
             $('#year').append($('<option selected></option>').val(year).html(year));
             $('#country').append($('<option selected></option>').val(country).html(country));
             $('#state').append($('<option selected></option>').val(state).html(state));
-            expect($('#state option').length).toBe(1);
+            assert.strictEqual($('#state option').length, 1);
             hd.init(country, state);
             const holidays = await getHolidays();
             expect(holidays).toEqual(hd.getHolidays(year));
@@ -413,7 +414,7 @@ describe('Test Workday Waiver Window', function()
             $('#country').append($('<option selected></option>').val(country).html(country));
             $('#state').append($('<option selected></option>').val(state).html(state));
             $('#city').append($('<option selected></option>').val(city).html(city));
-            expect($('#state option').length).toBe(1);
+            assert.strictEqual($('#state option').length, 1);
             hd.init(country, state, city);
             const holidays = await getHolidays();
             expect(holidays).toEqual(hd.getHolidays(year));
@@ -448,8 +449,8 @@ describe('Test Workday Waiver Window', function()
             loadHolidaysTable();
             const holidaysLength = 0;
             const rowLength = $('#holiday-list-table tbody tr').length;
-            expect($('#holiday-list-table').css('display')).toBe('table');
-            expect(holidaysLength).toBe(rowLength);
+            assert.strictEqual($('#holiday-list-table').css('display'), 'table');
+            assert.strictEqual(holidaysLength, rowLength);
         });
 
         test('Load holidays table', async() =>
@@ -461,8 +462,8 @@ describe('Test Workday Waiver Window', function()
             const holidays = await getHolidays();
             const holidaysLength = holidays.length;
             const rowLength = $('#holiday-list-table tbody tr').length;
-            expect($('#holiday-list-table').css('display')).toBe('table');
-            expect(holidaysLength).toBe(rowLength);
+            assert.strictEqual($('#holiday-list-table').css('display'), 'table');
+            assert.strictEqual(holidaysLength, rowLength);
         });
 
         test('Holiday info initialize', async() =>
@@ -471,11 +472,11 @@ describe('Test Workday Waiver Window', function()
             $('#country').append($('<option selected></option>').val(country).html(country));
             $('#state').append($('<option selected></option>').val(state).html(state));
             await initializeHolidayInfo();
-            expect($('#holiday-list-table').css('display')).toBe('none');
-            expect($('#state').css('display')).toBe('none');
-            expect($('#holiday-state').css('display')).toBe('none');
-            expect($('#city').css('display')).toBe('none');
-            expect($('#holiday-city').css('display')).toBe('none');
+            assert.strictEqual($('#holiday-list-table').css('display'), 'none');
+            assert.strictEqual($('#state').css('display'), 'none');
+            assert.strictEqual($('#holiday-state').css('display'), 'none');
+            assert.strictEqual($('#city').css('display'), 'none');
+            assert.strictEqual($('#holiday-city').css('display'), 'none');
         });
     });
 
@@ -493,15 +494,15 @@ describe('Test Workday Waiver Window', function()
             addHolidayToList(day, reason);
             const table = $('#holiday-list-table tbody');
             const rowsLength = table.find('tr').length;
-            expect(rowsLength).toBe(1);
+            assert.strictEqual(rowsLength, 1);
             const firstCell = table.find('td')[0].innerHTML;
             const secondCell = table.find('td')[1].innerHTML;
             const thirdCell = table.find('td')[2].innerHTML;
             const fourthCell = table.find('td')[4].innerHTML;
             const fourthCellContent = `<label class="switch"><input type="checkbox" checked="" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
-            expect(firstCell).toBe(day);
-            expect(secondCell).toBe(reason);
-            expect(thirdCell).toBe('undefined');
+            assert.strictEqual(firstCell, day);
+            assert.strictEqual(secondCell, reason);
+            assert.strictEqual(thirdCell, 'undefined');
             expect(fourthCell).toEqual(fourthCellContent);
         });
 
@@ -513,15 +514,15 @@ describe('Test Workday Waiver Window', function()
             addHolidayToList(day, reason, workingDay);
             const table = $('#holiday-list-table tbody');
             const rowsLength = table.find('tr').length;
-            expect(rowsLength).toBe(1);
+            assert.strictEqual(rowsLength, 1);
             const firstCell = table.find('td')[0].innerHTML;
             const secondCell = table.find('td')[1].innerHTML;
             const thirdCell = table.find('td')[2].innerHTML;
             const fourthCell = table.find('td')[4].innerHTML;
             const fourthCellContent = `<label class="switch"><input type="checkbox" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
-            expect(firstCell).toBe(day);
-            expect(secondCell).toBe(reason);
-            expect(thirdCell).toBe(workingDay);
+            assert.strictEqual(firstCell, day);
+            assert.strictEqual(secondCell, reason);
+            assert.strictEqual(thirdCell, workingDay);
             expect(fourthCell).toEqual(fourthCellContent);
         });
 
@@ -534,17 +535,17 @@ describe('Test Workday Waiver Window', function()
             addHolidayToList(day, reason, workingDay, conflicts);
             const table = $('#holiday-list-table tbody');
             const rowsLength = table.find('tr').length;
-            expect(rowsLength).toBe(1);
+            assert.strictEqual(rowsLength, 1);
             const firstCell = table.find('td')[0].innerHTML;
             const secondCell = table.find('td')[1].innerHTML;
             const thirdCell = table.find('td')[2].innerHTML;
             const conflictsCell = table.find('td')[3].innerHTML;
             const fourthCell = table.find('td')[4].innerHTML;
             const fourthCellContent = `<label class="switch"><input type="checkbox" name="import-${day}" id="import-${day}"><span class="slider round"></span></label>`;
-            expect(firstCell).toBe(day);
-            expect(secondCell).toBe(reason);
-            expect(thirdCell).toBe(workingDay);
-            expect(conflictsCell).toBe(conflicts);
+            assert.strictEqual(firstCell, day);
+            assert.strictEqual(secondCell, reason);
+            assert.strictEqual(thirdCell, workingDay);
+            assert.strictEqual(conflictsCell, conflicts);
             expect(fourthCell).toEqual(fourthCellContent);
         });
     });
@@ -563,28 +564,28 @@ describe('Test Workday Waiver Window', function()
         {
             const tableId = 'waiver-list-table';
             let rowLength = $(`#${tableId} tbody tr`).length;
-            expect(rowLength).toBe(2);
+            assert.strictEqual(rowLength, 2);
             clearTable($(`#${tableId}`));
             rowLength = $(`#${tableId} tbody tr`).length;
-            expect(rowLength).toBe(0);
+            assert.strictEqual(rowLength, 0);
         });
 
         test('Clear holiday table', () =>
         {
             let rowLength = $('#holiday-list-table tbody tr').length;
-            expect(rowLength).toBe(1);
+            assert.strictEqual(rowLength, 1);
             clearHolidayTable();
             rowLength = $('#holiday-list-table tbody tr').length;
-            expect(rowLength).toBe(0);
+            assert.strictEqual(rowLength, 0);
         });
 
         test('Clear waiver table', () =>
         {
             let rowLength = $('#waiver-list-table tbody tr').length;
-            expect(rowLength).toBe(2);
+            assert.strictEqual(rowLength, 2);
             clearWaiverList();
             rowLength = $('#waiver-list-table tbody tr').length;
-            expect(rowLength).toBe(0);
+            assert.strictEqual(rowLength, 0);
         });
     });
 });

--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -259,10 +259,10 @@ describe('Test Workday Waiver Window', function()
             document.body.appendChild(btn);
         });
 
-        test('Testing button is exist', () =>
+        test('Testing button exists', () =>
         {
-            const exists = document.querySelectorAll(`#${btnId}`).length;
-            assert.notStrictEqual(exists, undefined);
+            const btnLength = document.querySelectorAll(`#${btnId}`).length;
+            assert.strictEqual(btnLength > 0, true);
         });
 
         test('Make disabled', () =>


### PR DESCRIPTION
#### Related issue
Helps #1037

#### Context / Background
As described in #1054, jest no longer works with electron and we'll be switching to mocha. Mocha does not have its own assertion library, so we'll be using node's "assert" library.

#### What change is being introduced by this PR?
Replacing all possible "expect" calls from jest with the correspondent ones from "assert", so the changes in the next PR are smaller.

#### How will this be tested?
Tests are passing in the same way.