### PR TITLE
Update "set-output" GitHub action command being deprecated

### DIFF
--- a/.github/workflows/localization-report.yml
+++ b/.github/workflows/localization-report.yml
@@ -35,8 +35,8 @@ jobs:
           body=$(cat comparison.md)
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo ::set-output name=log::$body
+          body="${body//$'\r'/'%0D'}"
+          echo "log=$body" >> $GITHUB_OUTPUT
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:

--- a/.github/workflows/update-missing-translations.yml
+++ b/.github/workflows/update-missing-translations.yml
@@ -23,8 +23,8 @@ jobs:
         body=$(cat missing.md)
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
-        body="${body//$'\r'/'%0D'}" 
-        echo ::set-output name=body::$body 
+        body="${body//$'\r'/'%0D'}"
+        echo "body=$body" >> $GITHUB_OUTPUT
     - name: Update comment
       uses: peter-evans/create-or-update-comment@v1
       with:


### PR DESCRIPTION
#### Related issue
Closes #1100

#### Context / Background
"The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands"

#### What change is being introduced by this PR?
Using the new solution for the command being deprecated in the two places where we use it.

#### How will this be tested?
Checking the action succeeds after this PR.
