### PR TITLE
Creating an enum of IpcConstants to have a single source of truth for ipc channel strings

### DIFF
--- a/__tests__/__main__/menus.mjs
+++ b/__tests__/__main__/menus.mjs
@@ -14,6 +14,7 @@ import {
 } from '../../js/menus.mjs';
 
 import i18NextConfig from '../../src/configs/i18next.config.mjs';
+import IpcConstants from '../../js/ipc-constants.mjs';
 import Windows from '../../js/windows.mjs';
 import Notification from '../../js/notification.mjs';
 import UpdateManager from '../../js/update-manager.mjs';
@@ -116,7 +117,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        assert.strictEqual(key, 'PUNCH_DATE');
+                        assert.strictEqual(key, IpcConstants.PunchDate);
                     }
                 }
             };
@@ -177,7 +178,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        assert.strictEqual(key, 'PUNCH_DATE');
+                        assert.strictEqual(key, IpcConstants.PunchDate);
                     }
                 }
             };
@@ -435,7 +436,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        assert.strictEqual(key, 'RELOAD_CALENDAR');
+                        assert.strictEqual(key, IpcConstants.ReloadCalendar);
                     }
                 }
             };
@@ -460,7 +461,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        assert.strictEqual(key, 'RELOAD_CALENDAR');
+                        assert.strictEqual(key, IpcConstants.ReloadCalendar);
                     }
                 }
             };
@@ -485,7 +486,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        assert.strictEqual(key, 'RELOAD_CALENDAR');
+                        assert.strictEqual(key, IpcConstants.ReloadCalendar);
                     }
                 }
             };
@@ -547,7 +548,7 @@ describe('menus.js', () =>
                 webContents: {
                     send: (key) =>
                     {
-                        assert.strictEqual(key, 'RELOAD_CALENDAR');
+                        assert.strictEqual(key, IpcConstants.ReloadCalendar);
                     }
                 }
             };

--- a/__tests__/__renderer__/notification-channel.mjs
+++ b/__tests__/__renderer__/notification-channel.mjs
@@ -5,6 +5,7 @@ import '../../__mocks__/jquery.mjs';
 import assert from 'assert';
 
 import { searchLeaveByElement } from '../../renderer/notification-channel.js';
