### PR TITLE
Fix broken scripts after electron 28 migration

### DIFF
--- a/scripts/check_languages.py
+++ b/scripts/check_languages.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode, unquote, urlparse, parse_qsl, ParseResult
 
 LOCALES_PATH = 'locales/'
 BASELINE_LANGUAGE = 'en'
-LANG_CONFIG_FILE = 'src/configs/app.config.js'
+LANG_CONFIG_FILE = 'src/configs/app.config.mjs'
 SCOPE_KEY_TO_IGNORE = {'$Menu' : ['ttl-github']}
 
 LANG_SCOPE_KEY_TO_IGNORE = {'de-DE': {'$Preferences' : ['themes', 'hours-per-day'],

--- a/scripts/update-changelog.py
+++ b/scripts/update-changelog.py
@@ -10,7 +10,7 @@ from pathlib import Path
 # And updates the the changelog file to include the new information
 
 # Global settings
-g_prefix_line = '-   '
+g_prefix_line = '- '
 g_begin_changes = '<!--- Begin changes - Do not remove -->'
 g_end_changes = '<!--- End changes - Do not remove -->'
 g_begin_users = '<!--- Begin users - Do not remove -->'


### PR DESCRIPTION
This just fixes some things broken by #1037 :
- e51fc72dbf09ec86caa41d4c619bd03c96b46fb8 - The changelog will now be updated according to prettier
- 750348b1add49c58f1ffd6fa6c5860823bc6aa71 - Use the new path for `app.config`