### PR TITLE
check for empty array of values

### DIFF
--- a/js/import-export.js
+++ b/js/import-export.js
@@ -84,7 +84,7 @@ function validEntry(entry)
         let validatedTime = true;
         if (entry.type === 'flexible')
         {
-            hasExpectedProperties = entry.hasOwnProperty('values') && Array.isArray(entry.values);
+            hasExpectedProperties = entry.hasOwnProperty('values') && Array.isArray(entry.values) && entry.values.length > 0;
             if (hasExpectedProperties)
             {
                 for (const value of entry.values)


### PR DESCRIPTION
#### Related issue
Closes #1068 

#### Context / Background
A user can import a database which has an array of empty values, and the overall balance incorrectly updates. When importing a database, I expected that the app would check for an array of empty values before validating, and fail if there is no values in the database file. And even if the app should accept empty values, the overall time balance shouldn't be affected since there is no times entered.


#### What change is being introduced by this PR?

- _How did you approach this problem?_
I thought about what has to be changed in the logic of the `validEntry` function in the `import-export.js` file so that users can't upload an empty database file which automatically would fix the issue of seeing an incorrect balance update.
- _What changes did you make to achieve the goal?_
I have added a check for an array of empty values before validating. The user can now only import a database which actually has values.
- _What are the indirect and direct consequences of the change?_
The function's update ensures data validation by rejecting entries with empty value arrays, maintaining data integrity. This change also indirectly prevents errors in other application parts relying on entries with at least one time value, thus avoiding potential inaccuracies or failures in calculations.

#### How will this be tested?
After running the Time To Leave App, a user will not be able to import an empty database. To test this, create a `testdb.ttldb` file with the contents: 
`[ { "type": "flexible", "date": "2023-05-21", "values": [] } ]`

After attempting to import the file, the app should say:
![image](https://github.com/thamara/time-to-leave/assets/107959606/24699ea3-4833-46cd-8df1-edece5d11493)

