### PR TITLE
use electronmon for debug:main debug:render and start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "c8": "10.1.3",
         "electron": "34.1.1",
         "electron-mocha": "13.1.0",
-        "electron-reloader": "1.2.3",
         "electron-winstaller": "5.4.0",
+        "electronmon": "2.0.3",
         "eslint": "9.20.0",
         "globals": "15.14.0",
         "husky": "9.1.7",
@@ -40,7 +40,6 @@
         "npm-run-all": "4.1.5",
         "playwright": "1.50.1",
         "prettier": "3.4.2",
-        "rimraf": "6.0.1",
         "sinon": "19.0.2",
         "stylelint": "16.14.1",
         "stylelint-config-standard": "37.0.0"
@@ -2281,19 +2280,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/date-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
-      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "time-zone": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/debounce-fn": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
@@ -2577,13 +2563,6 @@
         "node": ">= 12.20.55"
       }
     },
-    "node_modules/electron-is-dev": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
-      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/electron-mocha": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-13.1.0.tgz",
@@ -2628,23 +2607,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/electron-reloader": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/electron-reloader/-/electron-reloader-1.2.3.tgz",
-      "integrity": "sha512-aDnACAzNg0QvQhzw7LYOx/nVS10mEtbuG6M0QQvNQcLnJEwFs6is+EGRCnM+KQlQ4KcTbdwnt07nd7ZjHpY4iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "chokidar": "^3.5.0",
-        "date-time": "^3.1.0",
-        "electron-is-dev": "^1.2.0",
-        "find-up": "^5.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-store": {
@@ -2794,6 +2756,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/electronmon": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/electronmon/-/electronmon-2.0.3.tgz",
+      "integrity": "sha512-vpsNupi9sCzOCvx8GACbSHKEImkNF2a6pU5Io2yabARbJeQ/8ZuY7t/43LilF6Qw0nZ0MbKQt4sO3x0F3drpQQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "import-from": "^3.0.0",
+        "runtime-required": "^1.1.0",
+        "watchboy": "^0.4.3"
+      },
+      "bin": {
+        "electronmon": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/electronmon/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/emoji-regex": {
@@ -4246,6 +4241,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-from/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5312,6 +5330,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -7093,6 +7118,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7362,6 +7394,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/runtime-required": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/runtime-required/-/runtime-required-1.1.0.tgz",
+      "integrity": "sha512-yX97f5E0WfNpcQnfVjap6vzQcvErkYYCx6eTK4siqGEdC8lglwypUFgZVTX7ShvIlgfkC4XGFl9O1KTYcff0pw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -8372,16 +8414,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/time-zone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tldts": {
       "version": "6.1.76",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.76.tgz",
@@ -8625,6 +8657,32 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "normalize-path": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unixify/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8679,6 +8737,32 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/watchboy": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/watchboy/-/watchboy-0.4.3.tgz",
+      "integrity": "sha512-GHs1HxwvxSMBsqd/WfTOZhj5gBdMqf5HQpfgtKxDfZRxrlYPDdVLRB61LCeRzJaWANmvSIMlfmRVDwVmJFgAKA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash.difference": "^4.5.0",
+        "micromatch": "^4.0.2",
+        "pify": "^4.0.1",
+        "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/watchboy/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "main": "main.mjs",
   "scripts": {
     "clean": "npx rimraf coverage release-builds __tests__/__main__/__database.ttldb__ ",
-    "debug:main": "electron --inspect=5858 .",
-    "debug:render": "electron --remote-debugging-port=9222 .",
+    "debug:main": "electronmon --inspect=5858 .",
+    "debug:render": "electronmon --remote-debugging-port=9222 .",
     "lint": "npm-run-all --parallel lint:*",
     "lint:css": "stylelint css/*.css",
     "lint:eslint": "eslint .",
@@ -31,7 +31,7 @@
     "preinstall": "npx force-resolutions",
     "prepare": "husky",
     "pretest": "npm run clean",
-    "start": "electron .",
+    "start": "electronmon .",
     "test": "npm-run-all test:*",
     "test:mocha": "c8 -o ./coverage_mocha -- mocha",
     "test:electron-mocha": "c8 electron-mocha",
@@ -45,8 +45,8 @@
     "@eslint/js": "9.20.0",
     "c8": "10.1.3",
     "electron": "34.1.1",
+    "electronmon": "2.0.3",
     "electron-mocha": "13.1.0",
-    "electron-reloader": "1.2.3",
     "electron-winstaller": "5.4.0",
     "eslint": "9.20.0",
     "globals": "15.14.0",
@@ -56,7 +56,6 @@
     "npm-run-all": "4.1.5",
     "playwright": "1.50.1",
     "prettier": "3.4.2",
-    "rimraf": "6.0.1",
     "sinon": "19.0.2",
     "stylelint": "16.14.1",
     "stylelint-config-standard": "37.0.0"
@@ -77,7 +76,7 @@
   "engines": {
     "node": ">=20.18.0"
   },
-  "resolutions": {
-    "rimraf": "6.0.1"
+  "electronmon": {
+    "patterns": ["!__tests__/**"]
   }
 }


### PR DESCRIPTION
#### Context / Background
Replaces debugger with [electronmon](https://github.com/catdad/electronmon)

#### What change is being introduced by this PR?
- I looked at alternate methods and found electronmon to be what I consider the best one
- Basically just added “mon” to the debug commands.
- Better debugging with faster reloading and more, clearer information.


<img width="1680" alt="Screenshot 2025-02-08 at 9 07 13 AM" src="https://github.com/user-attachments/assets/a61cbee2-5cb5-4086-8857-4217e4481c1b" />
