### PR TITLE
Add a progress indication to main window when another window is being opened

### DIFF
--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -12,6 +12,7 @@ import {
     getLeaveByInterval,
     getMainWindow,
     resetMainWindow,
+    toggleMainWindowWait,
     triggerStartupDialogs
 } from '../../js/main-window.mjs';
 
@@ -486,6 +487,24 @@ describe('main-window.mjs', () =>
                 intervalSpy.restore();
             });
         });
+    });
+
+    it('Toggling wait state for the window', async() =>
+    {
+        createWindow();
+        const mainWindow = getMainWindow();
+        let hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
+        assert.strictEqual(hasClass, false, 'Starts without wait class');
+
+        toggleMainWindowWait(true);
+        await new Promise(r => setTimeout(r, 50));
+        hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
+        assert.strictEqual(hasClass, true, 'Now has wait class');
+
+        toggleMainWindowWait(false);
+        await new Promise(r => setTimeout(r, 50));
+        hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
+        assert.strictEqual(hasClass, false, 'Back to not having wait class');
     });
 
     afterEach(() =>

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -491,7 +491,7 @@ describe('main-window.mjs', () =>
 
     describe('toggleMainWindowWait()', () =>
     {
-        it('Starts without wait class', () =>
+        it('Starts without wait class', (done) =>
         {
             createWindow();
             const mainWindow = getMainWindow();
@@ -499,10 +499,12 @@ describe('main-window.mjs', () =>
             {
                 const hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
                 assert.strictEqual(hasClass, false, 'Starts without wait class');
+
+                done();
             });
         });
 
-        it('Toggling wait state for the window', () =>
+        it('Toggling wait state for the window', (done) =>
         {
             createWindow();
             const mainWindow = getMainWindow();
@@ -517,6 +519,8 @@ describe('main-window.mjs', () =>
                 await new Promise(r => setTimeout(r, 50));
                 hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
                 assert.strictEqual(hasClass, false, 'Back to not having wait class');
+
+                done();
             });
         });
     });

--- a/__tests__/__main__/main-window.mjs
+++ b/__tests__/__main__/main-window.mjs
@@ -489,22 +489,36 @@ describe('main-window.mjs', () =>
         });
     });
 
-    it('Toggling wait state for the window', async() =>
+    describe('toggleMainWindowWait()', () =>
     {
-        createWindow();
-        const mainWindow = getMainWindow();
-        let hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
-        assert.strictEqual(hasClass, false, 'Starts without wait class');
+        it('Starts without wait class', () =>
+        {
+            createWindow();
+            const mainWindow = getMainWindow();
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
+            {
+                const hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
+                assert.strictEqual(hasClass, false, 'Starts without wait class');
+            });
+        });
 
-        toggleMainWindowWait(true);
-        await new Promise(r => setTimeout(r, 50));
-        hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
-        assert.strictEqual(hasClass, true, 'Now has wait class');
+        it('Toggling wait state for the window', () =>
+        {
+            createWindow();
+            const mainWindow = getMainWindow();
+            mainWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, async() =>
+            {
+                toggleMainWindowWait(true);
+                await new Promise(r => setTimeout(r, 50));
+                let hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
+                assert.strictEqual(hasClass, true, 'Now has wait class');
 
-        toggleMainWindowWait(false);
-        await new Promise(r => setTimeout(r, 50));
-        hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
-        assert.strictEqual(hasClass, false, 'Back to not having wait class');
+                toggleMainWindowWait(false);
+                await new Promise(r => setTimeout(r, 50));
+                hasClass = await mainWindow.webContents.executeJavaScript('$("html").hasClass("wait")');
+                assert.strictEqual(hasClass, false, 'Back to not having wait class');
+            });
+        });
     });
 
     afterEach(() =>

--- a/__tests__/__renderer__/calendar.mjs
+++ b/__tests__/__renderer__/calendar.mjs
@@ -1,0 +1,82 @@
+'use strict';
+
+import '../../__mocks__/jquery.mjs';
+
+import assert from 'assert';
+import { JSDOM } from 'jsdom';
+import path from 'path';
+
+import { rootDir } from '../../js/app-config.mjs';
+import { getDefaultPreferences } from '../../js/user-preferences.mjs';
+
+async function prepareMockup()
+{
+    const calendar = path.join(rootDir, '/src/calendar.html');
+    const htmlDoc = await JSDOM.fromFile(calendar, 'text/html');
+    window.document.documentElement.innerHTML = htmlDoc.window.document.documentElement.innerHTML;
+}
+
+const testPreferences = structuredClone(getDefaultPreferences());
+
+describe('Test Calendar Window', () =>
+{
+    let handleToggleMainWindowWaitCallback = undefined;
+    before(async() =>
+    {
+        // Mocking APIs
+        window.rendererApi = {
+            getLanguageDataPromise: () =>
+            {
+                return new Promise((resolve) => resolve({
+                    'language': 'en',
+                    'data': {}
+                }));
+            },
+            getOriginalUserPreferences: () => { return testPreferences; },
+            notifyWindowReadyToShow: () => {}
+        };
+
+        window.calendarApi = {
+            handleToggleMainWindowWait: (callback) => { handleToggleMainWindowWaitCallback = callback; },
+            handleCalendarReload: () => {},
+            handleRefreshOnDayChange: () => {},
+            handlePreferencesSaved: () => {},
+            handleWaiverSaved: () => {},
+            handlePunchDate: () => {},
+            handleThemeChange: () => {},
+            handleLeaveBy: () => {}
+        };
+
+        // Using dynamic imports because when the file is imported a $() callback is triggered and
+        // methods must be mocked before-hand
+        await import('../../src/calendar.js');
+    });
+
+    beforeEach(async function()
+    {
+        await prepareMockup();
+    });
+
+    describe('Toggle wait mode', () =>
+    {
+        it('Starts without wait class', () =>
+        {
+            assert.notStrictEqual(handleToggleMainWindowWaitCallback, undefined, 'Callback was set');
+            const hasClass = $('html').hasClass('wait');
+            assert.strictEqual(hasClass, false, 'Starts without wait class');
+        });
+
+        it('Toggling wait state for the window', () =>
+        {
+            assert.notStrictEqual(handleToggleMainWindowWaitCallback, undefined, 'Callback was set');
+
+            handleToggleMainWindowWaitCallback(undefined, true);
+            let hasClass = $('html').hasClass('wait');
+            assert.strictEqual(hasClass, true, 'Now has wait class');
+
+            handleToggleMainWindowWaitCallback(undefined, false);
+            hasClass = $('html').hasClass('wait');
+            assert.strictEqual(hasClass, false, 'Back to not having wait class');
+        });
+    });
+});

--- a/css/styles.css
+++ b/css/styles.css
@@ -179,6 +179,10 @@ body {
   }
 }
 
