### PR TITLE
Make CI run on ubuntu-latest again

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -25,6 +25,7 @@ jobs:
           wget --directory-prefix=/tmp https://chromedriver.storage.googleapis.com/100.0.4896.20/chromedriver_linux64.zip
           unzip -d /tmp/chromedriver /tmp/chromedriver_linux64.zip
           sudo chmod +x /tmp/chromedriver/chromedriver
+          # Fix not being able to run electron on CI https://github.com/microsoft/playwright/issues/34251#issuecomment-2580645333
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           /tmp/chromedriver/chromedriver &
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &

--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Ubuntu is not ubuntu-latest as that is causing hangs in the CI
-        os: [macos-latest, ubuntu-20.04, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
@@ -19,13 +18,14 @@ jobs:
           cache: 'npm'
       - name: '        Startup ChromeDriver and Display in Ubuntu'
         shell: bash
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           export DISPLAY=:99
           # TODO: need to download driver according to electron's version
           wget --directory-prefix=/tmp https://chromedriver.storage.googleapis.com/100.0.4896.20/chromedriver_linux64.zip
           unzip -d /tmp/chromedriver /tmp/chromedriver_linux64.zip
           sudo chmod +x /tmp/chromedriver/chromedriver
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           /tmp/chromedriver/chromedriver &
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
       - name: '        Install Dependencies'
@@ -41,7 +41,7 @@ jobs:
         env:
           OS: ${{ matrix.os }}
         run: |
-          if [[ $OS == 'ubuntu-20.04' ]]; then
+          if [[ $OS == 'ubuntu-latest' ]]; then
             # Avoid "failed to connect to the bus" errors on CI https://github.com/microsoft/WSL/issues/7915
             export XDG_RUNTIME_DIR=/run/user/$(id -u)
             sudo mkdir -p $XDG_RUNTIME_DIR


### PR DESCRIPTION
#### Context / Background
We've been running on ubuntu-20.04 for a while, because it seemed like for latest the CI would hang. That runner is now [being deprecated](https://github.com/actions/runner-images/issues/11101)

#### What change is being introduced by this PR?
Make  the CI use `ubuntu-latest` again, which will make it behave like the other CIs. Hopefully with all the test rewrite we've done, it will just work.

#### How will this be tested?
Let the CI run :D