### PR TITLE
Custom hours daily

### DIFF
--- a/js/time-balance.js
+++ b/js/time-balance.js
@@ -64,12 +64,26 @@ function _getOverallBalanceStartDate()
     return savedPreferences['overall-balance-start-date'];
 }
 
-function _getHoursPerDay()
+// function _getHoursPerDay()
+// {
+//     const savedPreferences = getUserPreferences();
+//     return savedPreferences['hours-per-day'];
+// }
+
+function _getHoursForDay(dayIndex)
 {
     const savedPreferences = getUserPreferences();
-    return savedPreferences['hours-per-day'];
+    const days = [
+        'sunday',
+        'monday',
+        'tuesday',
+        'wednesday',
+        'thursday',
+        'friday',
+        'saturday'
+    ];
+    return savedPreferences[`hours-${days[dayIndex]}`] || '08:00';
 }
-
 /**
 * Given an array of times from a day in the flexible calendar, returns the
 * day total according to same calculation rules as those of the calendar.
@@ -170,7 +184,7 @@ async function computeAllTimeBalanceUntil(limitDate)
     const totals = _getDayTotalsFromStores(firstDate, limitDate);
 
     const preferences = getUserPreferences();
-    const hoursPerDay = _getHoursPerDay();
+    // const hoursPerDay = _getHoursPerDay();
     let allTimeTotal = '00:00';
     const date = new Date(firstDate);
     const limitDateStr = getDateStr(limitDate);
@@ -179,8 +193,10 @@ async function computeAllTimeBalanceUntil(limitDate)
     {
         if (showDay(date.getFullYear(), date.getMonth(), date.getDate(), preferences))
         {
+            const dayIndex = date.getDay();
+            const dayHours = _getHoursForDay(dayIndex);
             const dayTotal = dateStr in totals ? totals[dateStr] : '00:00';
-            const dayBalance = subtractTime(hoursPerDay, dayTotal);
+            const dayBalance = subtractTime(dayHours, dayTotal);
             allTimeTotal = sumTime(dayBalance, allTimeTotal);
         }
         date.setDate(date.getDate() + 1);

--- a/js/user-preferences.js
+++ b/js/user-preferences.js
@@ -32,7 +32,14 @@ const defaultPreferences = {
     'close-to-tray': true,
     'minimize-to-tray': true,
     'hide-non-working-days': false,
-    'hours-per-day': '08:00',
+    'hours-sunday': '08:00',
+    'hours-monday': '08:00',
+    'hours-tuesday': '08:00',
+    'hours-wednesday': '08:00',
+    'hours-thursday': '08:00',
+    'hours-friday': '08:00',
+    'hours-saturday': '08:00',
+    'hours-per-day': '08:00', //probably need to remove
     'enable-prefill-break-time': false,
     'break-time-interval': '00:30',
     'notification': true,
@@ -76,6 +83,13 @@ const timeInputs = [
     'notifications-interval',
     'hours-per-day',
     'break-time-interval',
+    'hours-sunday',
+    'hours-monday',
+    'hours-tuesday',
+    'hours-wednesday',
+    'hours-thursday',
+    'hours-friday',
+    'hours-saturday',
 ];
 
 const isNotBoolean = (val) => typeof val !== 'boolean';
@@ -111,7 +125,9 @@ function savePreferences(preferencesOptions, filePath = getPreferencesFilePath()
 {
     try
     {
-        getFs().writeFileSync(filePath, JSON.stringify(preferencesOptions));
+        const preferencesToSave = { ...defaultPreferences, ...preferencesOptions };
+        getFs().writeFileSync(filePath, JSON.stringify(preferencesToSave));
+
     }
     catch (err)
     {
@@ -190,6 +206,13 @@ function initPreferencesFileIfNotExistsOrInvalid(filePath = getPreferencesFilePa
                 'notifications-interval' : () => isNotificationInterval(value),
                 'hours-per-day' : () =>  validateTime(value),
                 'break-time-interval' : () =>  validateTime(value),
+                'hours-sunday': () => validateTime(value),
+                'hours-monday': () => validateTime(value),
+                'hours-tuesday': () => validateTime(value),
+                'hours-wednesday': () => validateTime(value),
+                'hours-thursday': () => validateTime(value),
+                'hours-friday': () => validateTime(value),
+                'hours-saturday': () => validateTime(value),
             };
             if (!timeValidationEnum[key]())
             {

--- a/renderer/classes/BaseCalendar.js
+++ b/renderer/classes/BaseCalendar.js
@@ -336,7 +336,8 @@ class BaseCalendar
         return this._preferences['hours-per-day'];
     }
 
-    _getHoursForDay(dayIndex) {
+    _getHoursForDay(dayIndex)
+    {
         const days = [
             'sunday',
             'monday',
@@ -346,7 +347,7 @@ class BaseCalendar
             'friday',
             'saturday'
         ];
-        return this._preferences[`hours-${days[dayIndex]}`] || '08:00'; 
+        return this._preferences[`hours-${days[dayIndex]}`] || '08:00';
     }
 
     /**

--- a/renderer/classes/BaseCalendar.js
+++ b/renderer/classes/BaseCalendar.js
@@ -336,6 +336,19 @@ class BaseCalendar
         return this._preferences['hours-per-day'];
     }
 
+    _getHoursForDay(dayIndex) {
+        const days = [
+            'sunday',
+            'monday',
+            'tuesday',
+            'wednesday',
+            'thursday',
+            'friday',
+            'saturday'
+        ];
+        return this._preferences[`hours-${days[dayIndex]}`] || '08:00'; 
+    }
+
     /**
      * Returns if "hide non-working days" was set in preferences.
      * @return {Boolean}
@@ -659,8 +672,10 @@ class BaseCalendar
             }
             if (timesAreProgressing)
             {
-                const lastTime = validatedTimes[validatedTimes.length-1];
-                const remainingTime = subtractTime(dayTotal, this._getHoursPerDay());
+                const lastTime = validatedTimes[validatedTimes.length - 1];
+                const dayIndex = new Date(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate()).getDay();
+                const dayHours = this._getHoursForDay(dayIndex);
+                const remainingTime = subtractTime(dayTotal, dayHours);
                 leaveBy = sumTime(lastTime, remainingTime);
             }
         }

--- a/renderer/classes/FlexibleDayCalendar.js
+++ b/renderer/classes/FlexibleDayCalendar.js
@@ -2,7 +2,6 @@
 
 import {
     isNegative,
-    multiplyTime,
     subtractTime,
     sumTime,
     validateTime
@@ -63,7 +62,8 @@ class FlexibleDayCalendar extends BaseCalendar
             'hours-friday',
             'hours-saturday'
         ];
-        if (dayIndex < 0 || dayIndex > 6) {
+        if (dayIndex < 0 || dayIndex > 6)
+        {
             throw new Error('Invalid dayIndex provided to _getHoursForDay.');
         }
         return this._preferences[dayKeys[dayIndex]] || '08:00';
@@ -404,37 +404,37 @@ class FlexibleDayCalendar extends BaseCalendar
     {
         const yesterday = new Date(this._calendarDate);
         yesterday.setDate(this._calendarDate.getDate() - 1);
-        let workingDaysToCompute = 0,
-            monthTotalWorked = '00:00';
-        let countDays = false;
+
+        let monthTotalWorked = '00:00';
 
         const limit = this._getCountToday() ? this._getCalendarDate() : (yesterday.getMonth() !== this._getCalendarMonth() ? 0 : yesterday.getDate());
-        for (let day = 1; day <= limit; ++day) {
-            if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day)) {
+        for (let day = 1; day <= limit; ++day)
+        {
+            if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day))
+            {
                 continue;
             }
             const dayTotal = this._getDayTotal(this._getCalendarYear(), this._getCalendarMonth(), day);
-            if (dayTotal !== undefined) {
-                countDays = true;
-        
-                const dayIndex = new Date(this._getCalendarYear(), this._getCalendarMonth(), day).getDay(); // Get current day 
-                const hoursForDay = this._getHoursForDay(dayIndex); 
+            if (dayTotal !== undefined)
+            {
+
+                const dayIndex = new Date(this._getCalendarYear(), this._getCalendarMonth(), day).getDay(); // Get current day
+                const hoursForDay = this._getHoursForDay(dayIndex);
                 const dayBalance = subtractTime(hoursForDay, dayTotal);
-                monthTotalWorked = sumTime(monthTotalWorked, dayBalance); 
+                monthTotalWorked = sumTime(monthTotalWorked, dayBalance);
             }
-            if (countDays) {
-                workingDaysToCompute += 1;
-            }
+
         }
-        
+
         const balance = monthTotalWorked;
         const balanceElement = $('#month-balance');
-        if (balanceElement) {
+        if (balanceElement)
+        {
             balanceElement.html(balance);
             balanceElement.removeClass('text-success text-danger');
             balanceElement.addClass(isNegative(balance) ? 'text-danger' : 'text-success');
         }
-        
+
     }
 
     /**
@@ -456,8 +456,8 @@ class FlexibleDayCalendar extends BaseCalendar
         const dayTotal = $('.day-total span').html();
         if (dayTotal !== undefined && dayTotal.length > 0)
         {
-            const dayIndex = new Date(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate()).getDay(); 
-            const dayHours = this._getHoursForDay(dayIndex); 
+            const dayIndex = new Date(this._getTodayYear(), this._getTodayMonth(), this._getTodayDate()).getDay();
+            const dayHours = this._getHoursForDay(dayIndex);
             const dayBalance = subtractTime(dayHours, dayTotal);
             $('#leave-day-balance').val(dayBalance);
             $('#leave-day-balance').removeClass('text-success text-danger');

--- a/renderer/classes/FlexibleMonthCalendar.js
+++ b/renderer/classes/FlexibleMonthCalendar.js
@@ -512,56 +512,61 @@ class FlexibleMonthCalendar extends BaseCalendar
     /*
     * Updates the monthly time balance.
     */
