### PR TITLE
Fix System Default theme not listening to system theme change

### DIFF
--- a/js/main-window.js
+++ b/js/main-window.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { app, BrowserWindow, dialog, ipcMain, Menu, shell, Tray } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, shell, Tray } from 'electron';
 import path from 'path';
 import Store from 'electron-store';
 
@@ -162,6 +162,16 @@ function createWindow()
         }
     });
 
+    // Listen for system theme changes in real-time
+    nativeTheme.on('updated', () =>
+    {
+        const savedPreferences = getUserPreferences();
+        const theme = savedPreferences['theme'];
+        if (theme === 'system-default')
+        {
+            mainWindow.webContents.send('RELOAD_THEME', theme);
+        }
+    });
 }
 
 function triggerStartupDialogs()

--- a/renderer/preload-scripts/calendar-api.js
+++ b/renderer/preload-scripts/calendar-api.js
@@ -73,6 +73,7 @@ const calendarApi = {
     handleWaiverSaved: (callback) => ipcRenderer.on('WAIVER_SAVED', callback),
     handleCalendarReload: (callback) => ipcRenderer.on('RELOAD_CALENDAR', callback),
     handlePunchDate: (callback) => ipcRenderer.on('PUNCH_DATE', callback),
+    handleThemeChange: (callback) => ipcRenderer.on('RELOAD_THEME', callback),
     handleLeaveBy: (callback) => ipcRenderer.on('GET_LEAVE_BY', callback),
     resizeMainWindow: () => resizeMainWindow(),
     switchView: () => switchView(),

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -58,6 +58,14 @@ window.mainApi.handlePunchDate(() =>
 });
 
 /*
+ * Reload theme.
+ */
+window.mainApi.handleThemeChange(async(event, theme) =>
+{
+    applyTheme(theme);
+});
+
+/*
  * Returns value of "leave by" for notifications.
  */
 window.mainApi.handleLeaveBy(searchLeaveByElement);


### PR DESCRIPTION
#### Related issue
Somewhat related to #879

#### Context / Background
Upon reviewing #1080 I noticed that we could take the chance to start listening for the system theme changes to update the app on the fly.

#### What change is being introduced by this PR?
The app will now listen for system theme changes and reload the theme.

#### How will this be tested?
Tested manually, see the video:


https://github.com/user-attachments/assets/06a4b6d3-497c-4ddd-b8c6-45d276f65aba


