### PR TITLE
Only run 'Update missing translations' workflow on main repo

### DIFF
--- a/.github/workflows/update-missing-translations.yml
+++ b/.github/workflows/update-missing-translations.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   missing-translations:
+    if: github.repository == 'TTLApp/time-to-leave'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Due to how it was coded, every time someone pushed onto a fork, it would try to update an issue there and fail, possibly generating a misleading e-mail of a broken flow.