### PR TITLE
Move unsafe-inline scripts to listeners

### DIFF
--- a/__tests__/__renderer__/preferences.mjs
+++ b/__tests__/__renderer__/preferences.mjs
@@ -12,7 +12,7 @@ import { rootDir } from '../../js/app-config.mjs';
 import {
     getDefaultPreferences,
     getPreferencesFilePath,
-    savePreferences,
+    savePreferences
 } from '../../js/user-preferences.mjs';
 import { preferencesApi } from '../../renderer/preload-scripts/preferences-api.mjs';
 import i18nTranslator from '../../renderer/i18n-translator.js';
@@ -181,6 +181,18 @@ describe('Test Preferences Window', () =>
             checkRenderedItem('hours-per-day');
         });
 
+        it('Change pre-filling break time to true', () =>
+        {
+            changeItemInputValue('enable-prefill-break-time', true);
+            checkRenderedItem('enable-prefill-break-time', isCheckBox);
+        });
+
+        it('Change break-time-interval from 00:30 to 00:15', () =>
+        {
+            changeItemValue('break-time-interval', '00:15');
+            checkRenderedItem('break-time-interval');
+        });
+
         it('Change repetition to false', () =>
         {
             changeItemInputValue('repetition', false);
@@ -203,6 +215,12 @@ describe('Test Preferences Window', () =>
         it('Change notifications-interval to 10', () =>
         {
             changeItemValue('notifications-interval', '10');
+            checkRenderedItem('notifications-interval');
+        });
+
+        it('Change notifications-interval to 10', () =>
+        {
+            changeItemValue('notifications-interval', '99');
             checkRenderedItem('notifications-interval');
         });
 

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -2,6 +2,7 @@
 <html data-theme="" lang="en">
 
 <head>
+    <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../node_modules/@fortawesome/fontawesome-free/css/all.min.css">
@@ -42,7 +43,7 @@
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.hoursPerDay">Hours per day</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" title="X, XX, XX.X, X.XX, X:XX, XX.XX, XX:XX" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^((0|1)?[0-9]|2[0-3])(\.[0-9][0-9]?|:[0-5][0-9])?$" value="08:00" size=5 required oninput="this.setCustomValidity('');this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '08:00';this.setCustomValidity('')">
+                <input data-i18n="[placeholder]$Preferences.hours-per-day;[oninvalid]$Generic.hours-on-invalid" title="X, XX, XX.X, X.XX, X:XX, XX.XX, XX:XX" type="text" name="hours-per-day" id="hours-per-day" maxlength=5 pattern="^((0|1)?[0-9]|2[0-3])(\.[0-9][0-9]?|:[0-5][0-9])?$" value="08:00" size=5 required>
             </div>
             <div class="flex-box">
                 <p><i class="fas fa-utensils"></i><span data-i18n="$Preferences.enablePrefillBreakTime">Enable prefilling of break time</span></p>
@@ -50,7 +51,7 @@
             </div>
             <div class="flex-box">
                 <p data-i18n="$Preferences.breakTimeInterval">Break time interval</p>
-                <input data-i18n="[placeholder]$Preferences.hours-per-day" title="X, XX, XX.X, X.XX, X:XX, XX.XX, XX:XX" type="text" name="break-time-interval" id="break-time-interval" maxlength=5 pattern="^((0|1)?[0-9]|2[0-3])(\.[0-9][0-9]?|:[0-5][0-9])?$" value="00:30" size=5 required oninput="this.reportValidity()" onblur="this.value = this.checkValidity() ? this.value : '00:30'">
+                <input data-i18n="[placeholder]$Preferences.break-time-interval" title="X, XX, XX.X, X.XX, X:XX, XX.XX, XX:XX" type="text" name="break-time-interval" id="break-time-interval" maxlength=5 pattern="^((0|1)?[0-9]|2[0-3])(\.[0-9][0-9]?|:[0-5][0-9])?$" value="00:30" size=5 required">
             </div>
             
         </section>
@@ -67,7 +68,7 @@
             </div>
             <div class="flex-box mb-2">
                 <p><i class="fas fa-stopwatch"></i><span data-i18n="$Preferences.minutesBetweenNotifications">Minutes between notifications</span></p>
-                <input type="number" name="notifications-interval" id="notifications-interval" min="1" max="30" value="5" required onblur="this.value = this.checkValidity() ? this.value : 5">
+                <input type="number" name="notifications-interval" id="notifications-interval" min="1" max="30" value="5" required">
             </div>
             
         </section>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -178,15 +178,21 @@ function setupListeners()
         changeValue(this.name, this.checked);
     });
 
-    $('#hours-per-day, #break-time-interval').on('change', function()
+    $('#break-time-interval').on('change', function()
     {
-        /* istanbul ignore else */
-        if (this.checkValidity() === true)
-        {
-            const entry = convertTimeFormat(this.value);
-            this.value = entry;
-            changeValue(this.name, entry);
-        }
+        this.value = this.checkValidity() ? this.value : '00:30';
+    });
+
+    $('#hours-per-day').on('change', function()
+    {
+        this.setCustomValidity('');
+        this.reportValidity();
+        this.value = this.checkValidity() ? this.value : '08:00'; this.setCustomValidity('');
+    });
+
+    $('#notifications-interval').on('change', function()
+    {
+        this.value = this.checkValidity() ? this.value : 5;
     });
 
     $('input[type="number"], input[type="date"]').on('change', function()


### PR DESCRIPTION
#### Context / Background
Right now, the logic that corrects inputs in the preferences pane is done in unsafe-inline scripts, which electron complains about due to security policy.

#### What change is being introduced by this PR?
I've moved the inlines into listeners in preferences.js, and a adjusted a couple existing ones.

#### How will this be tested?
Open up the devtools, change an option, and you shouldn't get any content security warnings.

