### PR TITLE
Using JS resizeTo directly on renderer

### DIFF
--- a/__mocks__/jquery.mjs
+++ b/__mocks__/jquery.mjs
@@ -17,3 +17,6 @@ window.matchMedia = window.matchMedia || function()
 
 // Mocking requestAnimationFrame since it's not usually defined but we use it
 global.requestAnimationFrame = callback => callback();
+
+// Mocking resizeTo since it's not implemented by JSDOM but used by the calendar
+window.resizeTo = () => {};

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -71,7 +71,6 @@ describe('main-window.mjs', () =>
             const mainWindow = getMainWindow();
             assert.strictEqual(mainWindow instanceof BrowserWindow, true);
             assert.strictEqual(ipcMain.listenerCount(IpcConstants.ToggleTrayPunchTime), 1);
-            assert.strictEqual(ipcMain.listenerCount(IpcConstants.ResizeMainWindow), 1);
             assert.strictEqual(ipcMain.listenerCount(IpcConstants.SwitchView), 1);
             assert.strictEqual(ipcMain.listenerCount(IpcConstants.ReceiveLeaveBy), 1);
             assert.strictEqual(mainWindow.listenerCount('minimize'), 2);
@@ -82,58 +81,6 @@ describe('main-window.mjs', () =>
             mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
                 assert.strictEqual(showSpy.calledOnce, true);
-                done();
-            });
-        });
-    });
-
-    describe('emit IpcConstants.ResizeMainWindow', function()
-    {
-        it('It should resize window', (done) =>
-        {
-            createWindow();
-            /**
-             * @type {BrowserWindow}
-             */
-            const mainWindow = getMainWindow();
-            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
-            {
-                // Wait a bit for values to accomodate
-                await new Promise(res => setTimeout(res, 500));
-
-                assert.strictEqual(ipcMain.emit(IpcConstants.ResizeMainWindow), true);
-                const windowSize = mainWindow.getSize();
-                assert.strictEqual(windowSize.length, 2);
-
-                // Width and height are within 5 pixels of the expected values
-                assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Value was ${windowSize[0]}`);
-                assert.strictEqual(Math.abs(windowSize[1] - 800) < 5, true, `Value was ${windowSize[1]}`);
-                done();
-            });
-        });
-        it('It should not resize window if values are smaller than minimum', (done) =>
-        {
-            assert.strictEqual(savePreferences({
-                ...getDefaultPreferences(),
-                ['view']: 'day'
-            }), true);
-            createWindow();
-            /**
-             * @type {BrowserWindow}
-             */
-            const mainWindow = getMainWindow();
-            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
-            {
-                // Wait a bit for values to accomodate
-                await new Promise(res => setTimeout(res, 500));
-
-                assert.strictEqual(ipcMain.emit(IpcConstants.ResizeMainWindow), true);
-                const windowSize = mainWindow.getSize();
-                assert.strictEqual(windowSize.length, 2);
-
-                // Width and height are within 5 pixels of the expected values
-                assert.strictEqual(Math.abs(windowSize[0] - 500) < 5, true, `Value was ${windowSize[0]}`);
-                assert.strictEqual(Math.abs(windowSize[1] - 500) < 5, true, `Value was ${windowSize[1]}`);
                 done();
             });
         });

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -104,6 +104,14 @@ describe('main-window.mjs', () =>
                 // Wait a bit for values to accomodate
                 await new Promise(res => setTimeout(res, 500));
 
+                const windowSize = mainWindow.getSize();
+                assert.strictEqual(windowSize.length, 2);
+
+                // First within the month view sizes
+                // Width and height are within 5 pixels of the expected values
+                assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Value was ${windowSize[0]}`);
+                assert.strictEqual(Math.abs(windowSize[1] - 800) < 5, true, `Value was ${windowSize[1]}`);
+
                 const windowStub = stub(mainWindow.webContents, 'send').callsFake((event, savedPreferences) =>
                 {
                     assert.strictEqual(windowStub.calledOnce, true);
@@ -111,6 +119,14 @@ describe('main-window.mjs', () =>
                     done();
                 });
                 ipcMain.emit(IpcConstants.SwitchView);
+
+                // Wait a bit for values to accomodate
+                await new Promise(res => setTimeout(res, 500));
+
+                // Now in day view sizes
+                assert.strictEqual(Math.abs(windowSize[0] - 500) < 5, true, `Value was ${windowSize[0]}`);
+                assert.strictEqual(Math.abs(windowSize[1] - 500) < 5, true, `Value was ${windowSize[1]}`);
+
                 windowStub.restore();
             });
         });

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -182,12 +182,12 @@ describe('main-window.mjs', () =>
                 const windowSize = mainWindow.getSize();
                 assert.strictEqual(windowSize.length, 2);
 
-                // First within the month view sizes
+                // First, check the month view sizes
                 // Width and height are within 5 pixels of the expected values
                 const macOS = process.platform === 'darwin';
-                const expectedWidth = macOS ? 970 : 1010;
-                assert.strictEqual(Math.abs(windowSize[0] - expectedWidth) < 5, true, `Value was ${windowSize[0]}`);
-                assert.strictEqual(Math.abs(windowSize[1] - 800) < 5, true, `Value was ${windowSize[1]}`);
+                const expectedWidth = macOS ? 970 : 800; // For some reason the width is different on macOS
+                assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Value was ${windowSize[0]}`);
+                assert.strictEqual(Math.abs(windowSize[1] - expectedWidth) < 5, true, `Value was ${windowSize[1]}`);
 
                 mainWindow.webContents.on('content-bounds-updated', () =>
                 {

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -179,39 +179,42 @@ describe('main-window.mjs', () =>
             const windowSpy = spy(mainWindow.webContents, 'send');
             mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
-                const windowSize = mainWindow.getSize();
-                assert.strictEqual(windowSize.length, 2);
-
-                // First, check the month view sizes
-                // Width and height are within 5 pixels of the expected values
-                const macOS = process.platform === 'darwin';
-                const expectedWidth = macOS ? 970 : 800; // For some reason the width is different on macOS
-                assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Value was ${windowSize[0]}`);
-                assert.strictEqual(Math.abs(windowSize[1] - expectedWidth) < 5, true, `Value was ${windowSize[1]}`);
-
-                mainWindow.webContents.on('content-bounds-updated', () =>
+                setTimeout(() =>
                 {
-                    setTimeout(() =>
+                    const windowSize = mainWindow.getSize();
+                    assert.strictEqual(windowSize.length, 2);
+
+                    // First, check the month view sizes
+                    // Width and height are within 5 pixels of the expected values
+                    const macOS = process.platform === 'darwin';
+                    const expectedWidth = macOS ? 970 : 800; // For some reason the width is different on macOS
+                    assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Value was ${windowSize[0]}`);
+                    assert.strictEqual(Math.abs(windowSize[1] - expectedWidth) < 5, true, `Value was ${windowSize[1]}`);
+
+                    mainWindow.webContents.on('content-bounds-updated', () =>
                     {
-                        const windowSize = mainWindow.getSize();
-                        assert.strictEqual(windowSize.length, 2);
+                        setTimeout(() =>
+                        {
+                            const windowSize = mainWindow.getSize();
+                            assert.strictEqual(windowSize.length, 2);
 
-                        // Now in day view sizes
-                        assert.strictEqual(Math.abs(windowSize[0] - 500) < 5, true, `Value was ${windowSize[0]}`);
-                        assert.strictEqual(Math.abs(windowSize[1] - 500) < 5, true, `Value was ${windowSize[1]}`);
+                            // Now in day view sizes
+                            assert.strictEqual(Math.abs(windowSize[0] - 500) < 5, true, `Value was ${windowSize[0]}`);
+                            assert.strictEqual(Math.abs(windowSize[1] - 500) < 5, true, `Value was ${windowSize[1]}`);
 
-                        assert.strictEqual(windowSpy.calledOnce, true);
+                            assert.strictEqual(windowSpy.calledOnce, true);
 
-                        const firstCall = windowSpy.firstCall;
-                        assert.strictEqual(firstCall.args[0], IpcConstants.PreferencesSaved);
-                        assert.strictEqual(firstCall.args[1]['view'], 'day');
+                            const firstCall = windowSpy.firstCall;
+                            assert.strictEqual(firstCall.args[0], IpcConstants.PreferencesSaved);
+                            assert.strictEqual(firstCall.args[1]['view'], 'day');
 
-                        windowSpy.restore();
-                        done();
-                    }, 300);
-                });
+                            windowSpy.restore();
+                            done();
+                        }, 300);
+                    });
 
-                ipcMain.emit(IpcConstants.SwitchView);
+                    ipcMain.emit(IpcConstants.SwitchView);
+                }, 300);
             });
         });
     });

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -179,42 +179,38 @@ describe('main-window.mjs', () =>
             const windowSpy = spy(mainWindow.webContents, 'send');
             mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
             {
-                setTimeout(() =>
+                const windowSize = mainWindow.getSize();
+                assert.strictEqual(windowSize.length, 2);
+
+                // First, check the month view sizes
+                // For some reason the default height is changing on CI
+                const possibleHeights = [800, 970, 728];
+                assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Width was ${windowSize[0]}`);
+                assert.strictEqual(possibleHeights.indexOf(windowSize[1]) !== -1, true, `Height was ${windowSize[1]}`);
+
+                mainWindow.webContents.on('content-bounds-updated', () =>
                 {
-                    const windowSize = mainWindow.getSize();
-                    assert.strictEqual(windowSize.length, 2);
-
-                    // First, check the month view sizes
-                    // Width and height are within 5 pixels of the expected values
-                    const macOS = process.platform === 'darwin';
-                    const expectedWidth = macOS ? 970 : 800; // For some reason the width is different on macOS
-                    assert.strictEqual(Math.abs(windowSize[0] - 1010) < 5, true, `Value was ${windowSize[0]}`);
-                    assert.strictEqual(Math.abs(windowSize[1] - expectedWidth) < 5, true, `Value was ${windowSize[1]}`);
-
-                    mainWindow.webContents.on('content-bounds-updated', () =>
+                    setTimeout(() =>
                     {
-                        setTimeout(() =>
-                        {
-                            const windowSize = mainWindow.getSize();
-                            assert.strictEqual(windowSize.length, 2);
+                        const windowSize = mainWindow.getSize();
+                        assert.strictEqual(windowSize.length, 2);
 
-                            // Now in day view sizes
-                            assert.strictEqual(Math.abs(windowSize[0] - 500) < 5, true, `Value was ${windowSize[0]}`);
-                            assert.strictEqual(Math.abs(windowSize[1] - 500) < 5, true, `Value was ${windowSize[1]}`);
+                        // Now in day view sizes
+                        assert.strictEqual(Math.abs(windowSize[0] - 500) < 5, true, `Width was ${windowSize[0]}`);
+                        assert.strictEqual(Math.abs(windowSize[1] - 500) < 5, true, `Height was ${windowSize[1]}`);
 
-                            assert.strictEqual(windowSpy.calledOnce, true);
+                        assert.strictEqual(windowSpy.calledOnce, true);
 
-                            const firstCall = windowSpy.firstCall;
-                            assert.strictEqual(firstCall.args[0], IpcConstants.PreferencesSaved);
-                            assert.strictEqual(firstCall.args[1]['view'], 'day');
+                        const firstCall = windowSpy.firstCall;
+                        assert.strictEqual(firstCall.args[0], IpcConstants.PreferencesSaved);
+                        assert.strictEqual(firstCall.args[1]['view'], 'day');
 
-                            windowSpy.restore();
-                            done();
-                        }, 300);
-                    });
+                        windowSpy.restore();
+                        done();
+                    }, 300);
+                });
 
-                    ipcMain.emit(IpcConstants.SwitchView);
-                }, 300);
+                ipcMain.emit(IpcConstants.SwitchView);
             });
         });
     });

