### PR TITLE
kill 'non-passive listener' bug

### DIFF
--- a/renderer/classes/MonthCalendar.js
+++ b/renderer/classes/MonthCalendar.js
@@ -437,14 +437,20 @@ class MonthCalendar extends BaseCalendar
             removeEntries(element);
         });
 
-        $('.time-cells').mousewheel(function(e, delta)
+        // Use native addEventListener with passive: false to kill warnings
+        $('.time-cells').each(function()
         {
-            const currentScroll = this.scrollLeft;
-            this.scrollLeft -= (delta * 30);
-            if (currentScroll !== this.scrollLeft)
+            this.addEventListener('mousewheel', function(e)
             {
-                e.preventDefault();
-            }
+                // jQuery Mousewheel passes delta as second arg, but native event uses wheelDelta
+                const delta = e.wheelDelta ? e.wheelDelta / 120 : 0;
+                const currentScroll = this.scrollLeft;
+                this.scrollLeft -= (delta * 30);
+                if (currentScroll !== this.scrollLeft)
+                {
+                    e.preventDefault();
+                }
+            }, { passive: false });
         });
     }
 


### PR DESCRIPTION
#### Related issue
Closes #1166 

#### Context / Background
One of our long-standing relatively innocuous errors/warnings in the dev tools is quelled! We get these warnings because we're using a non-passive jQuery listener and chrome wants a passive listener. We have already learned that we do need jQuery-mousewheel at least for the time being, so we can't just use a passive listener.

#### What change is being introduced by this PR?
I've added passive:false to the mouse wheel listener

#### How will this be tested?
Open up devtools and wait. Otherwise, existing tests should remain passing.

I'd really appreciate it if others can run this and see if it's identical behaviorally.


