### PR TITLE
Fix #1081: No tooltip when the cursor hovers over tray icon

### DIFF
--- a/js/main-window.js
+++ b/js/main-window.js
@@ -130,6 +130,8 @@ function createWindow()
         mainWindow.show();
     });
 
+    tray.setToolTip('Time to Leave');
+
     tray.on('right-click', () =>
     {
         tray.popUpContextMenu(contextMenu);


### PR DESCRIPTION
#### Related issue
Closes #1081

#### Context / Background
There is no tooltip (like the app name) when the mouse cursor is on the application icon on the tray area.

#### What change is being introduced by this PR?
A tooltip is added to the tray after it is instantiated.

#### How will this be tested?
Run the app.
Hover over the icon in your OS icon tray (Mac/Win).
You should see a tooltip with 'Time to Leave'.
