### PR TITLE
Fix #948: Cannot scroll down the window in calendar view

### DIFF
--- a/renderer/classes/MonthCalendar.js
+++ b/renderer/classes/MonthCalendar.js
@@ -444,7 +444,6 @@ class MonthCalendar extends BaseCalendar
         $('.time-cells').mousewheel(function(e, delta)
         {
             if(this.children.length > 5) {
-                console.log("too long!!", this.children.length);
                 this.scrollLeft -= (delta * 30);
                 e.preventDefault();
             }

--- a/renderer/classes/MonthCalendar.js
+++ b/renderer/classes/MonthCalendar.js
@@ -443,7 +443,8 @@ class MonthCalendar extends BaseCalendar
 
         $('.time-cells').mousewheel(function(e, delta)
         {
-            if(this.children.length > 5) {
+            if (this.children.length > 5)
+            {
                 this.scrollLeft -= (delta * 30);
                 e.preventDefault();
             }

--- a/renderer/classes/MonthCalendar.js
+++ b/renderer/classes/MonthCalendar.js
@@ -443,8 +443,11 @@ class MonthCalendar extends BaseCalendar
 
         $('.time-cells').mousewheel(function(e, delta)
         {
-            this.scrollLeft -= (delta * 30);
-            e.preventDefault();
+            if(this.children.length > 5) {
+                console.log("too long!!", this.children.length);
+                this.scrollLeft -= (delta * 30);
+                e.preventDefault();
+            }
         });
     }
 

--- a/renderer/classes/MonthCalendar.js
+++ b/renderer/classes/MonthCalendar.js
@@ -443,9 +443,10 @@ class MonthCalendar extends BaseCalendar
 
         $('.time-cells').mousewheel(function(e, delta)
         {
-            if (this.children.length > 5)
+            const currentScroll = this.scrollLeft;
+            this.scrollLeft -= (delta * 30);
+            if (currentScroll !== this.scrollLeft)
             {
-                this.scrollLeft -= (delta * 30);
                 e.preventDefault();
             }
         });


### PR DESCRIPTION
#### Related issue
Closes #948 

#### Context / Background
Horizontal scrolling features locks vertical scrolling in the calendar view, even when horizontal scrolling is not necessary/possible. This creates an unintuitive scroll lock.

#### What change is being introduced by this PR?

- How did you approach this problem?
I looked into the mechanism that was blocking vertical scrolling to see how it was blocked, and what could be done to unblock it under conditions where it wasn't appropriate.

- What changes did you make to achieve the goal?
I wrapped the logic that changes vertical scrolling to horizontal scrolling in a condition that ~~limited this to only cases where the element in question had enough data ( more than the default 5 child elements ).~~ re-enables vertical scrolling over the row once scrolling has reached the end in the horizontal direction.

- What are the indirect and direct consequences of the change?
Direct consequences: You can now scroll vertically while hovering the cursor on any element that is not a row with excess data. These rows still maintain their horizontal scrolling functionality as before.
There are no apparent indirect consequences.

#### How will this be tested?
Open the app in month view.
Make sure you have at least one row that has enough data to necessitate sideways scrolling.
 - Fill in all the times with random data, and then use the + button to add even more times.
Place the cursor over empty rows and check that vertical scrolling works.
Place the cursor over a row with extra (off-screen) data and check that horizontal scrolling still works, allowing you to still access all data in that row.


*Updated screen recording* 👇

https://github.com/user-attachments/assets/0041caa2-8c19-486a-b5fd-e36e6d3731e7