+.cursor-wait {
+  cursor: wait;
+}
+
 .dayheader {
   text-align: center;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -179,8 +179,21 @@ body {
   }
 }
 
-.cursor-wait {
+html.wait {
   cursor: wait;
+  transition: 0.4s;
+}
+
+html[data-theme="dark"].wait {
+  filter: opacity(0.95);
+}
+
+html[data-theme="cadent-star"].wait {
+  filter: opacity(0.75);
+}
+
+html[data-theme="light"].wait {
+  filter: brightness(0.75);
 }
 
 .dayheader {

--- a/js/ipc-constants.mjs
+++ b/js/ipc-constants.mjs
@@ -29,7 +29,7 @@ const IpcConstants = Object.freeze(
         ShowDialogSync: 'SHOW_DIALOG_SYNC',
         ShowDialog: 'SHOW_DIALOG',
         SwitchView: 'SWITCH_VIEW',
-        ToggleCursorWait: 'TOGGLE_CURSOR_WAIT',
+        ToggleMainWindowWait: 'TOGGLE_MAIN_WINDOW_WAIT',
         ToggleTrayPunchTime: 'TOGGLE_TRAY_PUNCH_TIME',
         WaiverSaved: 'WAIVER_SAVED',
         WindowReadyToShow: 'WINDOW_READY_TO_SHOW',

--- a/js/ipc-constants.mjs
+++ b/js/ipc-constants.mjs
@@ -29,6 +29,7 @@ const IpcConstants = Object.freeze(
         ShowDialogSync: 'SHOW_DIALOG_SYNC',
         ShowDialog: 'SHOW_DIALOG',
         SwitchView: 'SWITCH_VIEW',
+        ToggleCursorWait: 'TOGGLE_CURSOR_WAIT',
         ToggleTrayPunchTime: 'TOGGLE_TRAY_PUNCH_TIME',
         WaiverSaved: 'WAIVER_SAVED',
         WindowReadyToShow: 'WINDOW_READY_TO_SHOW',

--- a/js/main-window.mjs
+++ b/js/main-window.mjs
@@ -177,6 +177,16 @@ function createWindow()
     });
 }
 
+/**
+ * Toggles the main window style to indicate an operation is processing
+ *
+ * @param {Boolean} enable Enable or not the style
+ */
+function toggleMainWindowWait(enable)
+{
+    mainWindow.webContents.send(IpcConstants.ToggleMainWindowWait, enable);
+}
+
 function triggerStartupDialogs()
 {
     if (UpdateManager.shouldCheckForUpdates())
@@ -209,5 +219,6 @@ export {
     getLeaveByInterval,
     getMainWindow,
     resetMainWindow,
+    toggleMainWindowWait,
     triggerStartupDialogs,
 };

--- a/js/main-window.mjs
+++ b/js/main-window.mjs
@@ -184,7 +184,7 @@ function createWindow()
  */
 function toggleMainWindowWait(enable)
 {
-    mainWindow.webContents.send(IpcConstants.ToggleMainWindowWait, enable);
+    getMainWindow()?.webContents.send(IpcConstants.ToggleMainWindowWait, enable);
 }
 
 function triggerStartupDialogs()

--- a/js/windows.mjs
+++ b/js/windows.mjs
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { appConfig, rootDir } from './app-config.mjs';
 import { getDateStr } from './date-aux.mjs';
+import { toggleMainWindowWait } from './main-window.mjs';
 import { getSavedPreferences } from './saved-preferences.mjs';
 import { getUserPreferences, savePreferences } from './user-preferences.mjs';
 import IpcConstants from './ipc-constants.mjs';
@@ -54,6 +55,7 @@ class Windows
         global.waiverWindow.loadURL(htmlPath);
         global.waiverWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
         {
+            toggleMainWindowWait(false /*enable*/);
             global.waiverWindow.show();
         });
         global.waiverWindow.on('close', function()
@@ -68,6 +70,7 @@ class Windows
                 BrowserWindow.getFocusedWindow().webContents.toggleDevTools();
             }
         });
