### PR TITLE
Fixing translation report thread automatic comment

### DIFF
--- a/.github/workflows/update-missing-translations.yml
+++ b/.github/workflows/update-missing-translations.yml
@@ -18,20 +18,12 @@ jobs:
     - name: Write missing translation to file
       run: |
         python scripts/check_languages.py -output missing.md -report_summary -report_key_mismatch -report_missing_translations
-    - name: Get comment body
-      id: get-comment-body
-      run: |
-        body=$(cat missing.md)
-        body="${body//'%'/'%25'}"
-        body="${body//$'\n'/'%0A'}"
-        body="${body//$'\r'/'%0D'}"
-        echo "body=$body" >> $GITHUB_OUTPUT
     - name: Update comment
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v4
       with:
         # Update the comment in issue 475
         # https://github.com/TTLApp/time-to-leave/issues/475#issuecomment-808787273
         comment-id: 808787273
         edit-mode: replace
-        body: ${{ steps.get-comment-body.outputs.body }}
+        body-path: missing.md
         reactions: hooray

--- a/scripts/check_languages.py
+++ b/scripts/check_languages.py
@@ -240,7 +240,7 @@ def get_count_total_string_with_link(locale : str, missing_translations : dict, 
 
 def get_progress_bar(total_strings_for_translation : int, missing_strings : dict) -> str:
     percentage = percentage_translated(total_strings_for_translation, missing_strings)
-    return f'![Progress](https://progress-bar.dev/{floor(percentage)}/?width=200)'
+    return f'![Progress](https://progress-bar.xyz/{floor(percentage)}/?width=200)'
 
 def get_new_issue_url(locale : str, missing_translations : dict) -> str:
     language = get_locale_name(locale)


### PR DESCRIPTION
#### Related issue
Closes #1102

#### Context / Background
Progress image is not loading in the common translation report thread.
The text is also looking weird after #1101

#### What change is being introduced by this PR?
- Fixing usage by directly reading from the "missing.md" file through "body-path" argument
- Updating action to v4
- Using `progress-bar.xyz` as an alternative to expired `progress-bar.dev` for the progress bar image.

#### How will this be tested?
Running after this PR.