+import IpcConstants from '../../js/ipc-constants.mjs';
 
 describe('Notifications channel',  () =>
 {
@@ -16,7 +17,7 @@ describe('Notifications channel',  () =>
             sender: {
                 send: (channel, value) =>
                 {
-                    assert.strictEqual(channel, 'RECEIVE_LEAVE_BY');
+                    assert.strictEqual(channel, IpcConstants.ReceiveLeaveBy);
                     assert.strictEqual(value, '12:12');
                     done();
                 }

--- a/js/ipc-constants.mjs
+++ b/js/ipc-constants.mjs
@@ -1,0 +1,37 @@
+'use strict';
+
+const IpcConstants = Object.freeze(
+    {
+        ChangeLanguage: 'CHANGE_LANGUAGE',
+        ComputeAllTimeBalanceUntil: 'COMPUTE_ALL_TIME_BALANCE_UNTIL',
+        DeleteStoreData: 'DELETE_STORE_DATA',
+        DeleteWaiver: 'DELETE_WAIVER',
+        GetCountries: 'GET_COUNTRIES',
+        GetHolidays: 'GET_HOLIDAYS',
+        GetLanguageData: 'GET_LANGUAGE_DATA',
+        GetLeaveBy: 'GET_LEAVE_BY',
+        GetRegions: 'GET_REGIONS',
+        GetStates: 'GET_STATES',
+        GetStoreContents: 'GET_STORE_CONTENTS',
+        GetWaiverDay: 'GET_WAIVER_DAY',
+        GetWaiverStoreContents: 'GET_WAIVER_STORE_CONTENTS',
+        HasWaiver: 'HAS_WAIVER',
+        PreferenceSaveDataNeeded: 'PREFERENCE_SAVE_DATA_NEEDED',
+        PreferencesSaved: 'PREFERENCES_SAVED',
+        PunchDate: 'PUNCH_DATE',
+        ReceiveLeaveBy: 'RECEIVE_LEAVE_BY',
+        RefreshOnDayChange: 'REFRESH_ON_DAY_CHANGE',
+        ReloadCalendar: 'RELOAD_CALENDAR',
+        ReloadTheme: 'RELOAD_THEME',
+        ResizeMainWindow: 'RESIZE_MAIN_WINDOW',
+        SetStoreData: 'SET_STORE_DATA',
+        SetWaiver: 'SET_WAIVER',
+        SetWaiverDay: 'SET_WAIVER_DAY',
+        ShowAlert: 'SHOW_ALERT',
+        ShowDialog: 'SHOW_DIALOG',
+        SwitchView: 'SWITCH_VIEW',
+        ToggleTrayPunchTime: 'TOGGLE_TRAY_PUNCH_TIME',
+        WaiverSaved: 'WAIVER_SAVED',
+    });
+
+export default IpcConstants;

--- a/js/main-window.mjs
+++ b/js/main-window.mjs
@@ -16,6 +16,7 @@ import Notification from './notification.mjs';
 import UpdateManager from './update-manager.mjs';
 import { getDefaultWidthHeight, getUserPreferences, switchCalendarView } from './user-preferences.mjs';
 import i18NextConfig from '../src/configs/i18next.config.mjs';
+import IpcConstants from './ipc-constants.mjs';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -98,7 +99,7 @@ function createWindow()
     // and load the main html of the app as the default window
     mainWindow.loadFile(path.join(rootDir, 'src/calendar.html'));
 
-    ipcMain.on('TOGGLE_TRAY_PUNCH_TIME', (_event, arg) =>
+    ipcMain.on(IpcConstants.ToggleTrayPunchTime, (_event, arg) =>
     {
         const contextMenuTemplate = getContextMenuTemplate(mainWindow);
         contextMenuTemplate[0].enabled = arg;
@@ -106,19 +107,19 @@ function createWindow()
         global.tray.setContextMenu(global.contextMenu);
     });
 
-    ipcMain.on('RESIZE_MAIN_WINDOW', () =>
+    ipcMain.on(IpcConstants.ResizeMainWindow, () =>
     {
         const widthHeight = getDefaultWidthHeight();
         mainWindow.setSize(widthHeight.width, widthHeight.height);
     });
 
-    ipcMain.on('SWITCH_VIEW', () =>
+    ipcMain.on(IpcConstants.SwitchView, () =>
     {
         const preferences = switchCalendarView();
-        mainWindow.webContents.send('PREFERENCES_SAVED', preferences);
+        mainWindow.webContents.send(IpcConstants.PreferencesSaved, preferences);
     });
 
-    ipcMain.on('RECEIVE_LEAVE_BY', (event, element) =>
+    ipcMain.on(IpcConstants.ReceiveLeaveBy, (event, element) =>
     {
         const notification = Notification.createLeaveNotification(element);
         if (notification) notification.show();
@@ -126,7 +127,7 @@ function createWindow()
 
     leaveByInterval = setInterval(() =>
     {
-        mainWindow.webContents.send('GET_LEAVE_BY');
+        mainWindow.webContents.send(IpcConstants.GetLeaveBy);
     }, 60 * 1000);
 
     global.tray = new Tray(appConfig.trayIcon);
@@ -174,7 +175,7 @@ function createWindow()
         const theme = savedPreferences['theme'];
         if (theme === 'system-default')
         {
-            mainWindow.webContents.send('RELOAD_THEME', theme);
+            mainWindow.webContents.send(IpcConstants.ReloadTheme, theme);
         }
     });
 }

--- a/js/menus.mjs
+++ b/js/menus.mjs
@@ -13,6 +13,7 @@ import UpdateManager from './update-manager.mjs';
 import { getUserPreferences, savePreferences } from './user-preferences.mjs';
 import Windows from './windows.mjs';
 import i18NextConfig from '../src/configs/i18next.config.mjs';
+import IpcConstants from './ipc-constants.mjs';
 
 function getMainMenuTemplate(mainWindow)
 {
@@ -46,7 +47,7 @@ function getContextMenuTemplate(mainWindow)
             {
                 const now = new Date();
 
-                mainWindow.webContents.send('PUNCH_DATE');
+                mainWindow.webContents.send(IpcConstants.PunchDate);
                 // Slice keeps "HH:MM" part of "HH:MM:SS GMT+HHMM (GMT+HH:MM)" time string
                 Notification.createNotification(
                     `${i18NextConfig.getCurrentTranslation(
@@ -81,7 +82,7 @@ function getDockMenuTemplate(mainWindow)
             {
                 const now = new Date();
 
-                mainWindow.webContents.send('PUNCH_DATE');
+                mainWindow.webContents.send(IpcConstants.PunchDate);
                 // Slice keeps "HH:MM" part of "HH:MM:SS GMT+HHMM (GMT+HH:MM)" time string
                 Notification.createNotification(
                     `${i18NextConfig.getCurrentTranslation(
@@ -157,7 +158,7 @@ function getEditMenuTemplate(mainWindow)
                     if (savedPreferences !== null)
                     {
                         savePreferences(savedPreferences);
-                        mainWindow.webContents.send('PREFERENCES_SAVED', savedPreferences);
+                        mainWindow.webContents.send(IpcConstants.PreferencesSaved, savedPreferences);
                     }
                 });
                 global.prefWindow.webContents.on('before-input-event', (event, input) =>
@@ -239,7 +240,7 @@ function getEditMenuTemplate(mainWindow)
                     {
                         const importResult = ImportExport.importDatabaseFromFile(response);
                         // Reload only the calendar itself to avoid a flash
-                        mainWindow.webContents.send('RELOAD_CALENDAR');
+                        mainWindow.webContents.send(IpcConstants.ReloadCalendar);
                         if (importResult['result'])
                         {
                             dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
@@ -305,7 +306,7 @@ function getEditMenuTemplate(mainWindow)
                     waivedWorkdays.clear();
                     calendarStore.clear();
                     // Reload only the calendar itself to avoid a flash
-                    mainWindow.webContents.send('RELOAD_CALENDAR');
+                    mainWindow.webContents.send(IpcConstants.ReloadCalendar);
                     dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
                         title: 'Time to Leave',
                         message: i18NextConfig.getCurrentTranslation('$Menu.clear-database'),

--- a/js/saved-preferences.mjs
+++ b/js/saved-preferences.mjs
@@ -3,6 +3,7 @@
 import { app, ipcMain } from 'electron';
 
 import i18NextConfig from '../src/configs/i18next.config.mjs';
+import IpcConstants from './ipc-constants.mjs';
 
 let savedPreferences = null;
 
@@ -11,7 +12,7 @@ function getSavedPreferences()
     return savedPreferences;
 }
 
-ipcMain.on('PREFERENCE_SAVE_DATA_NEEDED', (event, preferences) =>
+ipcMain.on(IpcConstants.PreferenceSaveDataNeeded, (event, preferences) =>
 {
     savedPreferences = preferences;
     app.setLoginItemSettings({

--- a/js/windows.mjs
+++ b/js/windows.mjs
@@ -6,6 +6,7 @@ import path from 'path';
 import { appConfig, rootDir } from './app-config.mjs';
 import { getDateStr } from './date-aux.mjs';
 import { getUserPreferences } from './user-preferences.mjs';
+import IpcConstants from './ipc-constants.mjs';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -53,7 +54,7 @@ class Windows
         global.waiverWindow.on('close', function()
         {
             global.waiverWindow = null;
-            mainWindow.webContents.send('WAIVER_SAVED');
+            mainWindow.webContents.send(IpcConstants.WaiverSaved);
         });
         global.waiverWindow.webContents.on('before-input-event', (event, input) =>
         {

--- a/main.mjs
+++ b/main.mjs
@@ -13,6 +13,7 @@ import i18NextConfig from './src/configs/i18next.config.mjs';
 
 // Allow require()
 import { createRequire } from 'module';
+import IpcConstants from './js/ipc-constants.mjs';
 const require = createRequire(import.meta.url);
 
 const { showAlert, showDialogSync } = require('./js/window-aux.cjs');
@@ -28,32 +29,24 @@ if (appConfig.win32)
 
 setupWorkdayWaiverHandlers();
 
-ipcMain.on('SET_WAIVER_DAY', (event, waiverDay) =>
+ipcMain.on(IpcConstants.SetWaiverDay, (event, waiverDay) =>
 {
     global.waiverDay = waiverDay;
     const mainWindow = getMainWindow();
     Windows.openWaiverManagerWindow(mainWindow);
 });
 
-ipcMain.handle('GET_WAIVER_DAY', () =>
+ipcMain.handle(IpcConstants.GetWaiverDay, () =>
 {
     return global.waiverDay;
 });
 
-ipcMain.handle('USER_DATA_PATH', () =>
-{
-    return new Promise((resolve) =>
-    {
-        resolve(app.getPath('userData'));
-    });
-});
-
-ipcMain.on('SHOW_ALERT', (event, alertMessage) =>
+ipcMain.on(IpcConstants.ShowAlert, (event, alertMessage) =>
 {
     showAlert(alertMessage);
 });
 
-ipcMain.handle('SHOW_DIALOG', (event, dialogOptions) =>
+ipcMain.handle(IpcConstants.ShowDialog, (event, dialogOptions) =>
 {
     return showDialogSync(dialogOptions);
 });
@@ -100,7 +93,7 @@ function refreshOnDayChange()
         launchDate = today;
 
         // Reload only the calendar itself to avoid a flash
-        mainWindow.webContents.send('REFRESH_ON_DAY_CHANGE', oldDate, oldMonth, oldYear);
+        mainWindow.webContents.send(IpcConstants.RefreshOnDayChange, oldDate, oldMonth, oldYear);
     }
 }
 

--- a/main/calendar-aux.mjs
+++ b/main/calendar-aux.mjs
@@ -4,6 +4,7 @@ import { ipcMain } from 'electron';
 import Store from 'electron-store';
 
 import TimeBalance from '../js/time-balance.mjs';
+import IpcConstants from '../js/ipc-constants.mjs';
 
 const calendarStore = new Store({name: 'flexible-store'});
 
@@ -14,24 +15,24 @@ function getCalendarStore()
 
 function setupCalendarStore()
 {
-    ipcMain.handle('GET_STORE_CONTENTS', () =>
+    ipcMain.handle(IpcConstants.GetStoreContents, () =>
     {
         return getCalendarStore();
     });
 
-    ipcMain.handle('SET_STORE_DATA', (event, key, contents) =>
+    ipcMain.handle(IpcConstants.SetStoreData, (event, key, contents) =>
     {
         calendarStore.set(key, contents);
         return true;
     });
 
-    ipcMain.handle('DELETE_STORE_DATA', (event, key) =>
+    ipcMain.handle(IpcConstants.DeleteStoreData, (event, key) =>
     {
         calendarStore.delete(key);
         return true;
     });
 
-    ipcMain.handle('COMPUTE_ALL_TIME_BALANCE_UNTIL', (event, targetDate) =>
+    ipcMain.handle(IpcConstants.ComputeAllTimeBalanceUntil, (event, targetDate) =>
     {
         return TimeBalance.computeAllTimeBalanceUntilAsync(targetDate);
     });

--- a/main/workday-waiver-aux.mjs
+++ b/main/workday-waiver-aux.mjs
@@ -4,6 +4,8 @@ import Holidays from 'date-holidays';
 import { ipcMain } from 'electron';
 import Store from 'electron-store';
 
+import IpcConstants from '../js/ipc-constants.mjs';
+
 const hd = new Holidays();
 const waiverStore = new Store({name: 'waived-workdays'});
 
@@ -15,23 +17,23 @@ function getWaiverStore()
 
 function setupWorkdayWaiverStoreHandlers()
 {
-    ipcMain.handle('GET_WAIVER_STORE_CONTENTS', () =>
+    ipcMain.handle(IpcConstants.GetWaiverStoreContents, () =>
     {
         return getWaiverStore();
     });
 
-    ipcMain.handle('SET_WAIVER', (_event, key, contents) =>
+    ipcMain.handle(IpcConstants.SetWaiver, (_event, key, contents) =>
     {
         waiverStore.set(key, contents);
         return true;
     });
 
-    ipcMain.handle('HAS_WAIVER', (_event, key) =>
+    ipcMain.handle(IpcConstants.HasWaiver, (_event, key) =>
     {
         return waiverStore.has(key);
     });
 
-    ipcMain.handle('DELETE_WAIVER', (_event, key) =>
+    ipcMain.handle(IpcConstants.DeleteWaiver, (_event, key) =>
     {
         waiverStore.delete(key);
         return true;
@@ -79,22 +81,22 @@ function getRegions(country, state)
 
 function setupWorkdayHolidaysHandlers()
 {
-    ipcMain.handle('GET_HOLIDAYS', (_event, country, state, city, year) =>
+    ipcMain.handle(IpcConstants.GetHolidays, (_event, country, state, city, year) =>
     {
         return getAllHolidays(country, state, city, year);
     });
 
-    ipcMain.handle('GET_COUNTRIES', () =>
+    ipcMain.handle(IpcConstants.GetCountries, () =>
     {
         return getCountries();
     });
 
-    ipcMain.handle('GET_STATES', (_event, country) =>
+    ipcMain.handle(IpcConstants.GetStates, (_event, country) =>
     {
         return getStates(country);
     });
 
-    ipcMain.handle('GET_REGIONS', (_event, country, state) =>
+    ipcMain.handle(IpcConstants.GetRegions, (_event, country, state) =>
     {
         return getRegions(country, state);
     });

--- a/renderer/notification-channel.js
+++ b/renderer/notification-channel.js
@@ -1,9 +1,11 @@
 'use strict';
 
+import IpcConstants from '../js/ipc-constants.mjs';
+
 const searchLeaveByElement = (event) =>
 {
     const leaveByElement = $('#leave-by').val();
-    event.sender.send('RECEIVE_LEAVE_BY', leaveByElement);
+    event.sender.send(IpcConstants.ReceiveLeaveBy, leaveByElement);
 };
 
 export {

--- a/renderer/preload-scripts/calendar-api.mjs
+++ b/renderer/preload-scripts/calendar-api.mjs
@@ -1,58 +1,59 @@
 'use strict';
 
 import { createRequire } from 'module';
+import IpcConstants from '../../js/ipc-constants.mjs';
 const require = createRequire(import.meta.url);
 
 const { ipcRenderer } = require('electron');
 
 function resizeMainWindow()
 {
-    ipcRenderer.send('RESIZE_MAIN_WINDOW');
+    ipcRenderer.send(IpcConstants.ResizeMainWindow);
 }
 
 function switchView()
 {
-    ipcRenderer.send('SWITCH_VIEW');
+    ipcRenderer.send(IpcConstants.SwitchView);
 }
 
 function toggleTrayPunchTime(enable)
 {
-    ipcRenderer.send('TOGGLE_TRAY_PUNCH_TIME', enable);
+    ipcRenderer.send(IpcConstants.ToggleTrayPunchTime, enable);
 }
 
 function displayWaiverWindow(waiverDay)
 {
-    ipcRenderer.send('SET_WAIVER_DAY', waiverDay);
+    ipcRenderer.send(IpcConstants.SetWaiverDay, waiverDay);
 }
 
 function getStoreContents()
 {
-    return ipcRenderer.invoke('GET_STORE_CONTENTS');
+    return ipcRenderer.invoke(IpcConstants.GetStoreContents);
 }
 
 function setStoreData(key, contents)
 {
-    return ipcRenderer.invoke('SET_STORE_DATA', key, contents);
+    return ipcRenderer.invoke(IpcConstants.SetStoreData, key, contents);
 }
 
 function deleteStoreData(key)
 {
-    return ipcRenderer.invoke('DELETE_STORE_DATA', key);
+    return ipcRenderer.invoke(IpcConstants.DeleteStoreData, key);
 }
 
 function computeAllTimeBalanceUntilPromise(targetDate)
 {
-    return ipcRenderer.invoke('COMPUTE_ALL_TIME_BALANCE_UNTIL', targetDate);
+    return ipcRenderer.invoke(IpcConstants.ComputeAllTimeBalanceUntil, targetDate);
 }
 
 const calendarApi = {
-    handleRefreshOnDayChange: (callback) => ipcRenderer.on('REFRESH_ON_DAY_CHANGE', callback),
-    handlePreferencesSaved: (callback) => ipcRenderer.on('PREFERENCES_SAVED', callback),
-    handleWaiverSaved: (callback) => ipcRenderer.on('WAIVER_SAVED', callback),
-    handleCalendarReload: (callback) => ipcRenderer.on('RELOAD_CALENDAR', callback),
-    handlePunchDate: (callback) => ipcRenderer.on('PUNCH_DATE', callback),
-    handleThemeChange: (callback) => ipcRenderer.on('RELOAD_THEME', callback),
-    handleLeaveBy: (callback) => ipcRenderer.on('GET_LEAVE_BY', callback),
+    handleRefreshOnDayChange: (callback) => ipcRenderer.on(IpcConstants.RefreshOnDayChange, callback),
+    handlePreferencesSaved: (callback) => ipcRenderer.on(IpcConstants.PreferencesSaved, callback),
+    handleWaiverSaved: (callback) => ipcRenderer.on(IpcConstants.WaiverSaved, callback),
+    handleCalendarReload: (callback) => ipcRenderer.on(IpcConstants.ReloadCalendar, callback),
+    handlePunchDate: (callback) => ipcRenderer.on(IpcConstants.PunchDate, callback),
+    handleThemeChange: (callback) => ipcRenderer.on(IpcConstants.ReloadTheme, callback),
+    handleLeaveBy: (callback) => ipcRenderer.on(IpcConstants.GetLeaveBy, callback),
     resizeMainWindow: () => resizeMainWindow(),
     switchView: () => switchView(),
     toggleTrayPunchTime: (enable) => toggleTrayPunchTime(enable),

--- a/renderer/preload-scripts/preferences-api.mjs
+++ b/renderer/preload-scripts/preferences-api.mjs
@@ -7,15 +7,16 @@ const { ipcRenderer } = require('electron');
 
 import * as config from '../../src/configs/app.config.mjs';
 import { getDefaultPreferences } from '../../js/user-preferences.mjs';
+import IpcConstants from '../../js/ipc-constants.mjs';
 
 function notifyNewPreferences(preferences)
 {
-    ipcRenderer.send('PREFERENCE_SAVE_DATA_NEEDED', preferences);
+    ipcRenderer.send(IpcConstants.PreferenceSaveDataNeeded, preferences);
 }
 
 function changeLanguagePromise(language)
 {
-    return ipcRenderer.invoke('CHANGE_LANGUAGE', language);
+    return ipcRenderer.invoke(IpcConstants.ChangeLanguage, language);
 }
 
 const preferencesApi = {

--- a/renderer/preload-scripts/renderer-api.mjs
+++ b/renderer/preload-scripts/renderer-api.mjs
@@ -2,11 +2,12 @@
 
 import { ipcRenderer } from 'electron';
 
+import IpcConstants from '../../js/ipc-constants.mjs';
 import { showDay } from '../../js/user-preferences.mjs';
 
 function getLanguageDataPromise()
 {
-    return ipcRenderer.invoke('GET_LANGUAGE_DATA');
+    return ipcRenderer.invoke(IpcConstants.GetLanguageData);
 }
 
 function getOriginalUserPreferences()
@@ -18,12 +19,12 @@ function getOriginalUserPreferences()
 
 function getWaiverStoreContents()
 {
-    return ipcRenderer.invoke('GET_WAIVER_STORE_CONTENTS');
+    return ipcRenderer.invoke(IpcConstants.GetWaiverStoreContents);
 }
 
 function showDialogSync(dialogOptions)
 {
-    return ipcRenderer.invoke('SHOW_DIALOG', dialogOptions);
+    return ipcRenderer.invoke(IpcConstants.ShowDialog, dialogOptions);
 }
 
 const rendererApi = {

--- a/renderer/preload-scripts/workday-waiver-api.mjs
+++ b/renderer/preload-scripts/workday-waiver-api.mjs
@@ -5,49 +5,51 @@ const require = createRequire(import.meta.url);
 
 const { ipcRenderer } = require('electron');
 
+import IpcConstants from '../../js/ipc-constants.mjs';
+
 function getWaiverDay()
 {
-    return ipcRenderer.invoke('GET_WAIVER_DAY');
+    return ipcRenderer.invoke(IpcConstants.GetWaiverDay);
 }
 
 function showAlert(alertMessage)
 {
-    ipcRenderer.send('SHOW_ALERT', alertMessage);
+    ipcRenderer.send(IpcConstants.ShowAlert, alertMessage);
 }
 
 function setWaiver(key, contents)
 {
-    return ipcRenderer.invoke('SET_WAIVER', key, contents);
+    return ipcRenderer.invoke(IpcConstants.SetWaiver, key, contents);
 }
 
 function hasWaiver(key)
 {
-    return ipcRenderer.invoke('HAS_WAIVER', key);
+    return ipcRenderer.invoke(IpcConstants.HasWaiver, key);
 }
 
 function deleteWaiver(key)
 {
-    return ipcRenderer.invoke('DELETE_WAIVER', key);
+    return ipcRenderer.invoke(IpcConstants.DeleteWaiver, key);
 }
 
 function getHolidays(country, state, city, year)
 {
-    return ipcRenderer.invoke('GET_HOLIDAYS', country, state, city, year);
+    return ipcRenderer.invoke(IpcConstants.GetHolidays, country, state, city, year);
 }
 
 function getCountries()
 {
-    return ipcRenderer.invoke('GET_COUNTRIES');
+    return ipcRenderer.invoke(IpcConstants.GetCountries);
 }
 
 function getStates(country)
 {
-    return ipcRenderer.invoke('GET_STATES', country);
+    return ipcRenderer.invoke(IpcConstants.GetStates, country);
 }
 
 function getRegions(country, state)
 {
-    return ipcRenderer.invoke('GET_REGIONS', country, state);
+    return ipcRenderer.invoke(IpcConstants.GetRegions, country, state);
 }
 
 const workdayWaiverApi = {

--- a/src/configs/i18next.config.mjs
+++ b/src/configs/i18next.config.mjs
@@ -10,6 +10,7 @@ import { appConfig } from '../../js/app-config.mjs';
 
 // TODO: make async below again
 import { getUserLanguage } from '../../js/user-preferences.mjs';
+import IpcConstants from '../../js/ipc-constants.mjs';
 
 const i18nextOptions = {
     backend:{
@@ -32,7 +33,7 @@ const i18nextOptions = {
     }
 };
 
-ipcMain.handle('CHANGE_LANGUAGE', (event, language) =>
+ipcMain.handle(IpcConstants.ChangeLanguage, (event, language) =>
 {
     return new Promise((resolve) =>
     {
@@ -48,7 +49,7 @@ function getCurrentLanguageData()
     return i18n.getDataByLanguage(i18n.language);
 }
 
-ipcMain.handle('GET_LANGUAGE_DATA', () =>
+ipcMain.handle(IpcConstants.GetLanguageData, () =>
 {
     return {
         'language': i18n.language,


### PR DESCRIPTION
Creating an enum of IpcConstants to have a single source of truth for ipc channel strings.
object.freeze makes the object read-only, "creating" an enum on javascript.