--- a/__tests__/__main__/user-preferences.mjs
+++ b/__tests__/__main__/user-preferences.mjs
@@ -55,24 +55,16 @@ describe('Preferences Main', () =>
     {
         it('Month view', function()
         {
-            // For some reason this test takes longer when running the whole testsuite. My suspicion is that
-            // writing to file inside getDefaultWidthHeight is taking longer after many tests write to the file.
-            // Thus, increasing the timeout.
-            this.timeout(15000);
-            assert.strictEqual(getDefaultPreferences()['view'], 'month');
-            savePreferences(getDefaultPreferences());
-
-            assert.deepStrictEqual(getDefaultWidthHeight(), { width: 1010, height: 800 });
+            const preferences = structuredClone(getDefaultPreferences());
+            assert.strictEqual(preferences['view'], 'month');
+            assert.deepStrictEqual(getDefaultWidthHeight(preferences), { width: 1010, height: 800 });
         });
 
         it('Day view', () =>
         {
             const preferences = structuredClone(getDefaultPreferences());
-
             preferences['view'] = 'day';
-            savePreferences(preferences);
-
-            assert.deepStrictEqual(getDefaultWidthHeight(), { width: 500, height: 500 });
+            assert.deepStrictEqual(getDefaultWidthHeight(preferences), { width: 500, height: 500 });
         });
     });
 

