### PR TITLE
Minimizing new window flickering while painting

### DIFF
--- a/__mocks__/jquery.mjs
+++ b/__mocks__/jquery.mjs
@@ -14,3 +14,6 @@ window.matchMedia = window.matchMedia || function()
         removeListener: function() {}
     };
 };
+
+// Mocking requestAnimationFrame since it's not usually defined but we use it
+global.requestAnimationFrame = callback => callback();

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -47,17 +47,21 @@ describe('main-window.mjs', () =>
             assert.strictEqual(getLeaveByInterval(), null);
         });
 
-        it('Should get window', () =>
+        it('Should get window', (done) =>
         {
             createWindow();
-            assert.strictEqual(showSpy.calledOnce, true);
             assert.strictEqual(getMainWindow() instanceof BrowserWindow, true);
+            getMainWindow().webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+            {
+                assert.strictEqual(showSpy.calledOnce, true);
+                done();
+            });
         });
     });
 
     describe('createWindow()', () =>
     {
-        it('Should create and get window default behaviour', () =>
+        it('Should create and get window default behaviour', (done) =>
         {
             const loadFileSpy = spy(BrowserWindow.prototype, 'loadFile');
             createWindow();
@@ -73,9 +77,13 @@ describe('main-window.mjs', () =>
             assert.strictEqual(mainWindow.listenerCount('minimize'), 2);
             assert.strictEqual(mainWindow.listenerCount('close'), 2);
             assert.strictEqual(loadFileSpy.calledOnce, true);
-            assert.strictEqual(showSpy.calledOnce, true);
             assert.notStrictEqual(getLeaveByInterval(), null);
             assert.strictEqual(getLeaveByInterval()._idleNext.expiry > 0, true);
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+            {
+                assert.strictEqual(showSpy.calledOnce, true);
+                done();
+            });
         });
     });
 
@@ -88,7 +96,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', async() =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
             {
                 // Wait a bit for values to accomodate
                 await new Promise(res => setTimeout(res, 500));
@@ -114,7 +122,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', async() =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
             {
                 // Wait a bit for values to accomodate
                 await new Promise(res => setTimeout(res, 500));
@@ -144,7 +152,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', async() =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
             {
                 // Wait a bit for values to accomodate
                 await new Promise(res => setTimeout(res, 500));
@@ -170,7 +178,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 stub(Notification, 'createLeaveNotification').callsFake(() =>
                 {
@@ -200,7 +208,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 const now = new Date();
                 ipcMain.emit(
@@ -223,7 +231,7 @@ describe('main-window.mjs', () =>
                  * @type {BrowserWindow}
                  */
                 const mainWindow = getMainWindow();
-                mainWindow.on('ready-to-show', () =>
+                mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
                 {
                     showSpy.callsFake(() =>
                     {
@@ -245,7 +253,7 @@ describe('main-window.mjs', () =>
                  * @type {BrowserWindow}
                  */
                 const mainWindow = getMainWindow();
-                mainWindow.on('ready-to-show', () =>
+                mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
                 {
                     const trayStub = stub(global.tray, 'popUpContextMenu').callsFake(() =>
                     {
@@ -272,7 +280,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 mainWindow.emit('minimize', {
                     preventDefault: () => {}
@@ -295,7 +303,7 @@ describe('main-window.mjs', () =>
              */
             const mainWindow = getMainWindow();
             const minimizeSpy = spy(mainWindow, 'minimize');
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 mainWindow.emit('minimize', {});
                 assert.strictEqual(minimizeSpy.called, true);
@@ -318,7 +326,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 mainWindow.emit('close', {
                     preventDefault: () => {}
@@ -341,7 +349,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 // Force the exit
                 mainWindow.on('close', () =>
@@ -396,7 +404,7 @@ describe('main-window.mjs', () =>
              * @type {BrowserWindow}
              */
             const mainWindow = getMainWindow();
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 mainWindow.emit('close', {
                     preventDefault: () => {}
@@ -422,7 +430,7 @@ describe('main-window.mjs', () =>
                 clock.restore();
                 done();
             });
-            mainWindow.on('ready-to-show', () =>
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 mainWindow.emit('close', {
                     preventDefault: () => {}

--- a/__tests__/__main__/windows.mjs
+++ b/__tests__/__main__/windows.mjs
@@ -46,7 +46,7 @@ describe('Windows tests', () =>
         assert.strictEqual(Windows.getWaiverWindow(), null);
         assert.strictEqual(global.tray, null);
         assert.strictEqual(global.contextMenu, null);
-        assert.strictEqual(global.prefWindow, null);
+        assert.strictEqual(Windows.getPreferencesWindow(), null);
     });
 
     it('Should create waiver window', (done) =>
@@ -72,7 +72,7 @@ describe('Windows tests', () =>
         });
     });
 
-    it('Should show waiver window it has been created', (done) =>
+    it('Should show waiver window when it has been created', (done) =>
     {
         const mainWindow = new BrowserWindow({
             show: false
@@ -99,6 +99,7 @@ describe('Windows tests', () =>
         Windows.openWaiverManagerWindow(mainWindow, true);
         Windows.getWaiverWindow().webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
         {
+            assert.strictEqual(showSpy.calledOnce, true);
             assert.notStrictEqual(Windows.getWaiverWindow(), null);
             assert.strictEqual(global.waiverDay, getDateStr(new Date()));
             done();
@@ -113,8 +114,66 @@ describe('Windows tests', () =>
         Windows.openWaiverManagerWindow(mainWindow, true);
         Windows.getWaiverWindow().webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
         {
+            assert.strictEqual(showSpy.calledOnce, true);
             Windows.getWaiverWindow().close();
             assert.strictEqual(Windows.getWaiverWindow(), null);
+            done();
+        });
+    });
+
+    it('Should create preferences window', (done) =>
+    {
+        const mainWindow = new BrowserWindow({
+            show: false
+        });
+        Windows.openPreferencesWindow(mainWindow);
+        assert.notStrictEqual(Windows.getPreferencesWindow(), null);
+        assert.strictEqual(Windows.getPreferencesWindow() instanceof BrowserWindow, true);
+
+        // Values can vary about 10px from 600, 500
+        const size = Windows.getPreferencesWindow().getSize();
+        assert.strictEqual(Math.abs(size[0] - 550) < 10, true);
+        assert.strictEqual(Math.abs(size[1] - 620) < 10, true);
+
+        assert.strictEqual(loadSpy.calledOnce, true);
+
+        Windows.getPreferencesWindow().webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+        {
+            assert.strictEqual(showSpy.calledOnce, true);
+            done();
+        });
+    });
+
+    it('Should show preferences window when it has been created', (done) =>
+    {
+        const mainWindow = new BrowserWindow({
+            show: false
+        });
+        Windows.openPreferencesWindow(mainWindow);
+        Windows.openPreferencesWindow(mainWindow);
+        assert.notStrictEqual(Windows.getPreferencesWindow(), null);
+
+        // It should only load once the URL because it already exists
+        assert.strictEqual(loadSpy.calledOnce, true);
+
+        Windows.getPreferencesWindow().webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+        {
+            assert.strictEqual(showSpy.calledTwice, true);
+            done();
+        });
+    });
+
+    it('Should reset preferences window on close', (done) =>
+    {
+        const mainWindow = new BrowserWindow({
+            show: false
+        });
+        Windows.openPreferencesWindow(mainWindow, true);
+        Windows.getPreferencesWindow().webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+        {
+            assert.strictEqual(showSpy.calledOnce, true);
+            Windows.getPreferencesWindow().close();
+            assert.strictEqual(Windows.getPreferencesWindow(), null);
             done();
         });
     });

--- a/__tests__/__renderer__/preferences.mjs
+++ b/__tests__/__renderer__/preferences.mjs
@@ -105,7 +105,8 @@ describe('Test Preferences Window', () =>
                 }));
             },
             getOriginalUserPreferences: () => { return testPreferences; },
-            showDialog: () => { return new Promise((resolve) => resolve({ response: 0 })); }
+            notifyWindowReadyToShow: () => {},
+            showDialog: () => { return new Promise((resolve) => resolve({ response: 0 })); },
         };
 
         // Stub methods

--- a/__tests__/__renderer__/workday-waiver.mjs
+++ b/__tests__/__renderer__/workday-waiver.mjs
@@ -189,6 +189,7 @@ describe('Test Workday Waiver Window', function()
             return getUserPreferences();
         };
         window.rendererApi.showDay = showDay;
+        window.rendererApi.notifyWindowReadyToShow = () => {};
 
         window.workdayWaiverApi.showDialogSync = () => {};
 

--- a/js/ipc-constants.mjs
+++ b/js/ipc-constants.mjs
@@ -32,6 +32,7 @@ const IpcConstants = Object.freeze(
         SwitchView: 'SWITCH_VIEW',
         ToggleTrayPunchTime: 'TOGGLE_TRAY_PUNCH_TIME',
         WaiverSaved: 'WAIVER_SAVED',
+        WindowReadyToShow: 'WINDOW_READY_TO_SHOW',
     });
 
 export default IpcConstants;

--- a/js/main-window.mjs
+++ b/js/main-window.mjs
@@ -93,9 +93,6 @@ function createWindow()
 
     createMenu();
 
-    // Prevents flickering from maximize
-    mainWindow.show();
-
     // and load the main html of the app as the default window
     mainWindow.loadFile(path.join(rootDir, 'src/calendar.html'));
 
@@ -155,6 +152,12 @@ function createWindow()
         {
             mainWindow.minimize();
         }
+    });
+
+    // Prevents flickering from maximize
+    mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+    {
+        mainWindow.show();
     });
 
     // Emitted when the window is closed.

--- a/js/menus.mjs
+++ b/js/menus.mjs
@@ -2,15 +2,12 @@
 
 import { app, BrowserWindow, clipboard, dialog, shell } from 'electron';
 import Store from 'electron-store';
-import path from 'path';
 
-import { appConfig, getDetails, rootDir } from './app-config.mjs';
+import { appConfig, getDetails } from './app-config.mjs';
 import { getCurrentDateTimeStr } from './date-aux.mjs';
 import ImportExport from './import-export.mjs';
 import Notification from './notification.mjs';
-import { getSavedPreferences } from './saved-preferences.mjs';
 import UpdateManager from './update-manager.mjs';
-import { getUserPreferences, savePreferences } from './user-preferences.mjs';
 import Windows from './windows.mjs';
 import i18NextConfig from '../src/configs/i18next.config.mjs';
 import IpcConstants from './ipc-constants.mjs';
@@ -129,51 +126,7 @@ function getEditMenuTemplate(mainWindow)
             accelerator: appConfig.macOS ? 'Command+,' : 'Control+,',
             click()
             {
-                if (global.prefWindow !== null)
-                {
-                    global.prefWindow.show();
-                    return;
-                }
-
-                const htmlPath = path.join('file://', rootDir, 'src/preferences.html');
-                const dialogCoordinates = Windows.getDialogCoordinates(550, 620, mainWindow);
-                const userPreferences = getUserPreferences();
-                global.prefWindow = new BrowserWindow({ width: 550,
-                    height: 620,
-                    minWidth: 480,
-                    x: dialogCoordinates.x,
-                    y: dialogCoordinates.y,
-                    parent: mainWindow,
-                    resizable: true,
-                    icon: appConfig.iconpath,
-                    webPreferences: {
-                        nodeIntegration: true,
-                        preload: path.join(rootDir, '/renderer/preload-scripts/preferences-bridge.mjs'),
-                        contextIsolation: true,
-                        additionalArguments: [
-                            `--preferences=${JSON.stringify(userPreferences)}`,
-                        ],
-                    } });
-                global.prefWindow.setMenu(null);
-                global.prefWindow.loadURL(htmlPath);
-                global.prefWindow.show();
-                global.prefWindow.on('close', function()
-                {
-                    global.prefWindow = null;
-                    const savedPreferences = getSavedPreferences();
-                    if (savedPreferences !== null)
-                    {
-                        savePreferences(savedPreferences);
-                        mainWindow.webContents.send(IpcConstants.PreferencesSaved, savedPreferences);
-                    }
-                });
-                global.prefWindow.webContents.on('before-input-event', (event, input) =>
-                {
-                    if (input.control && input.shift && input.key.toLowerCase() === 'i')
-                    {
-                        BrowserWindow.getFocusedWindow().webContents.toggleDevTools();
-                    }
-                });
+                Windows.openPreferencesWindow(mainWindow);
             }
         },
         { type: 'separator' },

--- a/js/windows.mjs
+++ b/js/windows.mjs
@@ -144,6 +144,11 @@ class Windows
         return global.waiverWindow;
     }
 
+    static getPreferencesWindow()
+    {
+        return global.prefWindow;
+    }
+
     static resetWindowsElements()
     {
         global.waiverWindow = null;

--- a/js/windows.mjs
+++ b/js/windows.mjs
@@ -5,7 +5,8 @@ import path from 'path';
 
 import { appConfig, rootDir } from './app-config.mjs';
 import { getDateStr } from './date-aux.mjs';
-import { getUserPreferences } from './user-preferences.mjs';
+import { getSavedPreferences } from './saved-preferences.mjs';
+import { getUserPreferences, savePreferences } from './user-preferences.mjs';
 import IpcConstants from './ipc-constants.mjs';
 
 // Keep a global reference of the window object, if you don't, the window will
@@ -39,6 +40,7 @@ class Windows
             y: dialogCoordinates.y,
             parent: mainWindow,
             resizable: true,
+            show: false,
             icon: appConfig.iconpath,
             webPreferences: {
                 nodeIntegration: true,
@@ -50,13 +52,69 @@ class Windows
             } });
         global.waiverWindow.setMenu(null);
         global.waiverWindow.loadURL(htmlPath);
-        global.waiverWindow.show();
+        global.waiverWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+        {
+            global.waiverWindow.show();
+        });
         global.waiverWindow.on('close', function()
         {
             global.waiverWindow = null;
             mainWindow.webContents.send(IpcConstants.WaiverSaved);
         });
         global.waiverWindow.webContents.on('before-input-event', (event, input) =>
+        {
+            if (input.control && input.shift && input.key.toLowerCase() === 'i')
+            {
+                BrowserWindow.getFocusedWindow().webContents.toggleDevTools();
+            }
+        });
+    }
+
+    static openPreferencesWindow(mainWindow)
+    {
+        if (global.prefWindow !== null)
+        {
+            global.prefWindow.show();
+            return;
+        }
+
+        const htmlPath = path.join('file://', rootDir, 'src/preferences.html');
+        const dialogCoordinates = Windows.getDialogCoordinates(550, 620, mainWindow);
+        const userPreferences = getUserPreferences();
+        global.prefWindow = new BrowserWindow({ width: 550,
+            height: 620,
+            minWidth: 480,
+            x: dialogCoordinates.x,
+            y: dialogCoordinates.y,
+            parent: mainWindow,
+            show: false,
+            resizable: true,
+            icon: appConfig.iconpath,
+            webPreferences: {
+                nodeIntegration: true,
+                preload: path.join(rootDir, '/renderer/preload-scripts/preferences-bridge.mjs'),
+                contextIsolation: true,
+                additionalArguments: [
+                    `--preferences=${JSON.stringify(userPreferences)}`,
+                ],
+            } });
+        global.prefWindow.setMenu(null);
+        global.prefWindow.loadURL(htmlPath);
+        global.prefWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
+        {
+            global.prefWindow.show();
+        });
+        global.prefWindow.on('close', function()
+        {
+            global.prefWindow = null;
+            const savedPreferences = getSavedPreferences();
+            if (savedPreferences !== null)
+            {
+                savePreferences(savedPreferences);
+                mainWindow.webContents.send(IpcConstants.PreferencesSaved, savedPreferences);
+            }
+        });
+        global.prefWindow.webContents.on('before-input-event', (event, input) =>
         {
             if (input.control && input.shift && input.key.toLowerCase() === 'i')
             {

--- a/renderer/preload-scripts/renderer-api.mjs
+++ b/renderer/preload-scripts/renderer-api.mjs
@@ -13,13 +13,17 @@ function getLanguageDataPromise()
 function getOriginalUserPreferences()
 {
     const preferences = process.argv.filter((arg) => arg.startsWith('--preferences='))[0]?.split('=')?.[1];
-    console.log(preferences);
     return JSON.parse(preferences || '{}');
 }
 
 function getWaiverStoreContents()
 {
     return ipcRenderer.invoke(IpcConstants.GetWaiverStoreContents);
+}
+
+function notifyWindowReadyToShow()
+{
+    ipcRenderer.send(IpcConstants.WindowReadyToShow);
 }
 
 function showDialog(dialogOptions)
@@ -31,6 +35,7 @@ const rendererApi = {
     getLanguageDataPromise,
     getOriginalUserPreferences,
     getWaiverStoreContents,
+    notifyWindowReadyToShow,
     showDay,
     showDialog,
 };

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -74,5 +74,15 @@ window.calendarApi.handleLeaveBy(searchLeaveByElement);
 $(() =>
 {
     const preferences = window.rendererApi.getOriginalUserPreferences();
-    setupCalendar(preferences);
+    requestAnimationFrame(() =>
+    {
+        setupCalendar(preferences);
+        requestAnimationFrame(() =>
+        {
+            setTimeout(() =>
+            {
+                window.rendererApi.notifyWindowReadyToShow();
+            }, 100);
+        });
+    });
 });

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -102,7 +102,7 @@ function convertTimeFormat(entry)
     return entry;
 }
 
-function renderPreferencesWindow()
+function renderWindowTheme()
 {
     // Theme-handling should be towards the top. Applies theme early so it's more natural.
     const theme = 'theme';
@@ -117,7 +117,10 @@ function renderPreferencesWindow()
         .val();
     preferences[theme] = selectedThemeOption;
     applyTheme(selectedThemeOption);
+}
 
+function renderPreferencesWindow()
+{
     /* istanbul ignore else */
     if ('view' in preferences)
     {
@@ -262,6 +265,17 @@ function setupListeners()
 $(() =>
 {
     preferences = window.rendererApi.getOriginalUserPreferences();
+    requestAnimationFrame(() =>
+    {
+        renderWindowTheme();
+        requestAnimationFrame(() =>
+        {
+            setTimeout(() =>
+            {
+                window.rendererApi.notifyWindowReadyToShow();
+            }, 100);
+        });
+    });
     renderPreferencesWindow();
     setupListeners();
     setupLanguages();

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -441,7 +441,18 @@ async function initializeHolidayInfo()
 $(async() =>
 {
     userPreferences = window.rendererApi.getOriginalUserPreferences();
-    applyTheme(userPreferences.theme);
+
+    requestAnimationFrame(() =>
+    {
+        applyTheme(userPreferences.theme);
+        requestAnimationFrame(() =>
+        {
+            setTimeout(() =>
+            {
+                window.rendererApi.notifyWindowReadyToShow();
+            }, 100);
+        });
+    });
 
     const waiverDay = await window.workdayWaiverApi.getWaiverDay();
     languageData = await window.rendererApi.getLanguageDataPromise();


### PR DESCRIPTION
#### Related issue
Closes #1129

#### Context / Background
Whenever we open a new BrowserWindow in the app (waiver manager, preferences) it will flicker for a while with a white background while the elements show and the colors change. This happens because the window opens before it's properly painted by its javascript code.

#### What change is being introduced by this PR?
Introducing a custom WindowReadyToShow ipc event that the windows send when they have at least applied the window theme. The browser window creation on main waits for this event to invoke the .show() method. Not using the default 'ready-to-show' event as that still led to a flicker.
On renderer, the JS function requestAnimationFrame is used as it sort of provides a callback to run after a window has been animated/painted, and that helped synchronize things.

Electron still has a bug on windows that leads to a small flicker https://www.github.com/electron/electron/issues/42523 but I've minimized it here so that it's less of a visual bother.

Before
![flicker](https://github.com/user-attachments/assets/9976d49e-6c2e-430f-9019-7c1cd6fe912a)

After
![flicker2](https://github.com/user-attachments/assets/81f35333-3560-4793-b509-368ea9777032)

#### How will this be tested?
Tests were modified to listen for the event as well, making sure it is sent and works.
I had to increase the test timeout because it's taking longer to repaint the window than usual now on the CI environment.
