### PR TITLE
Remove duplicate RELOAD_CALENDAR listener

### DIFF
--- a/renderer/preload-scripts/calendar-api.js
+++ b/renderer/preload-scripts/calendar-api.js
@@ -73,7 +73,6 @@ const calendarApi = {
     handleWaiverSaved: (callback) => ipcRenderer.on('WAIVER_SAVED', callback),
     handleCalendarReload: (callback) => ipcRenderer.on('RELOAD_CALENDAR', callback),
     handlePunchDate: (callback) => ipcRenderer.on('PUNCH_DATE', callback),
-    handleReloadCalendar: (callback) => ipcRenderer.on('RELOAD_CALENDAR', callback),
     handleLeaveBy: (callback) => ipcRenderer.on('GET_LEAVE_BY', callback),
     resizeMainWindow: () => resizeMainWindow(),
     switchView: () => switchView(),

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -58,14 +58,6 @@ window.mainApi.handlePunchDate(() =>
 });
 
 /*
- * Reload calendar, used after database altering actions.
- */
-window.mainApi.handleReloadCalendar(() =>
-{
-    calendar.reload();
-});
-
-/*
  * Returns value of "leave by" for notifications.
  */
 window.mainApi.handleLeaveBy(searchLeaveByElement);


### PR DESCRIPTION
#### Related issue
Related to #1018

#### Context / Background
On making the calendar use a non-remote environment, #1018 had to create several async functions. While doing that, we kept the non-async function and it seems like we were registering (and likely executing) two identical functions upon the `RELOAD_CALENDAR` callback.

#### What change is being introduced by this PR?
Removing duplicated function

#### How will this be tested?
Tested manually that clearing the DB is still reloading the calendar:

https://github.com/user-attachments/assets/0d557374-b0eb-461f-bd3c-42b144b0aaf0

