### PR TITLE
Fix husky not detecting main.mjs

### DIFF
--- a/configs/husky/pre-commit
+++ b/configs/husky/pre-commit
@@ -19,7 +19,7 @@ if [ ! -z "$changed_css" ]; then
     pids="$pids $!"
 fi
 
-readarray -t changed_js < <(get_changed_files '*/*.cjs' '*/*.js' '*/*.mjs')
+readarray -t changed_js < <(get_changed_files '*.cjs' '*.js' '*.mjs')
 if [ ! -z "$changed_js" ]; then
     eslint "${changed_js[@]}" --config configs/eslint.config.mjs &
     pids="$pids $!"


### PR DESCRIPTION
Our patterns for js detection were only considering files within subfolders. There are two ways to solve this:
1. Removing the leading `*/`, which would make it match every file with `*.mjs`
2. Adding `main.mjs` explicitly

I went for two because the first option might inadvertently lint more files than expected, but let me know if you disagree.