### PR TITLE
Fixes main window test delay

### DIFF
--- a/tests/main-window.mjs
+++ b/tests/main-window.mjs
@@ -44,6 +44,7 @@ describe('Application launch', function()
     {
         // TODO: Investigate why this takes such a long time (10s)
         const window = await electronApp.firstWindow();
+        await window.waitForLoadState('domcontentloaded');
 
         const monthYearLocator = window.locator('#month-year');
         const monthYearText = await monthYearLocator.evaluate(node => node.innerText);


### PR DESCRIPTION
Right now, the first test in tests/main-window takes a stupidly long time. This patch fixes that, but I'm not entirely sure of why it fixes it.

#### What change is being introduced by this PR?
- adds await window.waitForLoadState('domcontentloaded') after const window = await electronApp.firstWindow();. 


#### How will this be tested?
The normal tests should be a lot faster.