-    _updateBalance() {
+    _updateBalance()
+    {
         const now = new Date();
         const monthLength = getMonthLength(this._getCalendarYear(), this._getCalendarMonth());
-        let workingDaysToCompute = [];
+        const workingDaysToCompute = [];
         let monthTotalWorked = '00:00';
-        let countDays = false;
         let isNextDay = false;
-    
-        for (let day = 1; day <= monthLength; ++day) {
+
+        for (let day = 1; day <= monthLength; ++day)
+        {
             const isToday = now.getDate() === day &&
                 now.getMonth() === this._getCalendarMonth() &&
                 now.getFullYear() === this._getCalendarYear();
-    
-            // balance should consider preferences and count or not today
-            if (isToday && !this._getCountToday() || isNextDay && this._getCountToday()) {
+
+            // balance should consider preferences and count or notyyyyyyyyyyyyyyyyyyyyyyyy today
+            if (isToday && !this._getCountToday() || isNextDay && this._getCountToday())
+            {
                 break;
             }
             isNextDay = isToday;
-    
-            if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day)) {
+
+            if (!this._showDay(this._getCalendarYear(), this._getCalendarMonth(), day))
+            {
                 continue;
             }
-    
+
             const dayTotal = this._getDayTotal(this._getCalendarYear(), this._getCalendarMonth(), day);
-            if (dayTotal) {
-                countDays = true;
+            if (dayTotal)
+            {
                 monthTotalWorked = sumTime(monthTotalWorked, dayTotal);
 
                 const dayIndex = new Date(this._getCalendarYear(), this._getCalendarMonth(), day).getDay();
                 workingDaysToCompute.push(dayIndex);
             }
         }
-    
-        const monthTotalToWork = workingDaysToCompute.reduce((total, dayIndex) => {
+
+        const monthTotalToWork = workingDaysToCompute.reduce((total, dayIndex) =>
+        {
             return sumTime(total, multiplyTime(this._getHoursForDay(dayIndex), -1));
         }, '00:00');
-    
+
         const balance = sumTime(monthTotalToWork, monthTotalWorked);
-    
+
 
         const balanceElement = $('#month-balance');
-        if (balanceElement) {
+        if (balanceElement)
+        {
             balanceElement.val(balance);
             balanceElement.removeClass('text-success text-danger');
             balanceElement.addClass(isNegative(balance) ? 'text-danger' : 'text-success');
         }
         this._updateAllTimeBalance();
     }
-    
-    
+
+
 
     /*
      * Updates data displayed based on the database.

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -44,6 +44,12 @@
                 <p data-i18n="$Preferences.hoursPerDay">Hours per day</p>
                 <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
             </div>
+            <section>
+                <div class="section-title" data-i18n="$Preferences.hoursForSelectedDays">Set hours for selected days</div>
+                <div id="hours-container">
+                    <!-- Dynamic inputs will appear here -->
+                </div>
+            </section>
             <div class="flex-box">
                 <p><i class="fas fa-utensils"></i><span data-i18n="$Preferences.enablePrefillBreakTime">Enable prefilling of break time</span></p>
                 <label class="switch"><input type="checkbox" id='enable-prefill-break-time' name="enable-prefill-break-time"><span class="slider round"></span></label>

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -36,20 +36,16 @@
                 <input type="checkbox" id="saturday" name="working-days-saturday" class="weekday" />
                 <label for="saturday" data-i18n="$Preferences.sat">Sat</label>
             </div>
-            <div class="flex-box">
+            
+            <section> 
+                <div class="section-title" data-i18n="$Preferences.hoursPerDay">Hours per day</div>
+                <div id="hours-container">
+                </div>
+            </section>
+            <div class="flex-box"style="margin-top: 1rem;">
                 <p data-i18n="$Preferences.hideNonWorkingDay">Hide non-working days (Month View)</p>
                 <label id='non-working-label' class="switch"><input type="checkbox" name="hide-non-working-days"><span class="slider round"></span></label>
             </div>
-            <div class="flex-box">
-                <p data-i18n="$Preferences.hoursPerDay">Hours per day</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
-            </div>
-            <section>
-                <div class="section-title" data-i18n="$Preferences.hoursForSelectedDays">Set hours for selected days</div>
-                <div id="hours-container">
-                    <!-- Dynamic inputs will appear here -->
-                </div>
-            </section>
             <div class="flex-box">
                 <p><i class="fas fa-utensils"></i><span data-i18n="$Preferences.enablePrefillBreakTime">Enable prefilling of break time</span></p>
                 <label class="switch"><input type="checkbox" id='enable-prefill-break-time' name="enable-prefill-break-time"><span class="slider round"></span></label>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -65,7 +65,13 @@ function refreshContent()
 
 function changeValue(type, newVal)
 {
+    //preferences[type] = "03:00 07:00 04:00 02:00 03:00 03:00 05:00";
     preferences[type] = newVal;
+    //preferences["hours-per-day"] = "03:00 07:00 04:00 02:00 03:00 03:00 05:00";
+    //console.log("HELP friday "+ preferences["hours-friday"]);
+    //console.log("HELP2 "+ preferences["hours-per-day"]);
+    console.log('HELP2 '+ preferences[type]);
+
     window.mainApi.notifyNewPreferences(preferences);
 }
 
@@ -182,6 +188,76 @@ function renderPreferencesWindow()
     {
         notificationsInterval.prop('disabled', !repetition.is(':checked'));
     });
+
+    const days = [
+        { id: 'sunday', label: 'Sunday' },
+        { id: 'monday', label: 'Monday' },
+        { id: 'tuesday', label: 'Tuesday' },
+        { id: 'wednesday', label: 'Wednesday' },
+        { id: 'thursday', label: 'Thursday' },
+        { id: 'friday', label: 'Friday' },
+        { id: 'saturday', label: 'Saturday' },
+    ];
+
+    const hoursContainer = $('#hours-container');
+
+    function updateHoursInputs()
+    {
+        hoursContainer.empty(); // Clear previous inputs
+
+        days.forEach(day =>
+        {
+            const isChecked = $(`#${day.id}`).is(':checked');
+            if (isChecked)
+            {
+                const inputId = `hours-${day.id}`;
+                const storedValue = usersStyles[inputId] || '08:00'; // Default or saved value
+
+                const inputHTML = `
+                    <div class="flex-box">
+                        <label for="${inputId}">${day.label}</label>
+                        <input 
+                            type="text" 
+                            id="${inputId}" 
+                            name="${inputId}" 
+                            maxlength="5" 
+                            pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" 
+                            value="${storedValue}" 
+                            size="5" 
+                            required 
+                        />
+                    </div>
+                `;
+                hoursContainer.append(inputHTML);
+
+                $(`#${inputId}`).on('change', function()
+                {
+                    if (this.checkValidity())
+                    {
+                        changeValue(inputId, this.value);
+                    }
+                });
+            }
+        });
+    }
+
+    days.forEach(day =>
+    {
+        const checkbox = $(`#${day.id}`);
+        if (checkbox)
+        {
+            checkbox.prop('checked', usersStyles[`working-days-${day.id}`] || false);
+
+            checkbox.on('change', function()
+            {
+                changeValue(`working-days-${day.id}`, this.checked);
+                updateHoursInputs();
+            });
+        }
+    });
+
+    updateHoursInputs();
+
 }
 /* istanbul ignore next */
 $(() =>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -65,12 +65,9 @@ function refreshContent()
 
 function changeValue(type, newVal)
 {
-    //preferences[type] = "03:00 07:00 04:00 02:00 03:00 03:00 05:00";
+
     preferences[type] = newVal;
-    //preferences["hours-per-day"] = "03:00 07:00 04:00 02:00 03:00 03:00 05:00";
-    //console.log("HELP friday "+ preferences["hours-friday"]);
-    //console.log("HELP2 "+ preferences["hours-per-day"]);
-    console.log('HELP2 '+ preferences[type]);
+
 
     window.mainApi.notifyNewPreferences(preferences);
 }
@@ -190,20 +187,20 @@ function renderPreferencesWindow()
     });
 
     const days = [
-        { id: 'sunday', label: 'Sunday' },
-        { id: 'monday', label: 'Monday' },
-        { id: 'tuesday', label: 'Tuesday' },
-        { id: 'wednesday', label: 'Wednesday' },
-        { id: 'thursday', label: 'Thursday' },
-        { id: 'friday', label: 'Friday' },
-        { id: 'saturday', label: 'Saturday' },
+        { id: 'sunday', label: 'sun' },
+        { id: 'monday', label: 'mon' },
+        { id: 'tuesday', label: 'tue' },
+        { id: 'wednesday', label: 'wed' },
+        { id: 'thursday', label: 'thu' },
+        { id: 'friday', label: 'fri' },
+        { id: 'saturday', label: 'sat' },
     ];
 
     const hoursContainer = $('#hours-container');
 
     function updateHoursInputs()
     {
-        hoursContainer.empty(); // Clear previous inputs
+        hoursContainer.empty();
 
         days.forEach(day =>
         {
@@ -214,20 +211,21 @@ function renderPreferencesWindow()
                 const storedValue = usersStyles[inputId] || '08:00'; // Default or saved value
 
                 const inputHTML = `
-                    <div class="flex-box">
-                        <label for="${inputId}">${day.label}</label>
-                        <input 
-                            type="text" 
-                            id="${inputId}" 
-                            name="${inputId}" 
-                            maxlength="5" 
-                            pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" 
-                            value="${storedValue}" 
-                            size="5" 
-                            required 
-                        />
-                    </div>
-                `;
+                <div class="flex-box">
+                    <p data-i18n="$Preferences.${day.id}">${day.label}</p>
+                    <input 
+                        type="text" 
+                        id="${inputId}" 
+                        name="${inputId}" 
+                        maxlength="5" 
+                        pattern="^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$" 
+                        value="${storedValue}" 
+                        size="5" 
+                        required 
+                        style="text-align: right;" 
+                    />
+                </div>
+            `;
                 hoursContainer.append(inputHTML);
 
                 $(`#${inputId}`).on('change', function()
@@ -238,6 +236,10 @@ function renderPreferencesWindow()
                     }
                 });
             }
+        });
+        window.mainApi.getLanguageDataPromise().then(languageData =>
+        {
+            translatePage(usersStyles.language, languageData.data, 'Preferences');
         });
     }
 


### PR DESCRIPTION
#### Related issue
Closes #1077

#### Context / Background

**Issue Description:**
**Describe the current limitation**
In the current state you can choose days in the preferences and choose hours per day (for all days).

**Describe the proposed feature or enhancement**
Add option to choose hours per day for every day.
For example for days: Sun, Tue, Thu set hours-per-day to 10:15 and for Mon, Wed set hours-per-day to 11:45.


#### What change is being introduced by this PR?

**- What changes did you make to achieve the goal? / How did you approach this problem?**
- Added a new section in the preferences.html/preferences.js page for "Hours per day" that **dynamically** displays inputs for working hours **based on selected weekdays**. 
- Also ensured that the new section is compatible and functional with the translation system set in place
- Updated the parameters in user-preferences.js, then updated the logic in:

BaseCalender.js
FlexibleDayCalender.js
FlexibleMonthCalender.js 
time-balance.js

to use these new params, and calculate the time to leave using the new daily hours

**If the user works Mon-Fri:**
![image](https://github.com/user-attachments/assets/9335c56f-3588-4f5b-a455-64aad8d8c88f)

**If the user works on Mon and Fri:**
![image](https://github.com/user-attachments/assets/a26c4b82-45c2-472c-9f19-2a98f9daf149)


**- What are the indirect and direct consequences of the change?**
**Direct Consequences:** 

- The "Hours per day" section dynamically adjusts to display inputs for the selected working days. This enables users to set specific working hours for each day.
- Users now have greater flexibility to customize their preferences, improving the overall usability.

**Indirect Consequence:** 
As a result **one** test case from "npm run test:jest" is failing, this is based on the **old** logic, where hours per day was a single value, So it was bound to fail, this needs to be updated in the case this issue is resolved.
![image](https://github.com/user-attachments/assets/906ef633-cc04-4420-8605-ac2a85a8ca6b)



#### How will this be tested?

**- How will you verify whether your changes worked as expected once merged?**
- As of now it is functional, once merged, manual testing of the "Hours per day" section can be done to verify that inputs are displayed, updated, and saved correctly.
- Additionally, the old logic's unit test can be updated to ensure this functionality is working with future updates.


----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
