### PR TITLE
Fix #1187: Race condition in renderer preferences test

### DIFF
--- a/__tests__/__renderer__/preferences.mjs
+++ b/__tests__/__renderer__/preferences.mjs
@@ -28,11 +28,22 @@ const weekdays = [
     'sunday'
 ];
 
+let windowReady = false;
+async function waitUntilWindowReady()
+{
+    while (!windowReady)
+    {
+        await new Promise(r => setTimeout(r, 100));
+    }
+}
+
 async function prepareMockup()
 {
     const userPreferences = path.join(rootDir, '/src/preferences.html');
     const htmlDoc = await JSDOM.fromFile(userPreferences, 'text/html');
     window.document.documentElement.innerHTML = htmlDoc.window.document.documentElement.innerHTML;
+    // The script on the preferences page only gets loaded once. We wait here until it is loaded so the page is ready for interactions
+    await waitUntilWindowReady();
 }
 
 function changeItemValue(item, value)
@@ -105,7 +116,7 @@ describe('Test Preferences Window', () =>
                 }));
             },
             getOriginalUserPreferences: () => { return testPreferences; },
-            notifyWindowReadyToShow: () => {},
+            notifyWindowReadyToShow: () => { windowReady = true; },
             showDialog: () => { return new Promise((resolve) => resolve({ response: 0 })); },
         };
 


### PR DESCRIPTION
#### Related issue
Closes #1187

#### Context / Background
The renderer preferences test is failing due to race condition. `preferences` is not set in time for the call to renderPreferencesWindow() inside the test because we don't actually wait for the page to be ready before starting the test.

https://github.com/TTLApp/time-to-leave/actions/runs/14185398902/job/39739684234?pr=1185

1) Test Preferences Window
       Changing values of items in window
         "before each" hook for "Change count-today to true":
     TypeError: Cannot use 'in' operator to search for 'view' in undefined
      at renderPreferencesWindow (file:///Users/runner/work/time-to-leave/time-to-leave/src/preferences.js:125:16)
      at Context.<anonymous> (file:///Users/runner/work/time-to-leave/time-to-leave/__tests__/__renderer__/preferences.mjs:133:13)

#### What change is being introduced by this PR?
Fixing the race condition by waiting for the window to report itself ready through the notifyWindowReadyToShow api call before proceeding with the test. promises are non-blocking so the code is free to change the value in the actual script loading that is happening at the same time