--- a/__tests__/__main__/windows.mjs
+++ b/__tests__/__main__/windows.mjs
@@ -45,6 +45,8 @@ describe('Windows tests', () =>
         {
             return new Promise(resolve => resolve([]));
         });
+
+        Windows.resetWindowsElements();
     });
 
     it('Elements should be null on starting', () =>

--- a/__tests__/__renderer__/classes/CalendarFactory.mjs
+++ b/__tests__/__renderer__/classes/CalendarFactory.mjs
@@ -20,7 +20,7 @@ describe('CalendarFactory', () =>
         // Mocked APIs from the preload script of the calendar window
         window.calendarApi = calendarApi;
 
-        window.calendarApi.resizeMainWindow = stub();
+        stub(CalendarFactory, 'ResizeCalendar');
 
         Object.setPrototypeOf(DayCalendar, stub());
         Object.setPrototypeOf(MonthCalendar, stub());
@@ -61,7 +61,7 @@ describe('CalendarFactory', () =>
 
         it('Should return new calendar with resizing if passing in an instance that is not a DayCalendar', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             let calls = 0;
             const testCalendar = {
                 constructor: {
@@ -76,17 +76,17 @@ describe('CalendarFactory', () =>
             }, {}, testCalendar);
             assert.strictEqual(calendar instanceof DayCalendar, true);
             assert.strictEqual(calls, 0);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.calledOnce, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.calledOnce, true);
         });
 
         it('Should return new calendar without resizing if passing in an undefined instance', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             const calendar = await CalendarFactory.getInstance({
                 view: 'day',
             }, {}, undefined);
             assert.strictEqual(calendar instanceof DayCalendar, true);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.notCalled, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.notCalled, true);
         });
     });
 
