### PR TITLE
Continue electron-mocha-renderer migration

### DIFF
--- a/__tests__/__renderer__/notification-channel.js
+++ b/__tests__/__renderer__/notification-channel.js
@@ -1,17 +1,20 @@
 'use strict';
 
-const assert = require('assert');
+import assert from 'assert';
+import jQuery from 'jquery';
+import jsdom from 'jsdom';
 
-const notificationChannel = require('../../renderer/notification-channel.js');
+import { searchLeaveByElement } from '../../renderer/notification-channel.js';
+
+global.$ = jQuery(new jsdom.JSDOM().window);
 
 describe('Notifications channel',  () =>
 {
     it('Should get content of #leave-by element', done =>
     {
-        window.$ = require('jquery');
         $('body').append('<input id="leave-by" value="12:12" />');
         // Way to get the file considered for coverage
-        notificationChannel.searchLeaveByElement({
+        searchLeaveByElement({
             sender: {
                 send: (channel, value) =>
                 {

--- a/__tests__/__renderer__/workday-waiver-aux.js
+++ b/__tests__/__renderer__/workday-waiver-aux.js
@@ -1,14 +1,16 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const assert = require('assert');
+import assert from 'assert';
 
 import { formatDayId, displayWaiverWindow } from '../../renderer/workday-waiver-aux.js';
 
 // Mocking call
 // TODO: find a better way to mock this or even really test it
-window.mainApi = {
-    displayWaiverWindow: () => {}
+global.window = {
+    mainApi: {
+        displayWaiverWindow: () => {}
+    }
 };
 
 describe('Workday Waiver Aux', function()
@@ -22,13 +24,13 @@ describe('Workday Waiver Aux', function()
 
     describe('formatDayId(dayId)', function()
     {
-        test('should be valid', () =>
+        it('should be valid', () =>
         {
             assert.strictEqual(formatDayId(validJSDay), '2020-04-10');
             assert.strictEqual(formatDayId(validJSDay2), '2020-01-10');
         });
 
-        test('should not be valid', () =>
+        it('should not be valid', () =>
         {
             assert.strictEqual(formatDayId(garbageString), NaN);
             assert.strictEqual(formatDayId(incompleteDate), NaN);
@@ -37,7 +39,7 @@ describe('Workday Waiver Aux', function()
 
     describe('displayWaiverWindow(dayId)', function()
     {
-        test('should do seamless call', async() =>
+        it('should do seamless call', async() =>
         {
             await displayWaiverWindow(validJSDay);
             await displayWaiverWindow(validJSDay2);

--- a/__tests__/electron-mocha-renderer.config.cjs
+++ b/__tests__/electron-mocha-renderer.config.cjs
@@ -1,5 +1,5 @@
 const data = require('./mocha-base.config.cjs');
 
-data.spec = ['__tests__/__renderer__/themes.js'];
+data.spec = ['__tests__/__renderer__/{themes,workday-waiver-aux}.js'];
 
 module.exports = data;

--- a/__tests__/electron-mocha-renderer.config.cjs
+++ b/__tests__/electron-mocha-renderer.config.cjs
@@ -1,5 +1,5 @@
 const data = require('./mocha-base.config.cjs');
 
-data.spec = ['__tests__/__renderer__/{themes,workday-waiver-aux}.js'];
+data.spec = ['__tests__/__renderer__/{notification-channel,themes,workday-waiver-aux}.js'];
 
 module.exports = data;

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
             displayName: 'RENDERER',
             runner: '@jest-runner/electron',
             testEnvironment: '@jest-runner/electron/environment',
-            testMatch: ['**/__tests__/**renderer**/*.js', '**/__tests__/**renderer**/classes/*.js', '!**/themes.js']
+            testMatch: ['**/__tests__/**renderer**/*.js', '**/__tests__/**renderer**/classes/*.js', '!**/{themes,workday-waiver-aux}.js']
         }
     ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
             displayName: 'RENDERER',
             runner: '@jest-runner/electron',
             testEnvironment: '@jest-runner/electron/environment',
-            testMatch: ['**/__tests__/**renderer**/*.js', '**/__tests__/**renderer**/classes/*.js', '!**/{themes,workday-waiver-aux}.js']
+            testMatch: ['**/__tests__/**renderer**/*.js', '**/__tests__/**renderer**/classes/*.js', '!**/{notification-channel,themes,workday-waiver-aux}.js']
         }
     ]
 };


### PR DESCRIPTION
#### Related issue
Helps #1037

#### Context / Background
Continues from #1065
Here I'm migrating the other tests that don't depend on jest and that require a simple migration.

We'll need to add `global.$ = jQuery(new jsdom.JSDOM().window);` when a test requires jquery because mocha needs jsdom to create an actual html document to test.