### PR TITLE
Fix not being able to create waiver from month calendar

### DIFF
--- a/__tests__/__renderer__/workday-waiver-aux.mjs
+++ b/__tests__/__renderer__/workday-waiver-aux.mjs
@@ -15,7 +15,7 @@ describe('Workday Waiver Aux', function()
         // Mocking call
         // TODO: find a better way to mock this or even really test it
         global.window = {
-            mainApi: {
+            calendarApi: {
                 displayWaiverWindow: () => {}
             }
         };

--- a/renderer/workday-waiver-aux.js
+++ b/renderer/workday-waiver-aux.js
@@ -19,7 +19,7 @@ function formatDayId(dayId)
  */
 function displayWaiverWindow(waiverDay)
 {
-    window.mainApi.displayWaiverWindow(waiverDay);
+    window.calendarApi.displayWaiverWindow(waiverDay);
 }
 
 export {


### PR DESCRIPTION
Likely a regression of #1131

It was not possible to open the workday waiver manager window from the month calendar anymore, because the `mainApi` reference was broken. Now it works again.