### PR TITLE
Update electron-store from 10.0.0 to 10.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/fontawesome-free": "6.7.2",
         "bootstrap": "5.3.3",
         "date-holidays": "3.23.18",
-        "electron-store": "10.0.0",
+        "electron-store": "10.0.1",
         "esm": "3.2.25",
         "i18next": "24.2.2",
         "i18next-fs-backend": "2.6.0",
@@ -353,22 +353,6 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1938,7 +1922,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/strip-ansi-cjs": {
@@ -3010,19 +2993,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/saxes": {
@@ -5354,12 +5324,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/conf/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/date-easter": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-1.0.3.tgz",
@@ -7580,9 +7544,9 @@
       }
     },
     "node_modules/electron-store": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-10.0.0.tgz",
-      "integrity": "sha512-BU/QZh+5twHBprRdLu3YZX/rIarmZzhTNpJvAvqG1/yN0mNCrsMh0kl7bM4xaUKDNRiHz1r7wP/7Prjh7cleIw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-10.0.1.tgz",
+      "integrity": "sha512-Ok0bF13WWdTzZi9rCtPN8wUfwx+yDMmV6PAnCMqjNRKEXHmklW/rV+6DofV/Vf5qoAh+Bl9Bj7dQ+0W+IL2psg==",
       "license": "MIT",
       "dependencies": {
         "conf": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@fortawesome/fontawesome-free": "6.7.2",
     "bootstrap": "5.3.3",
     "date-holidays": "3.23.18",
-    "electron-store": "10.0.0",
+    "electron-store": "10.0.1",
     "esm": "3.2.25",
     "i18next": "24.2.2",
     "i18next-fs-backend": "2.6.0",


### PR DESCRIPTION
It is a minor update, but since it seems to fix stuff related to how electron-store imports modules, I thought it would be important to do it already