### PR TITLE
Restyle number inputs in preferences window

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -572,7 +572,6 @@ input[type="number"]::-webkit-inner-spin-button {
 /* Make the number input not have the buttons on the right */
 input[type="number"] {
     appearance: textfield;
-    appearance: textfield;
     border: 1px solid #ccc;
     padding: 1px 4.8px 1px 0px;
     border-radius: 4px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -565,13 +565,13 @@ input:disabled + .slider {
 
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
+    appearance: none;
     margin: 0;
 }
 
 /* Make the number input not have the buttons on the right */
 input[type="number"] {
-    -moz-appearance: textfield;
+    appearance: textfield;
     appearance: textfield;
     border: 1px solid #ccc;
     padding: 1px 4.8px 1px 0px;
@@ -716,6 +716,7 @@ input[type="number"] {
 
 #preferences-window #hours-per-day, #break-time-interval {
   text-align: right;
+
   /* redefine the width in terms of characters for simpler match to notification interval */
   width: 5.4ch;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -575,7 +575,6 @@ input[type="number"] {
     border: 1px solid #ccc;
     padding: 1px 4.8px 1px 0px;
     border-radius: 4px;
-    font-size: 16px;
     text-align: right;
     width: 5.4ch;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -563,6 +563,24 @@ input:disabled + .slider {
   background-color: var(--disabled-input-bground);
 }
 
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+/* Make the number input not have the buttons on the right */
+input[type="number"] {
+    -moz-appearance: textfield;
+    appearance: textfield;
+    border: 1px solid #ccc;
+    padding: 1px 4.8px 1px 0px;
+    border-radius: 4px;
+    font-size: 16px;
+    text-align: right;
+    width: 5.4ch;
+}
+
 /** Common window styles **/
 
 .common-window {
@@ -698,6 +716,8 @@ input:disabled + .slider {
 
 #preferences-window #hours-per-day, #break-time-interval {
   text-align: right;
+  /* redefine the width in terms of characters for simpler match to notification interval */
+  width: 5.4ch;
 }
 
 #preferences-window i {

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,8 +7,11 @@
   font-weight: 1 999;
 }
 
-/* This is an implicit, and an explicit declaration of the Default color scheme */
+* {
+  --interval-width: 5.4ch;
+}
 
+/* This is an implicit, and an explicit declaration of the Default color scheme */
 html,
 html[data-theme="light"] {
   --page-bground: white;
@@ -563,6 +566,7 @@ input:disabled + .slider {
   background-color: var(--disabled-input-bground);
 }
 
+/* Hide spinners to clean up number inputs */
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
     appearance: none;
@@ -576,7 +580,7 @@ input[type="number"] {
     padding: 1px 4.8px 1px 0px;
     border-radius: 4px;
     text-align: right;
-    width: 5.4ch;
+    width: var(--interval-width);
 }
 
 /** Common window styles **/
@@ -716,7 +720,7 @@ input[type="number"] {
   text-align: right;
 
   /* redefine the width in terms of characters for simpler match to notification interval */
-  width: 5.4ch;
+  width: var(--interval-width);
 }
 
 #preferences-window i {


### PR DESCRIPTION
#### Related issue
#1163 

#### Context / Background
As shown in the issue #1163 , the number input doesn't look correct. 

#### What change is being introduced by this PR?
- How did you approach this problem?
I thought it would be best to just remove all styling from that input type, and restyle it to match the others it should resemble.

- What changes did you make to achieve the goal?
added a small piece to css/styles.css
- What are the indirect and direct consequences of the change?
The only consequence of this change is that number inputs will no longer have the up/down buttons on the right.

#### How will this be tested?
Visually

----
<img width="1388" alt="Screenshot 2025-02-21 at 2 54 52 PM" src="https://github.com/user-attachments/assets/7d251b3d-79af-4918-b5cb-5805db311f33" />

