### PR TITLE
bump timeout by one second for windows tests

### DIFF
--- a/__tests__/__renderer__/workday-waiver.mjs
+++ b/__tests__/__renderer__/workday-waiver.mjs
@@ -202,7 +202,7 @@ describe('Test Workday Waiver Window', function()
         beforeEach(async() =>
         {
             await prepareMockup();
-        });
+        }).timeout(3000);
 
         it('One Waiver', async() =>
         {


### PR DESCRIPTION
#### Related issue
Closes #1158 

#### Context / Background
Currently the Windows mocha tests will fail _sometimes_, due to a timeout.

#### What change is being introduced by this PR?
I changed the timeout for that portion from 2 seconds to 3. It doesn't take 3 seconds, but it does take more than 2 in some cases.

#### How will this be tested?
Applying this PR to a timeout failing branch it should fix that.

#### Screenshots

Before:
<img width="1037" alt="Screenshot 2025-02-12 at 9 34 30 AM" src="https://github.com/user-attachments/assets/a34ebc2d-62ee-4753-adfd-59cbc1d2f61c" />


After: 
<img width="1037" alt="Screenshot 2025-02-12 at 9 29 34 AM" src="https://github.com/user-attachments/assets/4c452f78-0e05-432d-8563-069d88660ebe" />