+        toggleMainWindowWait(true /*enable*/);
     }
 
     static openPreferencesWindow(mainWindow)
@@ -102,6 +105,7 @@ class Windows
         global.prefWindow.loadURL(htmlPath);
         global.prefWindow.webContents.ipc.on(IpcConstants.WindowReadyToShow, () =>
         {
+            toggleMainWindowWait(false /*enable*/);
             global.prefWindow.show();
         });
         global.prefWindow.on('close', function()
@@ -121,6 +125,7 @@ class Windows
                 BrowserWindow.getFocusedWindow().webContents.toggleDevTools();
             }
         });
+        toggleMainWindowWait(true /*enable*/);
     }
 
     /**

--- a/renderer/preload-scripts/calendar-api.mjs
+++ b/renderer/preload-scripts/calendar-api.mjs
@@ -51,7 +51,7 @@ const calendarApi = {
     handleThemeChange: (callback) => ipcRenderer.on(IpcConstants.ReloadTheme, callback),
     handleLeaveBy: (callback) => ipcRenderer.on(IpcConstants.GetLeaveBy, callback),
     getDefaultWidthHeight: getDefaultWidthHeight,
-    handleToggleCursorWait: (callback) => ipcRenderer.on(IpcConstants.ToggleCursorWait, callback),
+    handleToggleMainWindowWait: (callback) => ipcRenderer.on(IpcConstants.ToggleMainWindowWait, callback),
     switchView: () => switchView(),
     toggleTrayPunchTime: (enable) => toggleTrayPunchTime(enable),
     displayWaiverWindow: (waiverDay) => displayWaiverWindow(waiverDay),

--- a/renderer/preload-scripts/calendar-api.mjs
+++ b/renderer/preload-scripts/calendar-api.mjs
@@ -51,6 +51,7 @@ const calendarApi = {
     handleThemeChange: (callback) => ipcRenderer.on(IpcConstants.ReloadTheme, callback),
     handleLeaveBy: (callback) => ipcRenderer.on(IpcConstants.GetLeaveBy, callback),
     getDefaultWidthHeight: getDefaultWidthHeight,
+    handleToggleCursorWait: (callback) => ipcRenderer.on(IpcConstants.ToggleCursorWait, callback),
     switchView: () => switchView(),
     toggleTrayPunchTime: (enable) => toggleTrayPunchTime(enable),
     displayWaiverWindow: (waiverDay) => displayWaiverWindow(waiverDay),

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -71,11 +71,12 @@ window.calendarApi.handleThemeChange(async(event, theme) =>
 window.calendarApi.handleLeaveBy(searchLeaveByElement);
 
 /*
- * Change the cursor on the app to a wait cursor while an operation is happening.
+ * Change the main window style to indicate an operation is processing.
  */
