### PR TITLE
Update files to point to TTLApp organization

### DIFF
--- a/.github/workflows/UpdateDependencies.yml
+++ b/.github/workflows/UpdateDependencies.yml
@@ -3,7 +3,7 @@ on:
 name: Update package dependencies
 jobs:
   package-update:
-    if: github.repository == 'thamara/time-to-leave'
+    if: github.repository == 'TTLApp/time-to-leave'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/update-missing-translations.yml
+++ b/.github/workflows/update-missing-translations.yml
@@ -29,7 +29,7 @@ jobs:
       uses: peter-evans/create-or-update-comment@v1
       with:
         # Update the comment in issue 475
-        # https://github.com/thamara/time-to-leave/issues/475#issuecomment-808787273
+        # https://github.com/TTLApp/time-to-leave/issues/475#issuecomment-808787273
         comment-id: 808787273
         edit-mode: replace
         body: ${{ steps.get-comment-body.outputs.body }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ Working on your first Pull Request? You can learn how from this _free_ series [H
 ## Setup
 
 If you intend on contributing to the project, you will need to [fork the main repository](https://guides.github.com/activities/forking/) first, and then clone it to your local machine.
-If you just want to build it locally, you can clone directly from the main repository: `https://github.com/thamara/time-to-leave`
+If you just want to build it locally, you can clone directly from the main repository: `https://github.com/TTLApp/time-to-leave`
 
 ### Clone the repository
 

--- a/PRIVACYPOLICY.md
+++ b/PRIVACYPOLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-Thamara Andrade built the Time to Leave app as an Open Source app. This application is provided by Thamara Andrade at no cost and is intended for use as is.
+Thamara Andrade and the TTLApp organization built the Time to Leave app as an Open Source app. This application is provided by the TTLApp organization at no cost and is intended for use as is.
 
 Time to Leave does not collect, use or disclosure personal Information from its users.
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -64,7 +64,7 @@ You can also add waivers on the days you did not work.
 
 ## How to install TTL
 
-Time to Leave works on MacOS, Windows and Linux, and you can download the desired version from [the latest release](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave works on MacOS, Windows and Linux, and you can download the desired version from [the latest release](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## How to build and contribute to TTL
 

--- a/__tests__/__main__/menus.mjs
+++ b/__tests__/__main__/menus.mjs
@@ -276,7 +276,7 @@ describe('menus.js', () =>
         {
             const shellStub = stub(shell, 'openExternal').callsFake((key) =>
             {
-                assert.strictEqual(key, 'https://github.com/thamara/time-to-leave');
+                assert.strictEqual(key, 'https://github.com/TTLApp/time-to-leave');
                 shellStub.restore();
                 done();
             });
@@ -297,7 +297,7 @@ describe('menus.js', () =>
         {
             const shellStub = stub(shell, 'openExternal').callsFake((key) =>
             {
-                assert.strictEqual(key, 'https://github.com/thamara/time-to-leave/issues/new');
+                assert.strictEqual(key, 'https://github.com/TTLApp/time-to-leave/issues/new');
                 shellStub.restore();
                 done();
             });

--- a/__tests__/__main__/notification.mjs
+++ b/__tests__/__main__/notification.mjs
@@ -44,7 +44,7 @@ describe('Notifications', function()
             {
                 // Linux/macos window notifications are not shown on CI
                 // so this is a way to emit the same event that actually happens.
-                // Timeout error is visible here https://github.com/thamara/time-to-leave/actions/runs/3488950409/jobs/5838419982
+                // Timeout error is visible here https://github.com/TTLApp/time-to-leave/actions/runs/3488950409/jobs/5838419982
                 notification.emit('show', {
                     sender: {
                         title: 'Time to Leave'
@@ -84,7 +84,7 @@ describe('Notifications', function()
             {
                 // Linux/macos window notifications are not shown on CI
                 // so this is a way to emit the same event that actually happens.
-                // Timeout error is visible here https://github.com/thamara/time-to-leave/actions/runs/3488950409/jobs/5838419982
+                // Timeout error is visible here https://github.com/TTLApp/time-to-leave/actions/runs/3488950409/jobs/5838419982
                 notification.emit('show', {
                     sender: {
                         title: 'Time to Leave'

--- a/docs/README-bn.md
+++ b/docs/README-bn.md
@@ -8,8 +8,8 @@
   <br/>
 
   <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-  <img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-  <a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+  <img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+  <a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
   <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
   <br/>
@@ -36,7 +36,7 @@
 
 ## কিভাবে TTL ইনস্টল করবেন
 
-ছেড়ে যাওয়ার সময় ম্যাকওএস, উইন্ডোজ এবং লিনাক্সে কাজ করে এবং আপনি [সর্বশেষ প্রকাশ](https://github.com/thamara/time-to-leave/releases/latest) থেকে পছন্দসই সংস্করণটি ডাউনলোড করতে পারেন।
+ছেড়ে যাওয়ার সময় ম্যাকওএস, উইন্ডোজ এবং লিনাক্সে কাজ করে এবং আপনি [সর্বশেষ প্রকাশ](https://github.com/TTLApp/time-to-leave/releases/latest) থেকে পছন্দসই সংস্করণটি ডাউনলোড করতে পারেন।
 
 ## কিভাবে টিটিএল তৈরি এবং অবদান রাখতে হয়
 

--- a/docs/README-ca.md
+++ b/docs/README-ca.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@ També podeu afegir exempcions els dies que no hàgiu treballat.
 
 ## Com instal·lar TTL
 
-Time to Leave funciona a MacOS, Windows i Linux i podeu descarregar la versió desitjada des de [l'última versió](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave funciona a MacOS, Windows i Linux i podeu descarregar la versió desitjada des de [l'última versió](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Com crear i contribuir a TTL
 

--- a/docs/README-de-DE.md
+++ b/docs/README-de-DE.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads gesamt">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Neueste Version"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads gesamt">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Neueste Version"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Neueste Version"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Du kannst Tage, an denen du nicht gearbeitet hast, als Freizeit festlegen.
 
 ## TTL installieren
 
-Time to Leave ist kompatibel mit MacOS, Windows und Linux. Du kannst die gewünschte Version von der [Release Seite](https://github.com/thamara/time-to-leave/releases/latest) herunterladen.
+Time to Leave ist kompatibel mit MacOS, Windows und Linux. Du kannst die gewünschte Version von der [Release Seite](https://github.com/TTLApp/time-to-leave/releases/latest) herunterladen.
 
 ## Wie man TTL baut und dazu beiträgt
 

--- a/docs/README-el.md
+++ b/docs/README-el.md
@@ -7,8 +7,8 @@
 
 <br/>
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Πλατφόρμες">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Λήψεις συνολικά">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Τελευταία Έκδοση"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Λήψεις συνολικά">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Τελευταία Έκδοση"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Πρόσκληση για συνεισφορά"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## Πώς να εγκαταστήσετε το TTL
 
-Το Time to Leave λειτουργεί σε MacOS, Windows και Linux, και μπορείτε να κατεβάσετε την επιθυμητή έκδοση από την [τελευταία έκδοση](https://github.com/thamara/time-to-leave/releases/latest).
+Το Time to Leave λειτουργεί σε MacOS, Windows και Linux, και μπορείτε να κατεβάσετε την επιθυμητή έκδοση από την [τελευταία έκδοση](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Πώς να δημιουργήσετε και να συνεισφέρετε στο TTL
 

--- a/docs/README-es.md
+++ b/docs/README-es.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@ También puedes añadir tiempo libre en los días que no has trabajado.
 
 ## Cómo instalar TTL
 
-Time to Leave funciona en MacOS, Windows y Linux, y puede descargar la versión deseada de la [última versión](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave funciona en MacOS, Windows y Linux, y puede descargar la versión deseada de la [última versión](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Cómo construir y contribuir al TTL
 

--- a/docs/README-fa-IR.md
+++ b/docs/README-fa-IR.md
@@ -8,8 +8,8 @@
 <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -37,7 +37,7 @@
 
 ## <p dir="rtl">آموزش نصب TTL</p>
 
-<p dir="rtl">برنامه Time to Leave در سیستم عامل های مک، ویندوز و لینوکس نصب می شود و شما می توانید نسخه مورد نظرتان را از <a href="https://github.com/thamara/time-to-leave/releases/latest">این لینک</a> دانلود کنید.</p>
+<p dir="rtl">برنامه Time to Leave در سیستم عامل های مک، ویندوز و لینوکس نصب می شود و شما می توانید نسخه مورد نظرتان را از <a href="https://github.com/TTLApp/time-to-leave/releases/latest">این لینک</a> دانلود کنید.</p>
 
 ## <p dir="rtl">آموزش اجرای برنامه از طریق کد و مشارکت در TTL</p>
 

--- a/docs/README-fr-FR.md
+++ b/docs/README-fr-FR.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Vous pouvez également ajouter des dispenses les jours où vous ne travailler pa
 
 ## Comment installer TTL
 
-Time to Leave fonctionne sur MacOS, Windows et Linux, et vous pouvez télécharger la version souhaitée à partir de [la dernière version](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave fonctionne sur MacOS, Windows et Linux, et vous pouvez télécharger la version souhaitée à partir de [la dernière version](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Comment build et contribuer à TTL
 

--- a/docs/README-gu.md
+++ b/docs/README-gu.md
@@ -6,9 +6,9 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
-<img src="https://img.shields.io/github/workflow/status/thamara/time-to-leave/Code%20Coverage" alt="Build">
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/workflow/status/TTLApp/time-to-leave/Code%20Coverage" alt="Build">
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -35,7 +35,7 @@
 
 ## TTL કેવી રીતે ઇન્સ્ટોલ કરવું
 
-છોડવાનો સમય MacOS, Windows અને Linux પર કાર્ય કરે છે, અને તમે ઇચ્છિત સંસ્કરણને ડાઉનલોડ કરી શકો છો [the latest release](https://github.com/thamara/time-to-leave/releases/latest).
+છોડવાનો સમય MacOS, Windows અને Linux પર કાર્ય કરે છે, અને તમે ઇચ્છિત સંસ્કરણને ડાઉનલોડ કરી શકો છો [the latest release](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## TTL બનાવવા અને ફાળો કેવી રીતે આપવો
 

--- a/docs/README-he.md
+++ b/docs/README-he.md
@@ -6,8 +6,8 @@
 [Homepage](https://timetoleave.app/)
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## איך להתקין את TTL
 
-Time to Leave רץ על MacOS, Windows ו-Linux, וגם אפשר להוריד גרסה מבוקשת מ-[גרסה האחרונה](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave רץ על MacOS, Windows ו-Linux, וגם אפשר להוריד גרסה מבוקשת מ-[גרסה האחרונה](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## איך לבנות ולתרום ל-TTL
 

--- a/docs/README-hi.md
+++ b/docs/README-hi.md
@@ -7,8 +7,8 @@
 <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -35,7 +35,7 @@
 
 ## टीटीएल कैसे स्थापित करें
 
-मैकओएस, विंडोज और लिनक्स पर काम करने का समय निकल जाता है, और आप वांछित संस्करण डाउनलोड कर सकते हैं [the latest release](https://github.com/thamara/time-to-leave/releases/latest).
+मैकओएस, विंडोज और लिनक्स पर काम करने का समय निकल जाता है, और आप वांछित संस्करण डाउनलोड कर सकते हैं [the latest release](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## टीटीएल का निर्माण और योगदान कैसे करें
 

--- a/docs/README-id-ID.md
+++ b/docs/README-id-ID.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads gesamt">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Neueste Version"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads gesamt">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Neueste Version"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Neueste Version"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Kamu juga dapat menambahkan pengabaian di hari ketika kamu tidak bekerja.
 
 ## Cara menginstal TTL
 
-Time to Leave dapat berkerja pada sistem operasi MacOS, Windows and Linux, dan kamu dapat mengunduh versi yang kamu inginkan dari [rilis terakhir](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave dapat berkerja pada sistem operasi MacOS, Windows and Linux, dan kamu dapat mengunduh versi yang kamu inginkan dari [rilis terakhir](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Cara membuat dan berkontribusi untuk TTL
 

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Piattaforma">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Totale">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Ultima Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Totale">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Ultima Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Ultima Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Puoi anche escludere i giorni in cui non hai lavorato.
 
 ## Come installare TTL
 
-Time to Leave funziona su MacOS, Windows e Linux, e puoi scaricare la versione desiderata dall'[ultima release](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave funziona su MacOS, Windows e Linux, e puoi scaricare la versione desiderata dall'[ultima release](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Come compilare e contribuire a TTL
 

--- a/docs/README-ja.md
+++ b/docs/README-ja.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="プラットフォーム">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="ダウンロード数">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="最新版"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="ダウンロード数">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="最新版"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="プルリクエスト歓迎"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## TTL のインストール方法
 
-Time to Leave は MacOS、Windows、Linux で動作し、[最新リリース](https://github.com/thamara/time-to-leave/releases/latest)からご希望のバージョンをダウンロードすることができます。
+Time to Leave は MacOS、Windows、Linux で動作し、[最新リリース](https://github.com/TTLApp/time-to-leave/releases/latest)からご希望のバージョンをダウンロードすることができます。
 
 ## TTL の構築と貢献の仕方
 

--- a/docs/README-ko.md
+++ b/docs/README-ko.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## TTL 설치하기
 
-Time to Leave는 MacOS, Windows 그리고 Linux 환경에서 동작합니다. [최신 릴리즈](https://github.com/thamara/time-to-leave/releases/latest)에서 원하는 버전을 다운로드 받을 수 있습니다.
+Time to Leave는 MacOS, Windows 그리고 Linux 환경에서 동작합니다. [최신 릴리즈](https://github.com/TTLApp/time-to-leave/releases/latest)에서 원하는 버전을 다운로드 받을 수 있습니다.
 
 ## TTL 빌드하고 기여하기
 

--- a/docs/README-mr.md
+++ b/docs/README-mr.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Piattaforma">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Ultima Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Ultima Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Ultima Release"></a>
 
    <br/>
@@ -35,7 +35,7 @@
 
 ## टीटीएल कसे स्थापित करावे
 
-सोडण्याची वेळ MacOS, Windows आणि Linux वर कार्य करते आणि आपण वरून इच्छित आवृत्ती डाउनलोड करू शकता[ultima release](https://github.com/thamara/time-to-leave/releases/latest).
+सोडण्याची वेळ MacOS, Windows आणि Linux वर कार्य करते आणि आपण वरून इच्छित आवृत्ती डाउनलोड करू शकता[ultima release](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## संकलित कसे करावे आणि टीटीएलमध्ये सहयोग कसे करावे
 

--- a/docs/README-nl.md
+++ b/docs/README-nl.md
@@ -8,8 +8,8 @@
  <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platformen">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Totaal aantal downloads">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Laatste versie"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Totaal aantal downloads">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Laatste versie"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Laatste versie"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Je kunt ook vrije dagen en feestdagen toevoegen aan je kalender.
 
 ## Time to Leave installeren
 
-Time to Leave werkt op MacOS, Windows en Linux. Je kunt de laatste uitgave [hier](https://github.com/thamara/time-to-leave/releases/latest) downloaden.
+Time to Leave werkt op MacOS, Windows en Linux. Je kunt de laatste uitgave [hier](https://github.com/TTLApp/time-to-leave/releases/latest) downloaden.
 
 ## Aan de ontwikkeling meehelpen
 

--- a/docs/README-pl.md
+++ b/docs/README-pl.md
@@ -8,8 +8,8 @@
   <br>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Możesz dodać zwolnienia do dni, w których nie ma cię w pracy.
 
 ## Jak zainstalować _Time to Leave_
 
-_Time to Leave_ działa na systemach Windows, MacOS i Linux. Pożądaną wersję możesz pobrać z [ostatniego wydania na githubie](https://github.com/thamara/time-to-leave/releases/latest).
+_Time to Leave_ działa na systemach Windows, MacOS i Linux. Pożądaną wersję możesz pobrać z [ostatniego wydania na githubie](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Jak wesprzeć _Time to Leave_
 

--- a/docs/README-pt-BR.md
+++ b/docs/README-pt-BR.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Você também pode adicionar folgas nos dias que não trabalhou.
 
 ## Como instalar o TTL
 
-Time to Leave funciona em MacOS, Windows e Linux, e você pode baixar a versão desejada da [última versão](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave funciona em MacOS, Windows e Linux, e você pode baixar a versão desejada da [última versão](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Como fazer o build e contribuir com o TTL
 

--- a/docs/README-pt-PT.md
+++ b/docs/README-pt-PT.md
@@ -8,8 +8,8 @@
 <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platforma">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Total de downloads">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Última versão"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Total de downloads">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Última versão"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Última versão"></a>
 
    <br/>
@@ -36,7 +36,7 @@ Tu também podes adicionar folgas nos dias em que não trabalhas.
 
 ## Como instalar o TTL
 
-Time to Leave funciona no MacOS, Windows e Linux, e podes transferir a versão que desejas do [último lançamento](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave funciona no MacOS, Windows e Linux, e podes transferir a versão que desejas do [último lançamento](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Como compilar e contribuir para o TTL
 

--- a/docs/README-ru-RU.md
+++ b/docs/README-ru-RU.md
@@ -8,8 +8,8 @@
   <br>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## Как установить _Time to Leave_
 
-_Time to Leave_ работает on MacOS, Windows и Linux. Вы можете установить нужную вам версию из [последнего релиза на Github](https://github.com/thamara/time-to-leave/releases/latest).
+_Time to Leave_ работает on MacOS, Windows и Linux. Вы можете установить нужную вам версию из [последнего релиза на Github](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Как поддержать _Time to Leave_
 

--- a/docs/README-sv-SE.md
+++ b/docs/README-sv-SE.md
@@ -6,8 +6,8 @@
 [Homepage](https://timetoleave.app/)
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -35,7 +35,7 @@ Du kan också lägga till dagar du är ledig, dagar du inte arbetar.
 
 ## Hur man installerar TTL
 
-Time to Leave fungerar på MacOS, Windows och Linux, och du kan ladda ned den version du önskar från [den senaste releasen](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave fungerar på MacOS, Windows och Linux, och du kan ladda ned den version du önskar från [den senaste releasen](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Hur man bygger och bidrar till TTL
 

--- a/docs/README-ta.md
+++ b/docs/README-ta.md
@@ -8,8 +8,8 @@
 <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="இயங்கு தளம்">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="மொத்த பதிவிறக்கங்கள்">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="சமீபத்திய வெளியீடு"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="மொத்த பதிவிறக்கங்கள்">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="சமீபத்திய வெளியீடு"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="சமீபத்திய வெளியீடு"></a>
 
    <br/>
@@ -34,7 +34,7 @@
 
 ## TTL ஐ எவ்வாறு இன்ஸ்டால் செய்வது
 
-Time to Leave MacOS, Windows மற்றும் Linux இல் இயங்குகிறது, மற்றும் நீங்கள் விரும்பிய பதிவை இந்த லிங்கின் மூலம் இன்ஸ்டால் செய்யலாம் [சமீபத்திய வெளியீடு](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave MacOS, Windows மற்றும் Linux இல் இயங்குகிறது, மற்றும் நீங்கள் விரும்பிய பதிவை இந்த லிங்கின் மூலம் இன்ஸ்டால் செய்யலாம் [சமீபத்திய வெளியீடு](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## TTL ஐ எவ்வாறு உருவாக்குவது மற்றும் எப்படி பங்களிப்பது
 

--- a/docs/README-th-TH.md
+++ b/docs/README-th-TH.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## การติดตั้ง
 
-Time to Leave รองรับบนระบบปฏิบัติการ MacOS, Windows และ Linux, สามารถดาวน์โหลดเวอร์ชันล่าสุดได้[ที่นี่](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave รองรับบนระบบปฏิบัติการ MacOS, Windows และ Linux, สามารถดาวน์โหลดเวอร์ชันล่าสุดได้[ที่นี่](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## การมีส่วนรวมและการร่วมพัฒนา
 

--- a/docs/README-tr-TR.md
+++ b/docs/README-tr-TR.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Toplam İndirilme Sayısı">
-<a href="https://github.com/thamara/time-to-leave/releases/tag/v.1.5.5"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="En Son Sürümü"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Toplam İndirilme Sayısı">
+<a href="https://github.com/TTLApp/time-to-leave/releases/tag/v.1.5.5"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="En Son Sürümü"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="En Son Sürümü"></a>
 
    <br/>
@@ -37,7 +37,7 @@ Aynı zamanda izinli olduğunuz günleri de çalışmadığınız günlere ekley
 
 ## TTL'i Nasıl Yüklerim
 
-Time to Leave Macos, Windows ve Linux versiyonu bulunmaktadır. İstediğiniz versiyonu [buradan](https://github.com/thamara/time-to-leave/releases/latest) indirebilirsiniz.
+Time to Leave Macos, Windows ve Linux versiyonu bulunmaktadır. İstediğiniz versiyonu [buradan](https://github.com/TTLApp/time-to-leave/releases/latest) indirebilirsiniz.
 
 ## TTL'e Nasıl Katkıda Bulunabilirim
 

--- a/docs/README-uk-UA.md
+++ b/docs/README-uk-UA.md
@@ -6,8 +6,8 @@
 [Домашня сторінка](https://timetoleave.app/)
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Платформа">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Загальна кількість завантажень">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Останній реліз"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Загальна кількість завантажень">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Останній реліз"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Останній реліз"></a>
 
    <br/>
@@ -35,7 +35,7 @@
 
 ## Як встановити TTL
 
-Time to Leave працює на MacOS, Windows та Linux, і ви можете завантажити потрібну версію з [останнього релізу](https://github.com/thamara/time-to-leave/releases/latest).
+Time to Leave працює на MacOS, Windows та Linux, і ви можете завантажити потрібну версію з [останнього релізу](https://github.com/TTLApp/time-to-leave/releases/latest).
 
 ## Як зробити свій внесок у розробку TTL
 

--- a/docs/README-zh-CN.md
+++ b/docs/README-zh-CN.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## 如何安装 TTL
 
-Time to Leave 运行在 MacOS，Windows 和 Linux。你可以在[最新发布](https://github.com/thamara/time-to-leave/releases/latest)下载你想要的版本。
+Time to Leave 运行在 MacOS，Windows 和 Linux。你可以在[最新发布](https://github.com/TTLApp/time-to-leave/releases/latest)下载你想要的版本。
 
 ## 如何运行 TTL 及向 TTL 贡献
 

--- a/docs/README-zh-TW.md
+++ b/docs/README-zh-TW.md
@@ -8,8 +8,8 @@
   <br/>
 
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20MacOS%20%7C%20Linux-green" alt="Platform">
-<img src="https://img.shields.io/github/downloads/thamara/time-to-leave/total" alt="Downloads in Total">
-<a href="https://github.com/thamara/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/thamara/time-to-leave" alt="Latest Release"></a>
+<img src="https://img.shields.io/github/downloads/TTLApp/time-to-leave/total" alt="Downloads in Total">
+<a href="https://github.com/TTLApp/time-to-leave/releases/latest"><img src="https://img.shields.io/github/v/release/TTLApp/time-to-leave" alt="Latest Release"></a>
 <a href="http://makeapullrequest.com/"><img src="https://img.shields.io/badge/PRs-welcome-purple" alt="Latest Release"></a>
 
    <br/>
@@ -36,7 +36,7 @@
 
 ## 如何安裝 TTL
 
-Time to Leave 運行在 MacOS，Windows 和 Linux。你可以在[最新發布](https://github.com/thamara/time-to-leave/releases/latest)下載你想要的版本。
+Time to Leave 運行在 MacOS，Windows 和 Linux。你可以在[最新發布](https://github.com/TTLApp/time-to-leave/releases/latest)下載你想要的版本。
 
 ## 如何運行 TTL 及向 TTL 貢獻
 

--- a/js/menus.mjs
+++ b/js/menus.mjs
@@ -344,7 +344,7 @@ function getHelpMenuTemplate()
             label: getCurrentTranslation('$Menu.ttl-github'),
             click()
             {
-                shell.openExternal('https://github.com/thamara/time-to-leave');
+                shell.openExternal('https://github.com/TTLApp/time-to-leave');
             }
         },
         {
@@ -359,7 +359,7 @@ function getHelpMenuTemplate()
             click()
             {
                 shell.openExternal(
-                    'https://github.com/thamara/time-to-leave/issues/new'
+                    'https://github.com/TTLApp/time-to-leave/issues/new'
                 );
             }
         },

--- a/js/update-manager.mjs
+++ b/js/update-manager.mjs
@@ -25,7 +25,7 @@ async function _checkForUpdates(showUpToDateDialog)
         return;
     }
 
-    const request = net.request('https://api.github.com/repos/thamara/time-to-leave/releases/latest');
+    const request = net.request('https://api.github.com/repos/TTLApp/time-to-leave/releases/latest');
     request.on('response', (response) =>
     {
         response.on('data', (chunk) =>
@@ -53,7 +53,7 @@ async function _checkForUpdates(showUpToDateDialog)
                     if (response === 1)
                     {
                         //Download latest version
-                        shell.openExternal('https://github.com/thamara/time-to-leave/releases/latest');
+                        shell.openExternal('https://github.com/TTLApp/time-to-leave/releases/latest');
                     }
                     else if (response === 2)
                     {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "productName": "Time to Leave",
   "version": "3.0.1-dev",
   "description": "Log work hours and get notified when it's time to leave the office and start to live.",
-  "author": "Thamara Andrade",
-  "homepage": "https://github.com/thamara/time-to-leave#readme",
+  "author": "TTLApp Organization",
+  "homepage": "https://github.com/TTLApp/time-to-leave#readme",
   "repository": {
     "type": "git",
-    "url": "github:thamara/time-to-leave.git"
+    "url": "github:TTLApp/time-to-leave.git"
   },
   "type": "module",
   "main": "main.mjs",

--- a/scripts/check_languages.py
+++ b/scripts/check_languages.py
@@ -252,7 +252,7 @@ def get_new_issue_url(locale : str, missing_translations : dict) -> str:
         body += '\n```\n{}\n```\n\n'.format(json.dumps(missing_translations, indent=2))
     except:
         body += '\n```\n{}\n```\n\n'.format(missing_translations)
-    base_url = f'https://github.com/thamara/time-to-leave/issues/new?labels=localization,good+first+issue,Hacktoberfest'
+    base_url = f'https://github.com/TTLApp/time-to-leave/issues/new?labels=localization,good+first+issue,Hacktoberfest'
     opts = { 'body': body , 'title': f'Add missing translations for {language}'}
     return f'[(Open issue)]({add_url_params(base_url, opts)})'
 

--- a/scripts/create_windows_installer.js
+++ b/scripts/create_windows_installer.js
@@ -20,6 +20,6 @@ function getInstallerConfig()
         setupExe: 'TimeToLeaveInstaller.exe',
         noMsi: true,
         loadingGif: 'assets/installer.gif',
-        iconUrl: 'https://raw.githubusercontent.com/thamara/time-to-leave/main/assets/icon-win.ico',
+        iconUrl: 'https://raw.githubusercontent.com/TTLApp/time-to-leave/main/assets/icon-win.ico',
     });
 }


### PR DESCRIPTION
Following the move to an organization, this does the renaming on all of the non-website content to point to the new location of the repository