@@ -112,17 +112,17 @@ describe('CalendarFactory', () =>
 
         it('Should return new calendar without resizing if passing in an undefined instance', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             const calendar = await CalendarFactory.getInstance({
                 view: 'month',
             }, {}, undefined);
             assert.strictEqual(calendar instanceof MonthCalendar, true);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.notCalled, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.notCalled, true);
         });
 
         it('Should return new calendar with resizing if passing in an instance that is not a MonthCalendar', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             let calls = 0;
             const testCalendar = {
                 constructor: {
@@ -137,7 +137,7 @@ describe('CalendarFactory', () =>
             }, {}, testCalendar);
             assert.strictEqual(calendar instanceof MonthCalendar, true);
             assert.strictEqual(calls, 0);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.calledOnce, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.calledOnce, true);
         });
     });
 
@@ -146,5 +146,6 @@ describe('CalendarFactory', () =>
         Object.setPrototypeOf(DayCalendar, DayCalendarPrototype);
         Object.setPrototypeOf(MonthCalendar, MonthCalendarPrototype);
         BaseCalendar.prototype.reload.restore();
+        CalendarFactory.ResizeCalendar.restore();
     });
 });

--- a/__tests__/__renderer__/classes/DayCalendar.mjs
+++ b/__tests__/__renderer__/classes/DayCalendar.mjs
@@ -51,7 +51,6 @@ describe('DayCalendar class Tests', () =>
 
         // Stubbing methods that don't need the actual implementation for the tests
         window.calendarApi.toggleTrayPunchTime = () => {};
-        window.calendarApi.resizeMainWindow = () => {};
         BaseCalendar.prototype._getTranslation = () => {};
         BaseCalendar.prototype.redraw = () => {};
 

--- a/__tests__/__renderer__/classes/MonthCalendar.mjs
+++ b/__tests__/__renderer__/classes/MonthCalendar.mjs
@@ -51,7 +51,6 @@ describe('MonthCalendar class Tests', () =>
 
         // Stubbing methods that don't need the actual implementation for the tests
         // window.calendarApi.toggleTrayPunchTime = () => {};
-        window.calendarApi.resizeMainWindow = () => {};
         BaseCalendar.prototype._getTranslation = () => {};
         BaseCalendar.prototype.redraw = () => {};
         window.calendarApi.getStoreContents = () => { return new Promise((resolve) => { resolve(entryStore.store); }); };

--- a/js/ipc-constants.mjs
+++ b/js/ipc-constants.mjs
@@ -23,7 +23,6 @@ const IpcConstants = Object.freeze(
         RefreshOnDayChange: 'REFRESH_ON_DAY_CHANGE',
         ReloadCalendar: 'RELOAD_CALENDAR',
         ReloadTheme: 'RELOAD_THEME',
-        ResizeMainWindow: 'RESIZE_MAIN_WINDOW',
         SetStoreData: 'SET_STORE_DATA',
         SetWaiver: 'SET_WAIVER',
         SetWaiverDay: 'SET_WAIVER_DAY',

--- a/js/main-window.mjs
+++ b/js/main-window.mjs
@@ -70,8 +70,8 @@ function createMenu()
 function createWindow()
 {
     // Create the browser window.
-    const widthHeight = getDefaultWidthHeight();
     const userPreferences = getUserPreferences();
+    const widthHeight = getDefaultWidthHeight(userPreferences);
     mainWindow = new BrowserWindow({
         width: widthHeight.width,
         height: widthHeight.height,
@@ -102,12 +102,6 @@ function createWindow()
         contextMenuTemplate[0].enabled = arg;
         global.contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
         global.tray.setContextMenu(global.contextMenu);
-    });
-
-    ipcMain.on(IpcConstants.ResizeMainWindow, () =>
-    {
-        const widthHeight = getDefaultWidthHeight();
-        mainWindow.setSize(widthHeight.width, widthHeight.height);
     });
 
     ipcMain.on(IpcConstants.SwitchView, () =>

--- a/js/user-preferences.mjs
+++ b/js/user-preferences.mjs
@@ -285,9 +285,8 @@ function switchCalendarView()
     return preferences;
 }
 
-function getDefaultWidthHeight()
+function getDefaultWidthHeight(preferences)
 {
-    const preferences = getLoadedOrDerivedUserPreferences();
     if (preferences['view'] === 'month')
     {
         return { width: 1010, height: 800 };
@@ -297,7 +296,6 @@ function getDefaultWidthHeight()
         return { width: 500, height: 500 };
     }
 }
-
 
 /*
  * Returns the value of language in preferences.

--- a/renderer/classes/CalendarFactory.js
+++ b/renderer/classes/CalendarFactory.js
@@ -19,7 +19,7 @@ class CalendarFactory
         {
             if (calendar !== undefined && calendar.constructor.name !== constructorName)
             {
-                window.calendarApi.resizeMainWindow();
+                CalendarFactory.ResizeCalendar(preferences);
             }
             calendar = new CalendarClass(preferences, languageData);
             await calendar.reload();
@@ -32,6 +32,12 @@ class CalendarFactory
             calendar.redraw();
             return calendar;
         }
+    }
+
+    static ResizeCalendar(preferences)
+    {
+        const widthHeight = window.calendarApi.getDefaultWidthHeight(preferences);
+        window.resizeTo(widthHeight.width, widthHeight.height);
     }
 }
 

--- a/renderer/preload-scripts/calendar-api.mjs
+++ b/renderer/preload-scripts/calendar-api.mjs
@@ -2,14 +2,10 @@
 
 import { createRequire } from 'module';
 import IpcConstants from '../../js/ipc-constants.mjs';
+import { getDefaultWidthHeight } from '../../js/user-preferences.mjs';
 const require = createRequire(import.meta.url);
 
 const { ipcRenderer } = require('electron');
-
-function resizeMainWindow()
-{
-    ipcRenderer.send(IpcConstants.ResizeMainWindow);
-}
 
 function switchView()
 {
@@ -54,7 +50,7 @@ const calendarApi = {
     handlePunchDate: (callback) => ipcRenderer.on(IpcConstants.PunchDate, callback),
     handleThemeChange: (callback) => ipcRenderer.on(IpcConstants.ReloadTheme, callback),
     handleLeaveBy: (callback) => ipcRenderer.on(IpcConstants.GetLeaveBy, callback),
-    resizeMainWindow: () => resizeMainWindow(),
+    getDefaultWidthHeight: getDefaultWidthHeight,
     switchView: () => switchView(),
     toggleTrayPunchTime: (enable) => toggleTrayPunchTime(enable),
     displayWaiverWindow: (waiverDay) => displayWaiverWindow(waiverDay),


### PR DESCRIPTION
#### Related issue
Closes #1135

#### Context / Background
We currently resize the calendar upon changing from month/day view by calling back to main and asking it to resize the browser window.
We can however just use javascript's [resizeTo](https://developer.mozilla.org/en-US/docs/Web/API/Window/resizeTo) directly from renderer.

#### What change is being introduced by this PR?
Replacing the use of the ipc event with javascript's resizeTo.
Modifying getDefaultWidthHeight to receive a preferences parameter.

Changing the calendar view is actually faster now.

#### How will this be tested?
Ran locally, tests updated.