-window.calendarApi.handleToggleCursorWait((enable) =>
+window.calendarApi.handleToggleMainWindowWait((event, enable) =>
 {
-    const waitClass = 'cursor-wait';
+    console.log(enable);
+    const waitClass = 'wait';
     if (enable)
     {
         if (!$('html').hasClass(waitClass))

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -16,79 +16,65 @@ function setupCalendar(preferences)
     });
 }
 
-/*
- * Reload the calendar upon request from main
- */
-window.calendarApi.handleCalendarReload(async() =>
+function setupIpcHandlers()
 {
-    await calendar.reload();
-});
-
-/*
- * Update the calendar after a day has passed
- */
-window.calendarApi.handleRefreshOnDayChange((event, oldDate, oldMonth, oldYear) =>
-{
-    calendar.refreshOnDayChange(oldDate, oldMonth, oldYear);
-});
-
-/*
- * Get notified when preferences has been updated.
- */
-window.calendarApi.handlePreferencesSaved((event, prefs) =>
-{
-    setupCalendar(prefs);
-});
-
-/*
- * Get notified when waivers get updated.
- */
-window.calendarApi.handleWaiverSaved(async() =>
-{
-    await calendar.loadInternalWaiveStore();
-    calendar.redraw();
-});
-
-/*
- * Punch the date and time as requested by user.
- */
-window.calendarApi.handlePunchDate(() =>
-{
-    calendar.punchDate();
-});
-
-/*
- * Reload theme.
- */
-window.calendarApi.handleThemeChange(async(event, theme) =>
-{
-    applyTheme(theme);
-});
-
-/*
- * Returns value of "leave by" for notifications.
- */
-window.calendarApi.handleLeaveBy(searchLeaveByElement);
-
-/*
- * Change the main window style to indicate an operation is processing.
- */
-window.calendarApi.handleToggleMainWindowWait((event, enable) =>
-{
-    console.log(enable);
-    const waitClass = 'wait';
-    if (enable)
+    // Reload the calendar upon request from main
+    window.calendarApi.handleCalendarReload(async() =>
     {
-        if (!$('html').hasClass(waitClass))
+        await calendar.reload();
+    });
+
+    // Update the calendar after a day has passed
+    window.calendarApi.handleRefreshOnDayChange((event, oldDate, oldMonth, oldYear) =>
+    {
+        calendar.refreshOnDayChange(oldDate, oldMonth, oldYear);
+    });
+
+    // Get notified when preferences has been updated.
+    window.calendarApi.handlePreferencesSaved((event, prefs) =>
+    {
+        setupCalendar(prefs);
+    });
+
+    // Get notified when waivers get updated.
+    window.calendarApi.handleWaiverSaved(async() =>
+    {
+        await calendar.loadInternalWaiveStore();
+        calendar.redraw();
+    });
+
+    // Punch the date and time as requested by user.
+    window.calendarApi.handlePunchDate(() =>
+    {
+        calendar.punchDate();
+    });
+
+    // Reload theme.
+    window.calendarApi.handleThemeChange(async(event, theme) =>
+    {
+        applyTheme(theme);
+    });
+
+    // Returns value of "leave by" for notifications.
+    window.calendarApi.handleLeaveBy(searchLeaveByElement);
+
+    // Change the main window style to indicate an operation is processing.
+    window.calendarApi.handleToggleMainWindowWait((event, enable) =>
+    {
+        const waitClass = 'wait';
+        if (enable)
         {
-            $('html').addClass(waitClass);
+            if (!$('html').hasClass(waitClass))
+            {
+                $('html').addClass(waitClass);
+            }
         }
-    }
-    else
-    {
-        $('html').removeClass(waitClass);
-    }
-});
+        else
+        {
+            $('html').removeClass(waitClass);
+        }
+    });
+}
 
 // On page load, create the calendar and setup notification
 $(() =>
@@ -105,4 +91,5 @@ $(() =>
             }, 100);
         });
     });
+    setupIpcHandlers();
 });

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -70,6 +70,25 @@ window.calendarApi.handleThemeChange(async(event, theme) =>
  */
 window.calendarApi.handleLeaveBy(searchLeaveByElement);
 
+/*
+ * Change the cursor on the app to a wait cursor while an operation is happening.
+ */
+window.calendarApi.handleToggleCursorWait((enable) =>
+{
+    const waitClass = 'cursor-wait';
+    if (enable)
+    {
+        if (!$('html').hasClass(waitClass))
+        {
+            $('html').addClass(waitClass);
+        }
+    }
+    else
+    {
+        $('html').removeClass(waitClass);
+    }
+});
+
 // On page load, create the calendar and setup notification
 $(() =>
 {


### PR DESCRIPTION
#### Related issue
Closes #1146

#### Context / Background
Sometimes opening preferences or workday waiver takes a few seconds. We should add something like a spinner icon to the mouse pointer or an icon on the main window until the new window opens.

#### What change is being introduced by this PR?
- Whenever a window is being created, an animation is added to the main window. The animation always has the cursor in "wait" mode, which shows a spinner in windows.
- Depending on the theme, the window gets darker or lighter to indicate the operation is in progress.
- Clicking multiple times works fine, and after the window is shown the style goes back.

![white](https://github.com/user-attachments/assets/ef3a7156-e428-41a2-be3f-9a4e9d94bd91)

#### How will this be tested?
New tests. Tested manually on windows.